### PR TITLE
use go-cmp/protocmp instead of custom comparisons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bufbuild/protocompile
 go 1.18
 
 require (
+	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8
@@ -11,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/prototest/util.go
+++ b/internal/prototest/util.go
@@ -51,7 +51,7 @@ func checkFiles(t *testing.T, act protoreflect.FileDescriptor, expSet *descripto
 	}
 	checked[act.Path()] = struct{}{}
 
-	expProto := findFileInSet(t, expSet, act.Path())
+	expProto := findFileInSet(expSet, act.Path())
 	actProto := protoutil.ProtoFromFileDescriptor(act)
 	AssertMessagesEqual(t, expProto, actProto)
 
@@ -62,8 +62,7 @@ func checkFiles(t *testing.T, act protoreflect.FileDescriptor, expSet *descripto
 	}
 }
 
-func findFileInSet(t *testing.T, fps *descriptorpb.FileDescriptorSet, name string) *descriptorpb.FileDescriptorProto {
-	t.Helper()
+func findFileInSet(fps *descriptorpb.FileDescriptorSet, name string) *descriptorpb.FileDescriptorProto {
 	files := fps.File
 	for _, fd := range files {
 		if fd.GetName() == name {

--- a/internal/prototest/util.go
+++ b/internal/prototest/util.go
@@ -51,11 +51,9 @@ func checkFiles(t *testing.T, act protoreflect.FileDescriptor, expSet *descripto
 	}
 	checked[act.Path()] = struct{}{}
 
-	expProto := findFileInSet(expSet, act.Path())
+	expProto := findFileInSet(t, expSet, act.Path())
 	actProto := protoutil.ProtoFromFileDescriptor(act)
-	if diff := cmp.Diff(expProto, actProto, protocmp.Transform()); diff != "" {
-		t.Errorf("file descriptor mismatch (-want +got):\n%v", diff)
-	}
+	AssertMessagesEqual(t, expProto, actProto)
 
 	if recursive {
 		for i := 0; i < act.Imports().Len(); i++ {
@@ -64,7 +62,8 @@ func checkFiles(t *testing.T, act protoreflect.FileDescriptor, expSet *descripto
 	}
 }
 
-func findFileInSet(fps *descriptorpb.FileDescriptorSet, name string) *descriptorpb.FileDescriptorProto {
+func findFileInSet(t *testing.T, fps *descriptorpb.FileDescriptorSet, name string) *descriptorpb.FileDescriptorProto {
+	t.Helper()
 	files := fps.File
 	for _, fd := range files {
 		if fd.GetName() == name {

--- a/internal/prototest/util.go
+++ b/internal/prototest/util.go
@@ -15,17 +15,14 @@
 package prototest
 
 import (
-	"bytes"
-	"fmt"
-	"math"
 	"os"
-	"strconv"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/descriptorpb"
 
 	"github.com/bufbuild/protocompile/linker"
@@ -56,7 +53,9 @@ func checkFiles(t *testing.T, act protoreflect.FileDescriptor, expSet *descripto
 
 	expProto := findFileInSet(expSet, act.Path())
 	actProto := protoutil.ProtoFromFileDescriptor(act)
-	checkFileDescriptor(t, actProto, expProto)
+	if diff := cmp.Diff(expProto, actProto, protocmp.Transform()); diff != "" {
+		t.Errorf("file descriptor mismatch (-want +got):\n%v", diff)
+	}
 
 	if recursive {
 		for i := 0; i < act.Imports().Len(); i++ {
@@ -75,174 +74,15 @@ func findFileInSet(fps *descriptorpb.FileDescriptorSet, name string) *descriptor
 	return nil
 }
 
-func checkFileDescriptor(t *testing.T, act, exp *descriptorpb.FileDescriptorProto) {
-	compareFiles(t, fmt.Sprintf("%q", act.GetName()), exp, act)
-}
-
-// adapted from implementation of proto.Equal, but records an error for each discrepancy
-// found (does NOT exit early when a discrepancy is found).
-func compareFiles(t *testing.T, path string, exp, act *descriptorpb.FileDescriptorProto) {
-	if (exp == nil) != (act == nil) {
-		if exp == nil {
-			t.Errorf("%s: expected is nil; actual is not", path)
-		} else {
-			t.Errorf("%s: expected is not nil, but actual is", path)
-		}
-		return
-	}
-	mexp := exp.ProtoReflect()
-	mact := act.ProtoReflect()
-	if mexp.IsValid() != mact.IsValid() {
-		if mexp.IsValid() {
-			t.Errorf("%s: expected is valid; actual is not", path)
-		} else {
-			t.Errorf("%s: expected is not valid, but actual is", path)
-		}
-		return
-	}
-	CompareMessages(t, path, mexp, mact)
-}
-
-func CompareMessages(t *testing.T, path string, exp, act protoreflect.Message) {
+func CompareMessages(t *testing.T, path string, exp, act protoreflect.Message, opts ...cmp.Option) {
+	t.Helper()
 	if exp.Descriptor() != act.Descriptor() {
 		t.Errorf("%s: descriptors do not match: exp %#v, actual %#v", path, exp.Descriptor(), act.Descriptor())
 		return
 	}
-	exp.Range(func(fd protoreflect.FieldDescriptor, expVal protoreflect.Value) bool {
-		name := fieldDisplayName(fd)
-		actVal := act.Get(fd)
-		if !act.Has(fd) {
-			t.Errorf("%s: expected has field %s but actual does not", path, name)
-		} else {
-			compareFields(t, path+"."+name, fd, expVal, actVal)
-		}
-		return true
-	})
-	act.Range(func(fd protoreflect.FieldDescriptor, actVal protoreflect.Value) bool {
-		name := fieldDisplayName(fd)
-		if !exp.Has(fd) {
-			t.Errorf("%s: actual has field %s but expected does not", path, name)
-		}
-		return true
-	})
-
-	compareUnknown(t, path, exp.GetUnknown(), act.GetUnknown())
-}
-
-func fieldDisplayName(fd protoreflect.FieldDescriptor) string {
-	if fd.IsExtension() {
-		return "(" + string(fd.FullName()) + ")"
-	}
-	return string(fd.Name())
-}
-
-func compareFields(t *testing.T, path string, fd protoreflect.FieldDescriptor, exp, act protoreflect.Value) {
-	switch {
-	case fd.IsList():
-		compareLists(t, path, fd, exp.List(), act.List())
-	case fd.IsMap():
-		compareMaps(t, path, fd, exp.Map(), act.Map())
-	default:
-		compareValues(t, path, fd, exp, act)
-	}
-}
-
-func compareMaps(t *testing.T, path string, fd protoreflect.FieldDescriptor, exp, act protoreflect.Map) {
-	exp.Range(func(k protoreflect.MapKey, expVal protoreflect.Value) bool {
-		actVal := act.Get(k)
-		if !act.Has(k) {
-			t.Errorf("%s: expected map has key %s but actual does not", path, k.String())
-		} else {
-			compareValues(t, path+"["+k.String()+"]", fd.MapValue(), expVal, actVal)
-		}
-		return true
-	})
-	act.Range(func(k protoreflect.MapKey, actVal protoreflect.Value) bool {
-		if !exp.Has(k) {
-			t.Errorf("%s: actual map has key %s but expected does not", path, k.String())
-		}
-		return true
-	})
-}
-
-func compareLists(t *testing.T, path string, fd protoreflect.FieldDescriptor, exp, act protoreflect.List) {
-	if exp.Len() != act.Len() {
-		t.Errorf("%s: expected is list with %d items but actual has %d", path, exp.Len(), act.Len())
-	}
-	lim := exp.Len()
-	if act.Len() < lim {
-		lim = act.Len()
-	}
-	for i := 0; i < lim; i++ {
-		compareValues(t, path+"["+strconv.Itoa(i)+"]", fd, exp.Get(i), act.Get(i))
-	}
-}
-
-func compareValues(t *testing.T, path string, fd protoreflect.FieldDescriptor, exp, act protoreflect.Value) {
-	var eq bool
-	switch fd.Kind() {
-	case protoreflect.MessageKind, protoreflect.GroupKind:
-		CompareMessages(t, path, exp.Message(), act.Message())
-		return
-	case protoreflect.BoolKind:
-		eq = exp.Bool() == act.Bool()
-	case protoreflect.EnumKind:
-		eq = exp.Enum() == act.Enum()
-	case protoreflect.Int32Kind, protoreflect.Sint32Kind,
-		protoreflect.Int64Kind, protoreflect.Sint64Kind,
-		protoreflect.Sfixed32Kind, protoreflect.Sfixed64Kind:
-		eq = exp.Int() == act.Int()
-	case protoreflect.Uint32Kind, protoreflect.Uint64Kind,
-		protoreflect.Fixed32Kind, protoreflect.Fixed64Kind:
-		eq = exp.Uint() == act.Uint()
-	case protoreflect.FloatKind, protoreflect.DoubleKind:
-		fx := exp.Float()
-		fy := act.Float()
-		if math.IsNaN(fx) || math.IsNaN(fy) {
-			eq = math.IsNaN(fx) && math.IsNaN(fy)
-		} else {
-			eq = fx == fy
-		}
-	case protoreflect.StringKind:
-		eq = exp.String() == act.String()
-	case protoreflect.BytesKind:
-		eq = bytes.Equal(exp.Bytes(), act.Bytes())
-	default:
-		// should not be possible
-		eq = exp.Interface() == act.Interface()
-	}
-	if !eq {
-		t.Errorf("%s: expected is %v but actual is %v", path, exp, act)
-	}
-}
-
-func compareUnknown(t *testing.T, path string, exp, act protoreflect.RawFields) {
-	if bytes.Equal(exp, act) {
-		return
-	}
-
-	mexp := make(map[protoreflect.FieldNumber]protoreflect.RawFields)
-	mact := make(map[protoreflect.FieldNumber]protoreflect.RawFields)
-	for len(exp) > 0 {
-		fnum, _, n := protowire.ConsumeField(exp)
-		mexp[fnum] = append(mexp[fnum], exp[:n]...)
-		exp = exp[n:]
-	}
-	for len(act) > 0 {
-		fnum, _, n := protowire.ConsumeField(act)
-		bact := act[:n]
-		mact[fnum] = append(mact[fnum], bact...)
-		if bexp, ok := mexp[fnum]; !ok {
-			t.Errorf("%s: expected has data for unknown field with tag %d but actual does not", path, fnum)
-		} else if !bytes.Equal(bexp, bact) {
-			t.Errorf("%s: expected has %v for unknown field with tag %d but actual has %v", path, bexp, fnum, bact)
-		}
-		act = act[n:]
-	}
-	for fnum := range mexp {
-		_, ok := mact[fnum]
-		if !ok {
-			t.Errorf("%s: actual has data for unknown field with tag %d but expected does not", path, fnum)
-		}
+	cmpOpts := []cmp.Option{protocmp.Transform()}
+	cmpOpts = append(cmpOpts, opts...)
+	if diff := cmp.Diff(exp.Interface(), act.Interface(), cmpOpts...); diff != "" {
+		t.Errorf("message mismatch (-want +got):\n%v", diff)
 	}
 }

--- a/internal/prototest/util.go
+++ b/internal/prototest/util.go
@@ -74,15 +74,11 @@ func findFileInSet(fps *descriptorpb.FileDescriptorSet, name string) *descriptor
 	return nil
 }
 
-func CompareMessages(t *testing.T, path string, exp, act protoreflect.Message, opts ...cmp.Option) {
+func AssertMessagesEqual(t *testing.T, exp, act proto.Message, opts ...cmp.Option) {
 	t.Helper()
-	if exp.Descriptor() != act.Descriptor() {
-		t.Errorf("%s: descriptors do not match: exp %#v, actual %#v", path, exp.Descriptor(), act.Descriptor())
-		return
-	}
 	cmpOpts := []cmp.Option{protocmp.Transform()}
 	cmpOpts = append(cmpOpts, opts...)
-	if diff := cmp.Diff(exp.Interface(), act.Interface(), cmpOpts...); diff != "" {
+	if diff := cmp.Diff(exp, act, cmpOpts...); diff != "" {
 		t.Errorf("message mismatch (-want +got):\n%v", diff)
 	}
 }

--- a/sourceinfo/source_code_info_test.go
+++ b/sourceinfo/source_code_info_test.go
@@ -16,7 +16,6 @@ package sourceinfo_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -71,7 +70,7 @@ func TestSourceCodeInfo(t *testing.T) {
 			continue
 		}
 		fixupProtocSourceCodeInfo(expectedFd.SourceCodeInfo)
-		prototest.CompareMessages(t, fmt.Sprintf("%q.source_code_info", actualFd.GetName()), expectedFd.SourceCodeInfo.ProtoReflect(), actualFd.SourceCodeInfo.ProtoReflect())
+		prototest.AssertMessagesEqual(t, expectedFd.SourceCodeInfo, actualFd.SourceCodeInfo)
 	}
 }
 


### PR DESCRIPTION
For the purposes of testing, re-use existing go-cmp/protocmp functionality which provides nicely formatted diffs when comparing objects. This allows us to remove a large number of custom methods used to recursively compare protobufs.