### PR TITLE
don't put NoSourceNode into a *FileNode

### DIFF
--- a/ast/file.go
+++ b/ast/file.go
@@ -41,7 +41,7 @@ type FileNode struct {
 	EOF *RuneNode
 }
 
-// NewFileElement creates a new *FileNode. The syntax parameter is optional. If it
+// NewFileNode creates a new *FileNode. The syntax parameter is optional. If it
 // is absent, it means the file had no syntax declaration.
 //
 // This function panics if the concrete type of any element of decls is not
@@ -82,16 +82,10 @@ func NewFileNode(info *FileInfo, syntax *SyntaxNode, decls []FileElement, eof To
 	}
 }
 
+// NewEmptyFileNode returns an empty AST for a file with the given name.
 func NewEmptyFileNode(filename string) *FileNode {
 	fileInfo := NewFileInfo(filename, []byte{})
-	fileInfo.AddToken(0, 0) // EOF
-
-	return &FileNode{
-		compositeNode: compositeNode{
-			children: []Node{NewNoSourceNode(filename)},
-		},
-		fileInfo: fileInfo,
-	}
+	return NewFileNode(fileInfo, nil, nil, fileInfo.AddToken(0, 0))
 }
 
 func (f *FileNode) Name() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -83,7 +83,7 @@ func Parse(filename string, r io.Reader, handler *reporter.Handler) (*ast.FileNo
 		return nil, err
 	}
 	protoParse(lx)
-	if lx.res == nil || len(lx.res.Children()) == 0 {
+	if lx.res == nil {
 		// nil AST means there was an error that prevented any parsing
 		// or the file was empty; synthesize empty non-nil AST
 		lx.res = ast.NewEmptyFileNode(filename)

--- a/parser/proto.y
+++ b/parser/proto.y
@@ -156,6 +156,9 @@ file : syntax {
 		lex.res = $$
 	}
 	| {
+		lex := protolex.(*protoLex)
+		$$ = ast.NewFileNode(lex.info, nil, nil, lex.eof)
+		lex.res = $$
 	}
 
 fileDecls : fileDecls fileDecl {

--- a/parser/proto.y.go
+++ b/parser/proto.y.go
@@ -1233,6 +1233,9 @@ protodefault:
 	case 4:
 		protoDollar = protoS[protopt-0 : protopt+1]
 		{
+			lex := protolex.(*protoLex)
+			protoVAL.file = ast.NewFileNode(lex.info, nil, nil, lex.eof)
+			lex.res = protoVAL.file
 		}
 	case 5:
 		protoDollar = protoS[protopt-2 : protopt+1]


### PR DESCRIPTION
The `buf` repo is using an [earlier revision of protocompile](https://github.com/bufbuild/buf/blob/c8fc1a2a8176c69a1176a18741506181fc1edbaf/go.mod#L13), under the moniker `github.com/jhump/protocompile`, for formatting.

While integrating protocompile into the `buf build` command, I was also removing this old dependency and updating the format command to use the latest version of this repo (the one under the bufbuild organization).

While debugging some discrepancies, I encountered a bug in this repo: an empty file resulted in an AST that would cause a [panic when trying to visit/walk the AST](https://github.com/bufbuild/protocompile/blob/8d3afeb44a55d504f817ac52b5f1e4d705d5140c/ast/walk.go#L181). The problem is that it would store a `NoSourceNode` into the empty file node -- but that is a special placeholder node that means there is no AST, so it is (intentionally) not handled by the visit/walk functionality.

This fixes it. An empty file now looks like a normal file, but with no declarations. The singular token in the AST is now just the EOF token. (The reason a `NoSourceNode` was previously used was just to have some singular token, because the implementation of `compositeNode` gets cranky if it has zero children.) I also updated the grammar to produce a valid AST for an empty file (previously, it was only handled in a special check after the parser completed). That allows the AST for an empty file to still retain information about comments and whitespace (so "empty file" really meaning no tokens/lexical elements, not necessarily no bytes).