### PR TITLE
allow invalid UTF8 input to mirror protoc's lenient behavior

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -32,7 +32,7 @@ func (rr *runeReader) readRune() (r rune, size int, err error) {
 		return 0, 0, rr.err
 	}
 	r, sz := utf8.DecodeRune(rr.data[rr.pos:])
-	if r == utf8.RuneError {
+	if r == utf8.RuneError && sz == 1 {
 		// this really should be an error, but we mirror protoc's lenience
 		r = rune(rr.data[rr.pos])
 		sz = 1

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -291,6 +292,10 @@ func TestLexerErrors(t *testing.T) {
 		{str: "// foo \xBC", errMsg: ""},
 		{str: "'abc \xBC '", errMsg: ""},
 		{str: "\"abc \xBC \"", errMsg: ""},
+		// this one IS valid UTF8, so should be accepted without error
+		// even if we are rejecting the ones above (this is the VALID
+		// encoding of the unicode replacement char)
+		{str: "'abc " + string(utf8.RuneError) + " '", errMsg: ""},
 	}
 	for i, tc := range testCases {
 		handler := reporter.NewHandler(nil)


### PR DESCRIPTION
This will resolve https://github.com/jhump/protocompile/issues/5 (filed with earlier version/fork of this repo).