### PR TITLE
extension resolution differs from field type

### DIFF
--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -631,6 +631,18 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			`foo.proto:6:9: syntax error: unexpected string literal, expecting '{' or '<' or ']'`,
 		},
+		{
+			map[string]string{
+				"foo.proto": "package foo.bar;\n" +
+					"message M { \n" +
+					"  enum E { M = 0; }\n" +
+					"  optional M F1 = 1;\n" +
+					"  extensions 2 to 2;\n" +
+					"  extend M { optional string F2 = 2; }\n" +
+					"}",
+			},
+			`foo.proto:6:10: extendee is invalid: foo.bar.M.M is a enum value, not a message`,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -359,7 +359,7 @@ func (r *result) resolveFieldTypes(handler *reporter.Handler, s *Symbols, fqn pr
 	elemType := "field"
 	if fld.GetExtendee() != "" {
 		elemType = "extension"
-		dsc := r.resolve(fld.GetExtendee(), true, scopes)
+		dsc := r.resolve(fld.GetExtendee(), false, scopes)
 		if dsc == nil {
 			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()).Start(), "unknown extendee type %s", fld.GetExtendee())
 		}


### PR DESCRIPTION
I stumbled upon https://github.com/protocolbuffers/protobuf/issues/6296 when looking at protoc issues, and it gave me pause: I recalled implementing extensions and field types to be the same in this particular aspect. I had even included it in the language spec (though I recently fixed it there, too: https://github.com/bufbuild/protobuf.com/pull/24).

This fixes the implementation. The call to `resolve` was passing `onlyTypes = true` for both [extensions](https://github.com/jhump/protocompile/blob/d108583e055dbd42ed0e0bea2d6652d6a96e9eb4/linker/resolve.go#L362) and [field types](https://github.com/jhump/protocompile/blob/d108583e055dbd42ed0e0bea2d6652d6a96e9eb4/linker/resolve.go#L408). However, in `protoc`, [extensions](https://github.com/protocolbuffers/protobuf/blob/ab840345966d0fa8e7100d771c92a73bfbadd25c/src/google/protobuf/descriptor.cc#L6373-L6375) differ from [field types](https://github.com/protocolbuffers/protobuf/blob/ab840345966d0fa8e7100d771c92a73bfbadd25c/src/google/protobuf/descriptor.cc#L6437-L6441) in this regard. (For extensions, the protoc code uses the [default resolve mode](https://github.com/protocolbuffers/protobuf/blob/ab840345966d0fa8e7100d771c92a73bfbadd25c/src/google/protobuf/descriptor.cc#L3813-L3817) of `LOOKUP_ALL`, not `LOOKUP_TYPES`; this is akin to `!onlyTypes` vs. `onlyTypes` in protocompile.)

I've taken the example in the protoc issue linked above as a test case. That test case failed with protocompile, until applying the one-liner fix.

Fixes TCN-366