### PR TITLE
creating synthetic oneof names doesn't care about reserved names

### DIFF
--- a/parser/result.go
+++ b/parser/result.go
@@ -709,9 +709,6 @@ func (r *result) processProto3OptionalFields(msgd *descriptorpb.DescriptorProto)
 				for _, fd := range msgd.NestedType {
 					allNames[fd.GetName()] = struct{}{}
 				}
-				for _, n := range msgd.ReservedName {
-					allNames[n] = struct{}{}
-				}
 			}
 
 			// Compute a name for the synthetic oneof. This uses the same


### PR DESCRIPTION
When I was writing the spec, I realized that this part of the code was not needed/useful, but forgot to come back and make a change. I was reminded of it when I saw it again while reviewing your recent PR. 

Basically, reserved names don't actually occupy slots in the message's namespace -- so it's okay if an element conflicts with a reserved name -- _except_ for field names, since the whole purpose of reserving a name is to prevent a field from using that name.

That means it's okay for a oneof to use a reserved name (just like it's okay for an extension or nested type to do so). So we can remove this small block of code.