### PR TITLE
lenient utf8 parser

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -45,10 +45,13 @@ func (rr *runeReader) readRune() (r rune, size int, err error) {
 		return 0, 0, rr.err
 	}
 	r, sz := utf8.DecodeRune(rr.data[rr.pos:])
-	if r == utf8.RuneError {
-		rr.err = fmt.Errorf("invalid UTF8 at offset %d: %x", rr.pos, rr.data[rr.pos])
-		return 0, 0, rr.err
-	}
+	// TODO: Enable this check to make input strictly required to be UTF8. We may
+	//   want this to be an optional flag that the parser accepts, to make it
+	//   a conditional check. For now, since protoc allows bad UTF8, so must we :(
+	//if r == utf8.RuneError {
+	//	rr.err = fmt.Errorf("invalid UTF8 at offset %d: %x", rr.pos, rr.data[rr.pos])
+	//	return 0, 0, rr.err
+	//}
 	rr.pos = rr.pos + sz
 	return r, sz, nil
 }


### PR DESCRIPTION
As of today, `protoc` allows invalid UTF8. That means that proto sources that are mainly compiled with `protoc` (such as the googleapis module) could have bad encoding. And that means that protocompile, [at least for now](https://github.com/protocolbuffers/protobuf/issues/9175), needs to allow it, too.

This makes protocompile work the same way as [protoparse](https://github.com/jhump/protoreflect/blob/v1.13.0/desc/protoparse/lexer.go#L36): bad encoding bytes are silently replaced with the unicode replacement char. This is how lenient UTF8 decoders are expected to work. This does _not_ match the behavior of `protoc`, but this is an acceptable variance for now.

This addresses an old bug filed by @amckinney: https://github.com/jhump/protocompile-old/issues/5