### PR TITLE
catch conflicts between symbols and packages, smaller critical sections

### DIFF
--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -1340,6 +1340,20 @@ func TestLinkerValidation(t *testing.T) {
 					}`,
 			},
 		},
+		"failure_symbol_conflicts_with_package": {
+			input: map[string]string{
+				"foo.proto": `
+					syntax = "proto3";
+					package foo.bar;
+					enum baz { ZED = 0; }`,
+				"bar.proto": `
+					syntax = "proto3";
+					package foo.bar.baz;
+					message Empty { }`,
+			},
+			expectedErr: `foo.proto:3:6: symbol "foo.bar.baz" already defined as a package at bar.proto:2:9` +
+				` || bar.proto:2:9: symbol "foo.bar.baz" already defined at foo.proto:3:6`,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
This does a couple of things:

1. It adds package names to the `*Symbols` table, so we can actually catch conflicts between normal named elements and packages. (See new test.) This is a check that `protoc` performs. The new test fails without the other changes.
2. This also does some pre-factoring for an upcoming branch that will greatly reduce the lock granularity, so that `*Symbols` is much less contended. The idea is that (in the near future) each package will have its own table and lock, so two files contend over symbols only when they are in the same package. This branch also reduces the amount of work done while a write lock is held -- in particular, we only import a single file while holding the lock. Previously, from the `Import` method, it could try to import an entire transitive closure (a file and all of its imports...).
