### PR TITLE
improve comments; API consistency in reporter.Handler

### DIFF
--- a/ast/doc.go
+++ b/ast/doc.go
@@ -19,10 +19,10 @@
 // tree implement TerminalNode and all others implement CompositeNode.
 // The root of the tree for a proto source file is a *FileNode.
 //
-// Position information is tracked using a *FileInfo, callings its various
+// Position information is tracked using a *FileInfo, calling its various
 // Add* methods as the file is tokenized by the lexer. This allows AST
 // nodes to have a compact representation. To extract detailed position
-// information, you must use the nodeInfo method, available on either the
+// information, you must use the NodeInfo method, available on either the
 // *FileInfo which produced the node's tokens or the *FileNode root of
 // the tree that contains the node.
 //

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@
 // native Go protobuf compiler. "Compile" in this case just means parsing
 // and validating source and generating fully-linked descriptors in the end.
 // Unlike the protoc command-line tool, this package does not try to use the
-// descriptors to perform code.
+// descriptors to perform code generation.
 //
 // The various sub-packages represent the various compile phases and contain
 // models for the intermediate results. Those phases follow:
@@ -31,10 +31,15 @@
 //  5. Generate source code info.
 //     Also see: sourceinfo.GenerateSourceInfo
 //
-// This package provides an easy-to-use interface that does all of the phases
-// relevant, based on the inputs given. It is also capable of taking advantage
-// of multiple CPU cores, so a compilation involving thousands of files can be
-// done very quickly by compiling things in parallel.
+// This package provides an easy-to-use interface that does all the relevant
+// phases, based on the inputs given. If an input is provided as source, all
+// phases apply. If an input is provided as a descriptor proto, only phases
+// 3 to 5 apply. Nothing is necessary if provided a linked descriptor (which
+// is usually only the case for select system dependencies).
+//
+// This package is also capable of taking advantage of multiple CPU cores, so
+// a compilation involving thousands of files can be done very quickly by
+// compiling things in parallel.
 //
 // # Resolvers
 //

--- a/linker/doc.go
+++ b/linker/doc.go
@@ -27,10 +27,10 @@
 //
 // This interface is both the result of linking but also an input to the linking
 // process, as all dependencies of a file to be linked must be provided in this
-// form. The actual result of the Link function is a super-interface of File:
-// Result. The linker.Result interface provides even more functions, which are
-// needed for subsequent compilation steps: interpreting options and generating
-// source code info.
+// form. The actual result of the Link function, a Result, is an even broader
+// interface than File: The linker.Result interface provides even more functions,
+// which are needed for subsequent compilation steps: interpreting options and
+// generating source code info.
 //
 // # Symbols
 //

--- a/linker/files.go
+++ b/linker/files.go
@@ -185,16 +185,16 @@ type Resolver interface {
 	protoregistry.ExtensionTypeResolver
 }
 
-// ResolverFromFile returns a Resolver that uses the given file plus its full set of
-// transitive dependencies as the source of descriptors. If a given query
+// ResolverFromFile returns a Resolver that uses the given file plus its full
+// set of transitive dependencies as the source of descriptors. If a given query
 // cannot be answered with these files, the query will fail with a
 // protoregistry.NotFound error.
 //
-// Note that this function does not compute any additional indexes, for
-// efficient search, so queries generally take linear time, O(n) where n is the
-// number of files in the transitive closure of the given file. Queries for an
-// extension by number are linear with the number of messages and extensions
-// defined across all the files.
+// Note that this function does not compute any additional indexes for efficient
+// search, so queries generally take linear time, O(n) where n is the number of
+// files in the transitive closure of the given file. Queries for an extension
+// by number are linear with the number of messages and extensions defined across
+// all the files.
 func ResolverFromFile(f File) Resolver {
 	return fileResolver{
 		f:    f,

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -103,7 +103,7 @@ func (r *result) CheckForUnusedImports(handler *reporter.Handler) {
 					}
 				}
 			}
-			handler.HandleWarning(pos, errUnusedImport(dep))
+			handler.HandleWarningWithPos(pos, errUnusedImport(dep))
 		}
 	}
 }

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -134,7 +134,7 @@ func (r *result) validateJSONNamesInEnum(ed *descriptorpb.EnumDescriptorProto, h
 
 			// Since proto2 did not originally have a JSON format, we report conflicts as just warnings
 			if r.Syntax() != protoreflect.Proto3 {
-				handler.HandleWarning(r.FileNode().NodeInfo(fldNode).Start(), conflictErr)
+				handler.HandleWarningWithPos(r.FileNode().NodeInfo(fldNode).Start(), conflictErr)
 			} else if err := handler.HandleErrorf(r.FileNode().NodeInfo(fldNode).Start(), conflictErr.Error()); err != nil {
 				return err
 			}
@@ -192,7 +192,7 @@ func (r *result) validateFieldJSONNames(md *descriptorpb.DescriptorProto, useCus
 				// Since proto2 did not originally have default JSON names, we report conflicts involving
 				// default names as just warnings.
 				if r.Syntax() != protoreflect.Proto3 && (!custom || !existing.custom) {
-					handler.HandleWarning(pos, conflictErr.Unwrap())
+					handler.HandleWarning(conflictErr)
 				} else if err := handler.HandleError(conflictErr); err != nil {
 					return err
 				}

--- a/options/options.go
+++ b/options/options.go
@@ -17,9 +17,9 @@
 // identifiers and literal values.
 //
 // The process of interpreting an option is to resolve identifiers, by examining
-// descriptors for the Options types and their available extensions (custom
-// options). As field names are resolved, the values can be type-checked against
-// the types indicated in field descriptors.
+// descriptors for the google.protobuf.*Options types and their available
+// extensions (custom options). As field names are resolved, the values can be
+// type-checked against the types indicated in field descriptors.
 //
 // On success, the various fields and extensions of the options message are
 // populated and the field holding the uninterpreted form is cleared.

--- a/parser/result.go
+++ b/parser/result.go
@@ -96,7 +96,7 @@ func (r *result) createFileDescriptor(filename string, file *ast.FileNode, handl
 		}
 	} else {
 		nodeInfo := file.NodeInfo(file)
-		handler.HandleWarning(nodeInfo.Start(), ErrNoSyntax)
+		handler.HandleWarningWithPos(nodeInfo.Start(), ErrNoSyntax)
 	}
 
 	for _, decl := range file.Decls {


### PR DESCRIPTION
Since we're getting really close to ready with this, I did a pass over a bunch of the docs, exported API, and doc comments.

This PR includes mostly some doc fixes. But it also improves the API of `reporter.Handler` so it's more coherent and consistent.

I think that we are probably ready to drop a release on this repo after this lands -- like a v0.1.