### PR TITLE
Some symbols other than dot, `(` and `[`, are worthy of leading comments too

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -432,7 +432,7 @@ func (l *protoLex) setPrevAndAddComments(n ast.TerminalNode) {
 
 			isPunctuation := false
 			if rn, ok := n.(*ast.RuneNode); ok {
-				isPunctuation = rn.Rune != '.'
+				isPunctuation = rn.Rune != '.' && rn.Rune != '(' && rn.Rune != '['
 			}
 
 			if isPunctuation ||

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -15,6 +15,7 @@
 package parser
 
 import (
+	"fmt"
 	"io"
 	"math"
 	"strings"
@@ -462,4 +463,92 @@ func TestUTF8(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestCompactOptionsLeadingComments(t *testing.T) {
+	contents := `
+syntax = "proto2";
+
+package testprotos;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FieldOptions {
+  // Leading comment on custom.
+  optional int32 custom = 20000;
+}
+
+message Foo {
+  // Leading comment on one.
+  optional string one = 1 [
+    // Leading comment on deprecated.
+    deprecated = true,
+    // Leading comment on (custom).
+    (custom) = 2
+  ];
+
+  // Leading comment on two.
+  optional string two = 2;
+  // Leading comment on three.
+  optional string three = 3;
+}`
+
+	fileNode, err := Parse("test.proto", strings.NewReader(contents), reporter.NewHandler(nil))
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		ast.Walk(
+			fileNode,
+			&ast.SimpleVisitor{
+				DoVisitFieldReferenceNode: func(fieldReferenceNode *ast.FieldReferenceNode) error {
+					// We're only testing compact options, so we can confidently
+					// retrieve the leading comments from the FieldReference's name
+					// since it will always be a terminal *IdentNode unless the
+					// field reference has a '('.
+					info := fileNode.NodeInfo(fieldReferenceNode.Name)
+					if fieldReferenceNode.Open != nil {
+						// The leading comments will be attached to the '(', if one exists.
+						info = fileNode.NodeInfo(fieldReferenceNode.Open)
+					}
+					name := stringForFieldReference(fieldReferenceNode)
+					if assert.Equal(t, 1, info.LeadingComments().Len(), "%s should have a leading comment", name) {
+						assert.Equal(
+							t,
+							fmt.Sprintf("// Leading comment on %s.\n", name),
+							info.LeadingComments().Index(0).RawText(),
+						)
+					}
+					return nil
+				},
+				DoVisitFieldNode: func(fieldNode *ast.FieldNode) error {
+					// The fields in these tests always define a label,
+					// so we can confidently use it to retrieve the comments.
+					info := fileNode.NodeInfo(fieldNode.Label)
+					name := fieldNode.Name.Val
+					if assert.Equal(t, 1, info.LeadingComments().Len(), "%s should have a leading comment", name) {
+						assert.Equal(
+							t,
+							fmt.Sprintf("// Leading comment on %s.\n", name),
+							info.LeadingComments().Index(0).RawText(),
+						)
+					}
+					return nil
+				},
+			},
+		),
+	)
+}
+
+// stringForFieldReference returns the string representation of the
+// given field reference.
+func stringForFieldReference(fieldReference *ast.FieldReferenceNode) string {
+	var result string
+	if fieldReference.Open != nil {
+		result += "("
+	}
+	result += string(fieldReference.Name.AsIdentifier())
+	if fieldReference.Close != nil {
+		result += ")"
+	}
+	return result
 }

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -466,6 +466,7 @@ func TestUTF8(t *testing.T) {
 }
 
 func TestCompactOptionsLeadingComments(t *testing.T) {
+	t.Parallel()
 	contents := `
 syntax = "proto2";
 


### PR DESCRIPTION
This ports over an open PR by none other than @amckinney: https://github.com/jhump/protocompile-old/pull/3

He encountered this when implementing `buf format`: the leading comments for some compact options were often misattributed as a trailing comment for the prior token.

It turns out `(` (which can start RPC input and output types and custom option names) and `[` (which can start compact options, extension fields in message literals, and list literal values in message literals) are also punctuation that are worthy of leading comments (in addition to `.`, which can start a fully-qualified type name).

The one line change in `lexer.go` is the fix. Alex's test case fails without it, and passes with it.