### PR TITLE
ast has simple trailing comment logic, complicated attribution logic moved to sourceinfo

### DIFF
--- a/ast/file.go
+++ b/ast/file.go
@@ -88,6 +88,10 @@ func NewEmptyFileNode(filename string) *FileNode {
 	return NewFileNode(fileInfo, nil, nil, fileInfo.AddToken(0, 0))
 }
 
+func (f *FileNode) GetSyntax() Node {
+	return f.Syntax
+}
+
 func (f *FileNode) Name() string {
 	return f.fileInfo.Name()
 }
@@ -100,8 +104,20 @@ func (f *FileNode) TokenInfo(t Token) NodeInfo {
 	return f.fileInfo.TokenInfo(t)
 }
 
-func (f *FileNode) GetSyntax() Node {
-	return f.Syntax
+func (f *FileNode) FirstToken() Token {
+	return f.fileInfo.FirstToken()
+}
+
+func (f *FileNode) LastToken() Token {
+	return f.fileInfo.LastToken()
+}
+
+func (f *FileNode) NextToken(t Token) Token {
+	return f.fileInfo.NextToken(t)
+}
+
+func (f *FileNode) PreviousToken(t Token) Token {
+	return f.fileInfo.PreviousToken(t)
 }
 
 // FileElement is an interface implemented by all AST nodes that are

--- a/ast/file_info.go
+++ b/ast/file_info.go
@@ -160,8 +160,9 @@ func (f *FileInfo) SourcePos(offset int) SourcePos {
 		return f.lines[n] > offset
 	})
 
-	// If it weren't for tabs, we could trivially compute the column
-	// just based on offset and the starting offset of lineNumber :(
+	// If it weren't for tabs and multi-byte unicode characters, we
+	// could trivially compute the column just based on offset and the
+	// starting offset of lineNumber :(
 	// Wish this were more efficient... that would require also storing
 	// computed line+column information, which would triple the size of
 	// f's tokens slice...
@@ -170,7 +171,9 @@ func (f *FileInfo) SourcePos(offset int) SourcePos {
 		if f.data[i] == '\t' {
 			nextTabStop := 8 - (col % 8)
 			col += nextTabStop
-		} else {
+		} else if (f.data[i] & 0b11000000) != 0b10000000 {
+			// we only increment for single byte runes (highest bit unset)
+			// and the first byte of a multi-byte rune (>1 high bits set)
 			col++
 		}
 	}

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -74,9 +74,9 @@ foo
 	syntax = "proto2";
 
 	// some strange cases
-	1.543 g12 /* trailing line comment */
+	1.543 g12 /* trailing inline comment */
 	000.000
-	0.1234 .5678 .
+	0.1234 .5678 . // trailing line comment
 	12e12 1.2345e123412341234
 
 	Random_identifier_with_numbers_0123456789_and_letters...
@@ -91,8 +91,11 @@ foo
 	// this is an attached leading comment
 	foo
 
-	1.23e+20+20
-	// a trailing comment for last element
+	'abc 😊' /* this is not a trailing
+	            comment because it ends on
+	            same line as next token */ 'def 🙁'
+
+	1.23e+20+20 // a trailing comment for last element
 
 	// comment attached to no tokens (upcoming token is EOF!)
 	/* another comment followed by some final whitespace*/
@@ -110,77 +113,79 @@ foo
 		comments   []string
 		trailCount int
 	}{
-		{t: _INT32, line: 8, col: 9, span: 5, v: "int32", comments: []string{"// comment\n", "/*\n\t * block comment\n\t */", "/* inline comment */"}},
-		{t: _STRING_LIT, line: 8, col: 16, span: 25, v: "\032\x16\n\rfoobar\"zap"},
-		{t: _STRING_LIT, line: 8, col: 57, span: 22, v: "another\tstring's\t"},
-		{t: _NAME, line: 9, col: 1, span: 3, v: "foo"},
-		{t: _SERVICE, line: 14, col: 9, span: 7, v: "service", comments: []string{"// another comment\n", "// more and more...\n"}},
-		{t: _RPC, line: 14, col: 17, span: 3, v: "rpc"},
-		{t: _MESSAGE, line: 14, col: 21, span: 7, v: "message"},
-		{t: '.', line: 15, col: 9, span: 1},
-		{t: _NAME, line: 15, col: 10, span: 4, v: "type"},
-		{t: '.', line: 16, col: 9, span: 1},
-		{t: _NAME, line: 16, col: 10, span: 1, v: "f"},
-		{t: '.', line: 16, col: 11, span: 1},
-		{t: _NAME, line: 16, col: 12, span: 1, v: "q"},
-		{t: '.', line: 16, col: 13, span: 1},
-		{t: _NAME, line: 16, col: 14, span: 1, v: "n"},
-		{t: _NAME, line: 17, col: 9, span: 4, v: "name"},
-		{t: _NAME, line: 18, col: 9, span: 1, v: "f"},
-		{t: '.', line: 18, col: 10, span: 1},
-		{t: _NAME, line: 18, col: 11, span: 1, v: "q"},
-		{t: '.', line: 18, col: 12, span: 1},
-		{t: _NAME, line: 18, col: 13, span: 1, v: "n"},
-		{t: _FLOAT_LIT, line: 20, col: 9, span: 3, v: 0.01},
-		{t: _FLOAT_LIT, line: 21, col: 9, span: 6, v: 0.01e12},
-		{t: _FLOAT_LIT, line: 22, col: 9, span: 6, v: 0.01e5},
-		{t: _FLOAT_LIT, line: 23, col: 9, span: 7, v: 0.033e-1},
-		{t: _INT_LIT, line: 25, col: 9, span: 5, v: uint64(12345)},
-		{t: '-', line: 26, col: 9, span: 1, v: nil},
-		{t: _INT_LIT, line: 26, col: 10, span: 5, v: uint64(12345)},
-		{t: _FLOAT_LIT, line: 27, col: 9, span: 8, v: 123.1234},
-		{t: _FLOAT_LIT, line: 28, col: 9, span: 5, v: 0.123},
-		{t: _INT_LIT, line: 29, col: 9, span: 6, v: uint64(012345)},
-		{t: _INT_LIT, line: 30, col: 9, span: 14, v: uint64(0x2134abcdef30)},
-		{t: '-', line: 31, col: 9, span: 1, v: nil},
-		{t: _INT_LIT, line: 31, col: 10, span: 4, v: uint64(0543)},
-		{t: '-', line: 32, col: 9, span: 1, v: nil},
-		{t: _INT_LIT, line: 32, col: 10, span: 6, v: uint64(0xff76)},
-		{t: _FLOAT_LIT, line: 33, col: 9, span: 8, v: 101.0102},
-		{t: _FLOAT_LIT, line: 34, col: 9, span: 10, v: 202.0203e1},
-		{t: _FLOAT_LIT, line: 35, col: 9, span: 12, v: 304.0304e-10},
-		{t: _FLOAT_LIT, line: 36, col: 9, span: 10, v: 3.1234e+12},
-		{t: '{', line: 38, col: 9, span: 1, v: nil},
-		{t: '}', line: 38, col: 11, span: 1, v: nil},
-		{t: '+', line: 38, col: 13, span: 1, v: nil},
-		{t: '-', line: 38, col: 15, span: 1, v: nil},
-		{t: ',', line: 38, col: 17, span: 1, v: nil},
-		{t: ';', line: 38, col: 19, span: 1, v: nil},
-		{t: '[', line: 40, col: 9, span: 1, v: nil},
-		{t: _OPTION, line: 40, col: 10, span: 6, v: "option"},
-		{t: '=', line: 40, col: 16, span: 1, v: nil},
-		{t: _NAME, line: 40, col: 17, span: 3, v: "foo"},
-		{t: ']', line: 40, col: 20, span: 1, v: nil},
-		{t: _SYNTAX, line: 41, col: 9, span: 6, v: "syntax"},
-		{t: '=', line: 41, col: 16, span: 1, v: nil},
-		{t: _STRING_LIT, line: 41, col: 18, span: 8, v: "proto2"},
-		{t: ';', line: 41, col: 26, span: 1, v: nil},
-		{t: _FLOAT_LIT, line: 44, col: 9, span: 5, v: 1.543, comments: []string{"// some strange cases\n"}},
-		{t: _NAME, line: 44, col: 15, span: 3, v: "g12"},
-		{t: _FLOAT_LIT, line: 45, col: 9, span: 7, v: 0.0, comments: []string{"/* trailing line comment */"}, trailCount: 1},
-		{t: _FLOAT_LIT, line: 46, col: 9, span: 6, v: 0.1234},
-		{t: _FLOAT_LIT, line: 46, col: 16, span: 5, v: 0.5678},
-		{t: '.', line: 46, col: 22, span: 1, v: nil},
-		{t: _FLOAT_LIT, line: 47, col: 9, span: 5, v: 12e12},
-		{t: _FLOAT_LIT, line: 47, col: 15, span: 19, v: math.Inf(1)},
-		{t: _NAME, line: 49, col: 9, span: 53, v: "Random_identifier_with_numbers_0123456789_and_letters"},
-		{t: '.', line: 49, col: 62, span: 1, v: nil},
-		{t: '.', line: 49, col: 63, span: 1, v: nil},
-		{t: '.', line: 49, col: 64, span: 1, v: nil},
-		{t: _NAME, line: 59, col: 9, span: 3, v: "foo", comments: []string{"// this is a trailing comment\n", "// that spans multiple lines\n", "// over two in fact!\n", "/*\n\t * this is a detached comment\n\t * with lots of extra words and stuff...\n\t */", "// this is an attached leading comment\n"}, trailCount: 3},
-		{t: _FLOAT_LIT, line: 61, col: 9, span: 8, v: 1.23e+20},
-		{t: '+', line: 61, col: 17, span: 1, v: nil},
-		{t: _INT_LIT, line: 61, col: 18, span: 2, v: uint64(20)},
+		0:  {t: _INT32, line: 8, col: 9, span: 5, v: "int32", comments: []string{"// comment\n", "/*\n\t * block comment\n\t */", "/* inline comment */"}},
+		1:  {t: _STRING_LIT, line: 8, col: 16, span: 25, v: "\032\x16\n\rfoobar\"zap"},
+		2:  {t: _STRING_LIT, line: 8, col: 57, span: 22, v: "another\tstring's\t"},
+		3:  {t: _NAME, line: 9, col: 1, span: 3, v: "foo"},
+		4:  {t: _SERVICE, line: 14, col: 9, span: 7, v: "service", comments: []string{"// another comment\n", "// more and more...\n"}},
+		5:  {t: _RPC, line: 14, col: 17, span: 3, v: "rpc"},
+		6:  {t: _MESSAGE, line: 14, col: 21, span: 7, v: "message"},
+		7:  {t: '.', line: 15, col: 9, span: 1},
+		8:  {t: _NAME, line: 15, col: 10, span: 4, v: "type"},
+		9:  {t: '.', line: 16, col: 9, span: 1},
+		10: {t: _NAME, line: 16, col: 10, span: 1, v: "f"},
+		11: {t: '.', line: 16, col: 11, span: 1},
+		12: {t: _NAME, line: 16, col: 12, span: 1, v: "q"},
+		13: {t: '.', line: 16, col: 13, span: 1},
+		14: {t: _NAME, line: 16, col: 14, span: 1, v: "n"},
+		15: {t: _NAME, line: 17, col: 9, span: 4, v: "name"},
+		16: {t: _NAME, line: 18, col: 9, span: 1, v: "f"},
+		17: {t: '.', line: 18, col: 10, span: 1},
+		18: {t: _NAME, line: 18, col: 11, span: 1, v: "q"},
+		19: {t: '.', line: 18, col: 12, span: 1},
+		20: {t: _NAME, line: 18, col: 13, span: 1, v: "n"},
+		21: {t: _FLOAT_LIT, line: 20, col: 9, span: 3, v: 0.01},
+		22: {t: _FLOAT_LIT, line: 21, col: 9, span: 6, v: 0.01e12},
+		23: {t: _FLOAT_LIT, line: 22, col: 9, span: 6, v: 0.01e5},
+		24: {t: _FLOAT_LIT, line: 23, col: 9, span: 7, v: 0.033e-1},
+		25: {t: _INT_LIT, line: 25, col: 9, span: 5, v: uint64(12345)},
+		26: {t: '-', line: 26, col: 9, span: 1, v: nil},
+		27: {t: _INT_LIT, line: 26, col: 10, span: 5, v: uint64(12345)},
+		28: {t: _FLOAT_LIT, line: 27, col: 9, span: 8, v: 123.1234},
+		29: {t: _FLOAT_LIT, line: 28, col: 9, span: 5, v: 0.123},
+		30: {t: _INT_LIT, line: 29, col: 9, span: 6, v: uint64(012345)},
+		31: {t: _INT_LIT, line: 30, col: 9, span: 14, v: uint64(0x2134abcdef30)},
+		32: {t: '-', line: 31, col: 9, span: 1, v: nil},
+		33: {t: _INT_LIT, line: 31, col: 10, span: 4, v: uint64(0543)},
+		34: {t: '-', line: 32, col: 9, span: 1, v: nil},
+		35: {t: _INT_LIT, line: 32, col: 10, span: 6, v: uint64(0xff76)},
+		36: {t: _FLOAT_LIT, line: 33, col: 9, span: 8, v: 101.0102},
+		37: {t: _FLOAT_LIT, line: 34, col: 9, span: 10, v: 202.0203e1},
+		38: {t: _FLOAT_LIT, line: 35, col: 9, span: 12, v: 304.0304e-10},
+		39: {t: _FLOAT_LIT, line: 36, col: 9, span: 10, v: 3.1234e+12},
+		40: {t: '{', line: 38, col: 9, span: 1, v: nil},
+		41: {t: '}', line: 38, col: 11, span: 1, v: nil},
+		42: {t: '+', line: 38, col: 13, span: 1, v: nil},
+		43: {t: '-', line: 38, col: 15, span: 1, v: nil},
+		44: {t: ',', line: 38, col: 17, span: 1, v: nil},
+		45: {t: ';', line: 38, col: 19, span: 1, v: nil},
+		46: {t: '[', line: 40, col: 9, span: 1, v: nil},
+		47: {t: _OPTION, line: 40, col: 10, span: 6, v: "option"},
+		48: {t: '=', line: 40, col: 16, span: 1, v: nil},
+		49: {t: _NAME, line: 40, col: 17, span: 3, v: "foo"},
+		50: {t: ']', line: 40, col: 20, span: 1, v: nil},
+		51: {t: _SYNTAX, line: 41, col: 9, span: 6, v: "syntax"},
+		52: {t: '=', line: 41, col: 16, span: 1, v: nil},
+		53: {t: _STRING_LIT, line: 41, col: 18, span: 8, v: "proto2"},
+		54: {t: ';', line: 41, col: 26, span: 1, v: nil},
+		55: {t: _FLOAT_LIT, line: 44, col: 9, span: 5, v: 1.543, comments: []string{"// some strange cases\n"}},
+		56: {t: _NAME, line: 44, col: 15, span: 3, v: "g12"},
+		57: {t: _FLOAT_LIT, line: 45, col: 9, span: 7, v: 0.0, comments: []string{"/* trailing inline comment */"}, trailCount: 1},
+		58: {t: _FLOAT_LIT, line: 46, col: 9, span: 6, v: 0.1234},
+		59: {t: _FLOAT_LIT, line: 46, col: 16, span: 5, v: 0.5678},
+		60: {t: '.', line: 46, col: 22, span: 1, v: nil},
+		61: {t: _FLOAT_LIT, line: 47, col: 9, span: 5, v: 12e12, comments: []string{"// trailing line comment\n"}, trailCount: 1},
+		62: {t: _FLOAT_LIT, line: 47, col: 15, span: 19, v: math.Inf(1)},
+		63: {t: _NAME, line: 49, col: 9, span: 53, v: "Random_identifier_with_numbers_0123456789_and_letters"},
+		64: {t: '.', line: 49, col: 62, span: 1, v: nil},
+		65: {t: '.', line: 49, col: 63, span: 1, v: nil},
+		66: {t: '.', line: 49, col: 64, span: 1, v: nil},
+		67: {t: _NAME, line: 59, col: 9, span: 3, v: "foo", comments: []string{"// this is a trailing comment\n", "// that spans multiple lines\n", "// over two in fact!\n", "/*\n\t * this is a detached comment\n\t * with lots of extra words and stuff...\n\t */", "// this is an attached leading comment\n"}},
+		68: {t: _STRING_LIT, line: 61, col: 9, span: 7, v: "abc 😊"},
+		69: {t: _STRING_LIT, line: 63, col: 48, span: 7, v: "def 🙁", comments: []string{"/* this is not a trailing\n\t            comment because it ends on\n\t            same line as next token */"}},
+		70: {t: _FLOAT_LIT, line: 65, col: 9, span: 8, v: 1.23e+20},
+		71: {t: '+', line: 65, col: 17, span: 1, v: nil},
+		72: {t: _INT_LIT, line: 65, col: 18, span: 2, v: uint64(20)},
 	}
 
 	for i, exp := range expected {
@@ -233,9 +238,17 @@ foo
 		for ci := range exp.comments {
 			var c ast.Comment
 			if ci < exp.trailCount {
-				c = prevNodeInfo.TrailingComments().Index(ci)
+				if assert.Less(t, ci, prevNodeInfo.TrailingComments().Len(), "missing comment") {
+					c = prevNodeInfo.TrailingComments().Index(ci)
+				} else {
+					continue
+				}
 			} else {
-				c = nodeInfo.LeadingComments().Index(ci - exp.trailCount)
+				if assert.Less(t, ci-exp.trailCount, nodeInfo.LeadingComments().Len(), "missing comment") {
+					c = nodeInfo.LeadingComments().Index(ci - exp.trailCount)
+				} else {
+					continue
+				}
 			}
 			assert.Equal(t, exp.comments[ci], c.RawText(), "case %d, comment #%d: unexpected text", i, ci+1)
 		}

--- a/sourceinfo/source_code_info.go
+++ b/sourceinfo/source_code_info.go
@@ -588,10 +588,6 @@ func attributeComments(prevInfo, info ast.NodeInfo) (t comments, l []comments) {
 	trail := prevInfo.TrailingComments()
 	lead := groupComments(info.LeadingComments())
 
-	if commentsContain(trail, lead, "This is the first detached comment for the syntax.\n") {
-		_ = true
-	}
-
 	if trail.Len() > 0 || len(lead) == 0 {
 		// previous token already has trailing comments or current token
 		// has no comments from which it may borrow
@@ -621,27 +617,6 @@ func attributeComments(prevInfo, info ast.NodeInfo) (t comments, l []comments) {
 	}
 
 	return trail, lead
-}
-
-func commentsContain(t comments, l []comments, s string) bool {
-	if doContains(t, s) {
-		return true
-	}
-	for _, c := range l {
-		if doContains(c, s) {
-			return true
-		}
-	}
-	return false
-}
-
-func doContains(c comments, s string) bool {
-	for i := 0; i < c.Len(); i++ {
-		if strings.Contains(c.Index(i).RawText(), s) {
-			return true
-		}
-	}
-	return false
 }
 
 func makeSpan(start, end ast.SourcePos) []int32 {

--- a/sourceinfo/source_code_info.go
+++ b/sourceinfo/source_code_info.go
@@ -21,6 +21,7 @@ package sourceinfo
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
@@ -486,36 +487,45 @@ func (sci *sourceCodeInfo) newBlockLocWithComments(n, openBrace ast.Node, path [
 	//    }             // not this
 	//
 	nodeInfo := sci.file.NodeInfo(n)
-	leadingComments := nodeInfo.LeadingComments()
-	openBraceInfo := sci.file.NodeInfo(openBrace)
-	trailingComments := openBraceInfo.TrailingComments()
+	leadingComments := sci.getLeadingComments(n)
+	trailingComments := sci.getTrailingComments(openBrace)
 	sci.newLocWithGivenComments(nodeInfo, leadingComments, trailingComments, path)
 }
 
 func (sci *sourceCodeInfo) newLocWithComments(n ast.Node, path []int32) {
 	nodeInfo := sci.file.NodeInfo(n)
-	leadingComments := nodeInfo.LeadingComments()
-	trailingComments := nodeInfo.TrailingComments()
+	leadingComments := sci.getLeadingComments(n)
+	trailingComments := sci.getTrailingComments(n)
 	sci.newLocWithGivenComments(nodeInfo, leadingComments, trailingComments, path)
 }
 
-func (sci *sourceCodeInfo) newLocWithGivenComments(nodeInfo ast.NodeInfo, leadingComments, trailingComments ast.Comments, path []int32) {
-	if sci.commentUsed(leadingComments) {
-		leadingComments = ast.Comments{}
+func (sci *sourceCodeInfo) newLocWithGivenComments(nodeInfo ast.NodeInfo, leadingComments []comments, trailingComments comments, path []int32) {
+	if len(leadingComments) > 0 && sci.commentUsed(leadingComments[0]) {
+		leadingComments = nil
 	}
 	if sci.commentUsed(trailingComments) {
 		trailingComments = ast.Comments{}
 	}
-	detached := groupComments(leadingComments)
+
 	var trail *string
-	if str, ok := combineComments(trailingComments, 0, trailingComments.Len()); ok {
-		trail = proto.String(str)
+	if trailingComments.Len() > 0 {
+		trail = proto.String(combineComments(trailingComments))
 	}
+
 	var lead *string
-	if leadingComments.Len() > 0 && leadingComments.Index(leadingComments.Len()-1).End().Line >= nodeInfo.Start().Line-1 {
-		lead = proto.String(detached[len(detached)-1])
-		detached = detached[:len(detached)-1]
+	if len(leadingComments) > 0 {
+		lastGroup := leadingComments[len(leadingComments)-1]
+		lastComment := lastGroup.Index(lastGroup.Len() - 1)
+		if lastComment.End().Line >= nodeInfo.Start().Line-1 {
+			lead = proto.String(combineComments(lastGroup))
+			leadingComments = leadingComments[:len(leadingComments)-1]
+		}
 	}
+	detached := make([]string, len(leadingComments))
+	for i := range leadingComments {
+		detached[i] = combineComments(leadingComments[i])
+	}
+
 	dup := make([]int32, len(path))
 	copy(dup, path)
 	sci.locs = append(sci.locs, &descriptorpb.SourceCodeInfo_Location{
@@ -527,6 +537,113 @@ func (sci *sourceCodeInfo) newLocWithGivenComments(nodeInfo ast.NodeInfo, leadin
 	})
 }
 
+type comments interface {
+	Len() int
+	Index(int) ast.Comment
+}
+
+var emptyComments = subComments{offs: 0, n: 0, c: ast.Comments{}}
+
+type subComments struct {
+	offs, n int
+	c       ast.Comments
+}
+
+func (s subComments) Len() int {
+	return s.n
+}
+
+func (s subComments) Index(i int) ast.Comment {
+	if i < 0 || i >= s.n {
+		panic(fmt.Errorf("runtime error: index out of range [%d] with length %d", i, s.n))
+	}
+	return s.c.Index(i + s.offs)
+}
+
+func (sci *sourceCodeInfo) getLeadingComments(n ast.Node) []comments {
+	s := n.Start()
+	prev := sci.file.PreviousToken(s)
+	info := sci.file.TokenInfo(s)
+	if prev == ast.TokenError {
+		return groupComments(info.LeadingComments())
+	}
+	prevInfo := sci.file.TokenInfo(prev)
+	_, c := attributeComments(prevInfo, info)
+	return c
+}
+
+func (sci *sourceCodeInfo) getTrailingComments(n ast.Node) comments {
+	e := n.End()
+	next := sci.file.NextToken(e)
+	if next == ast.TokenError {
+		return emptyComments
+	}
+	info := sci.file.TokenInfo(e)
+	nextInfo := sci.file.TokenInfo(next)
+	c, _ := attributeComments(info, nextInfo)
+	return c
+}
+
+func attributeComments(prevInfo, info ast.NodeInfo) (t comments, l []comments) {
+	trail := prevInfo.TrailingComments()
+	lead := groupComments(info.LeadingComments())
+
+	if commentsContain(trail, lead, "This is the first detached comment for the syntax.\n") {
+		_ = true
+	}
+
+	if trail.Len() > 0 || len(lead) == 0 {
+		// previous token already has trailing comments or current token
+		// has no comments from which it may borrow
+		return trail, lead
+	}
+	if prevInfo.End().Line == info.Start().Line {
+		// if the tokens are on the same line, no way to attribute
+		return trail, nil
+	}
+	if lead[0].Index(0).Start().Line > prevInfo.End().Line+1 {
+		// first comment is detached from previous token, so can't be a trailing comment
+		return trail, lead
+	}
+	if len(lead) > 1 {
+		// multiple groups? then donate first comment to previous token
+		return lead[0], lead[1:]
+	}
+
+	if lead[0].Index(lead[0].Len()-1).End().Line < info.Start().Line-1 {
+		// there is a blank line between the comments and subsequent token, so
+		// we can donate the comment to previous token
+		return lead[0], lead[1:]
+	}
+	if txt := info.RawText(); len(txt) == 1 && strings.Contains("}])", txt) {
+		// token is a symbol for the end of a scope, which doesn't need a leading comment
+		return lead[0], lead[1:]
+	}
+
+	return trail, lead
+}
+
+func commentsContain(t comments, l []comments, s string) bool {
+	if doContains(t, s) {
+		return true
+	}
+	for _, c := range l {
+		if doContains(c, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func doContains(c comments, s string) bool {
+	for i := 0; i < c.Len(); i++ {
+		if strings.Contains(c.Index(i).RawText(), s) {
+			return true
+		}
+	}
+	return false
+}
+
 func makeSpan(start, end ast.SourcePos) []int32 {
 	if start.Line == end.Line {
 		return []int32{int32(start.Line) - 1, int32(start.Col) - 1, int32(end.Col) - 1}
@@ -534,7 +651,7 @@ func makeSpan(start, end ast.SourcePos) []int32 {
 	return []int32{int32(start.Line) - 1, int32(start.Col) - 1, int32(end.Line) - 1, int32(end.Col) - 1}
 }
 
-func (sci *sourceCodeInfo) commentUsed(c ast.Comments) bool {
+func (sci *sourceCodeInfo) commentUsed(c comments) bool {
 	if c.Len() == 0 {
 		return false
 	}
@@ -547,41 +664,36 @@ func (sci *sourceCodeInfo) commentUsed(c ast.Comments) bool {
 	return false
 }
 
-func groupComments(comments ast.Comments) []string {
-	if comments.Len() == 0 {
+func groupComments(cmts ast.Comments) []comments {
+	if cmts.Len() == 0 {
 		return nil
 	}
-
-	var groups []string
-	singleLineStyle := comments.Index(0).RawText()[:2] == "//"
-	line := comments.Index(0).End().Line
+	var groups []comments
+	singleLineStyle := cmts.Index(0).RawText()[:2] == "//"
+	line := cmts.Index(0).End().Line
 	start := 0
-	for i := 1; i < comments.Len(); i++ {
-		c := comments.Index(i)
+	for i := 1; i < cmts.Len(); i++ {
+		c := cmts.Index(i)
 		prevSingleLine := singleLineStyle
 		singleLineStyle = strings.HasPrefix(c.RawText(), "//")
 		if !singleLineStyle || prevSingleLine != singleLineStyle || c.Start().Line > line+1 {
 			// new group!
-			if str, ok := combineComments(comments, start, i); ok {
-				groups = append(groups, str)
-			}
+			groups = append(groups, subComments{offs: start, n: i - start, c: cmts})
 			start = i
 		}
 		line = c.End().Line
 	}
 	// don't forget last group
-	if str, ok := combineComments(comments, start, comments.Len()); ok {
-		groups = append(groups, str)
-	}
+	groups = append(groups, subComments{offs: start, n: cmts.Len() - start, c: cmts})
 	return groups
 }
 
-func combineComments(comments ast.Comments, start, end int) (string, bool) {
-	if start >= end {
-		return "", false
+func combineComments(comments comments) string {
+	if comments.Len() == 0 {
+		return ""
 	}
 	var buf bytes.Buffer
-	for i := start; i < end; i++ {
+	for i, l := 0, comments.Len(); i < l; i++ {
 		c := comments.Index(i)
 		txt := c.RawText()
 		if txt[:2] == "//" {
@@ -616,7 +728,7 @@ func combineComments(comments ast.Comments, start, end int) (string, bool) {
 			}
 		}
 	}
-	return buf.String(), true
+	return buf.String()
 }
 
 func dup(p []int32) []int32 {


### PR DESCRIPTION
Previously, the tokenizer was responsible for attributing trailing comments to a node. It used logic to mirror the behavior of `protoc`. However, that logic has heuristics for trailing comments that are more suited to matching the output of `protoc` and less suited to consumption by tools that are AST-driven (vs. descriptor-driven).

So this greatly simplifies the logic in the tokenizer: a trailing comment is only on a token that is the last on a line, and the comment is on the same line. However, if the comment is a multi-line (block-style) comment and another token appears on the same line as the comment ends, this is treated as if the two tokens were on the same line, and thus it is not a trailing comment. (Effectively, this is like the interior newlines of a trailing block comment being ignored, for purposes of deciding if the token is last one on the line.)

The heuristics then move to the `sourceinfo` package, where we translate comments in the AST into the various components in the file's source code info and attribute trailing comments, detached comments, and leading comments.