### PR TITLE
don't keep trailing newline inside line comment txt in AST

### DIFF
--- a/ast/doc.go
+++ b/ast/doc.go
@@ -13,18 +13,29 @@
 // limitations under the License.
 
 // Package ast defines types for modeling the AST (Abstract Syntax
-// Tree) for the protocol buffers source language.
+// Tree) for the Protocol Buffers interface definition language.
 //
-// All nodes of the tree implement the Node interface. Leaf nodes in the
-// tree implement TerminalNode and all others implement CompositeNode.
-// The root of the tree for a proto source file is a *FileNode.
+// # Nodes
 //
-// Position information is tracked using a *FileInfo, callings its various
-// Add* methods as the file is tokenized by the lexer. This allows AST
-// nodes to have a compact representation. To extract detailed position
-// information, you must use the nodeInfo method, available on either the
-// *FileInfo which produced the node's tokens or the *FileNode root of
-// the tree that contains the node.
+// All nodes of the tree implement the [Node] interface. Leaf nodes in the
+// tree implement [TerminalNode], and all others implement [CompositeNode].
+// The root of the tree for a proto source file is a *[FileNode].
+//
+// A [TerminalNode] represents a single lexical element, or [Token]. A
+// [CompositeNode] represents a sub-tree of the AST and range of tokens.
+//
+// Position information is tracked using a *[FileInfo]. The lexer invokes its
+// various Add* methods to add details as the file is tokenized. Storing
+// the position information in the *[FileInfo], instead of in each AST node,
+// allows the AST to have a much more compact representation. To extract
+// detailed position information, you must use the NodeInfo method, available
+// on either the *[FileInfo] which produced the node's items or the *[FileNode]
+// root of the tree that contains the node.
+//
+// # Items, Tokens, and Comments
+//
+// An [Item] represents a lexical item, excluding whitespace. This can be
+// either a [Token] or a [Comment].
 //
 // Comments are not represented as nodes in the tree. Instead, they are
 // attributed to terminal nodes in the tree. So, when lexing, comments
@@ -35,6 +46,21 @@
 // a non-leaf/non-token node (i.e. a CompositeNode) come from the first
 // and last nodes in its sub-tree, for leading and trailing comments
 // respectively.
+//
+// A [Comment] value corresponds to a line ("//") or block ("/*") style
+// comment in the source. These have no bearing on the grammar and are
+// effectively ignored as the parser is determining the shape of the
+// syntax tree.
+//
+// A [Token] value corresponds to a component of the grammar, that is
+// used to produce an AST. They correspond to leaves in the AST (i.e.
+// [TerminalNode]).
+//
+// The *[FileInfo] and *[FileNode] types provide methods for querying
+// and iterating through all the items or tokens in the file. They also
+// include a method for resolving an [Item] into a [Token] or [Comment].
+//
+// # Factory Functions
 //
 // Creation of AST nodes should use the factory functions in this
 // package instead of struct literals. Some factory functions accept

--- a/ast/file.go
+++ b/ast/file.go
@@ -104,20 +104,16 @@ func (f *FileNode) TokenInfo(t Token) NodeInfo {
 	return f.fileInfo.TokenInfo(t)
 }
 
-func (f *FileNode) FirstToken() Token {
-	return f.fileInfo.FirstToken()
+func (f *FileNode) GetItem(i Item) (Token, Comment) {
+	return f.fileInfo.GetItem(i)
 }
 
-func (f *FileNode) LastToken() Token {
-	return f.fileInfo.LastToken()
+func (f *FileNode) Items() Sequence[Item] {
+	return f.fileInfo.Items()
 }
 
-func (f *FileNode) NextToken(t Token) Token {
-	return f.fileInfo.NextToken(t)
-}
-
-func (f *FileNode) PreviousToken(t Token) Token {
-	return f.fileInfo.PreviousToken(t)
+func (f *FileNode) Tokens() Sequence[Token] {
+	return f.fileInfo.Tokens()
 }
 
 // FileElement is an interface implemented by all AST nodes that are

--- a/ast/node.go
+++ b/ast/node.go
@@ -25,7 +25,7 @@ type Node interface {
 }
 
 // TerminalNode represents a leaf in the AST. These represent
-// the tokens/lexemes in the protobuf language. Comments and
+// the items/lexemes in the protobuf language. Comments and
 // whitespace are accumulated by the lexer and associated with
 // the following lexed token.
 type TerminalNode interface {
@@ -88,7 +88,7 @@ func (n *compositeNode) End() Token {
 }
 
 // RuneNode represents a single rune in protobuf source. Runes
-// are typically collected into tokens, but some runes stand on
+// are typically collected into items, but some runes stand on
 // their own, such as punctuation/symbols like commas, semicolons,
 // equals signs, open and close symbols (braces, brackets, angles,
 // and parentheses), and periods/dots.

--- a/ast/options.go
+++ b/ast/options.go
@@ -130,8 +130,8 @@ type OptionNameNode struct {
 	compositeNode
 	Parts []*FieldReferenceNode
 	// Dots represent the separating '.' characters between name parts. The
-	// length of this slice must be exactly len(Parts)-1, each item in Parts
-	// having a corresponding item in this slice *except the last* (since a
+	// length of this slice must be exactly len(Parts)-1, each AsItem in Parts
+	// having a corresponding AsItem in this slice *except the last* (since a
 	// trailing dot is not allowed).
 	//
 	// These do *not* include dots that are inside of an extension name. For
@@ -315,8 +315,8 @@ type CompactOptionsNode struct {
 	OpenBracket *RuneNode
 	Options     []*OptionNode
 	// Commas represent the separating ',' characters between options. The
-	// length of this slice must be exactly len(Options)-1, with each item
-	// in Options having a corresponding item in this slice *except the last*
+	// length of this slice must be exactly len(Options)-1, with each AsItem
+	// in Options having a corresponding AsItem in this slice *except the last*
 	// (since a trailing comma is not allowed).
 	Commas       []*RuneNode
 	CloseBracket *RuneNode

--- a/ast/ranges.go
+++ b/ast/ranges.go
@@ -25,8 +25,8 @@ type ExtensionRangeNode struct {
 	Keyword *KeywordNode
 	Ranges  []*RangeNode
 	// Commas represent the separating ',' characters between ranges. The
-	// length of this slice must be exactly len(Ranges)-1, each item in Ranges
-	// having a corresponding item in this slice *except the last* (since a
+	// length of this slice must be exactly len(Ranges)-1, each AsItem in Ranges
+	// having a corresponding AsItem in this slice *except the last* (since a
 	// trailing comma is not allowed).
 	Commas    []*RuneNode
 	Options   *CompactOptionsNode
@@ -216,8 +216,8 @@ type ReservedNode struct {
 	Names []StringValueNode
 	// Commas represent the separating ',' characters between options. The
 	// length of this slice must be exactly len(Ranges)-1 or len(Names)-1, depending
-	// on whether this node represents reserved ranges or reserved names. Each item
-	// in Ranges or Names has a corresponding item in this slice *except the last*
+	// on whether this node represents reserved ranges or reserved names. Each AsItem
+	// in Ranges or Names has a corresponding AsItem in this slice *except the last*
 	// (since a trailing comma is not allowed).
 	Commas    []*RuneNode
 	Semicolon *RuneNode

--- a/ast/values.go
+++ b/ast/values.go
@@ -387,8 +387,8 @@ type ArrayLiteralNode struct {
 	OpenBracket *RuneNode
 	Elements    []ValueNode
 	// Commas represent the separating ',' characters between elements. The
-	// length of this slice must be exactly len(Elements)-1, with each item
-	// in Elements having a corresponding item in this slice *except the last*
+	// length of this slice must be exactly len(Elements)-1, with each AsItem
+	// in Elements having a corresponding AsItem in this slice *except the last*
 	// (since a trailing comma is not allowed).
 	Commas       []*RuneNode
 	CloseBracket *RuneNode
@@ -454,9 +454,9 @@ type MessageLiteralNode struct {
 	Elements []*MessageFieldNode
 	// Separator characters between elements, which can be either ','
 	// or ';' if present. This slice must be exactly len(Elements) in
-	// length, with each item in Elements having one corresponding item
+	// length, with each AsItem in Elements having one corresponding AsItem
 	// in Seps. Separators in message literals are optional, so a given
-	// item in this slice may be nil to indicate absence of a separator.
+	// AsItem in this slice may be nil to indicate absence of a separator.
 	Seps  []*RuneNode
 	Close *RuneNode // should be '}' or '>', depending on Open
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -631,13 +631,15 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 
 func (l *protoLex) skipToEndOfLineComment(lval *protoSymType) (hasErr bool) {
 	for {
-		c, _, err := l.input.readRune()
+		c, sz, err := l.input.readRune()
 		if err != nil {
+			// eof
 			return false
 		}
 		switch c {
 		case '\n':
-			l.info.AddLine(l.input.offset())
+			// don't include newline in the comment
+			l.input.unreadRune(sz)
 			return false
 		case 0:
 			l.setError(lval, errors.New("invalid control character"))

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -113,11 +113,11 @@ foo
 		comments   []string
 		trailCount int
 	}{
-		0:  {t: _INT32, line: 8, col: 9, span: 5, v: "int32", comments: []string{"// comment\n", "/*\n\t * block comment\n\t */", "/* inline comment */"}},
+		0:  {t: _INT32, line: 8, col: 9, span: 5, v: "int32", comments: []string{"// comment", "/*\n\t * block comment\n\t */", "/* inline comment */"}},
 		1:  {t: _STRING_LIT, line: 8, col: 16, span: 25, v: "\032\x16\n\rfoobar\"zap"},
 		2:  {t: _STRING_LIT, line: 8, col: 57, span: 22, v: "another\tstring's\t"},
 		3:  {t: _NAME, line: 9, col: 1, span: 3, v: "foo"},
-		4:  {t: _SERVICE, line: 14, col: 9, span: 7, v: "service", comments: []string{"// another comment\n", "// more and more...\n"}},
+		4:  {t: _SERVICE, line: 14, col: 9, span: 7, v: "service", comments: []string{"// another comment", "// more and more..."}},
 		5:  {t: _RPC, line: 14, col: 17, span: 3, v: "rpc"},
 		6:  {t: _MESSAGE, line: 14, col: 21, span: 7, v: "message"},
 		7:  {t: '.', line: 15, col: 9, span: 1},
@@ -168,19 +168,19 @@ foo
 		52: {t: '=', line: 41, col: 16, span: 1, v: nil},
 		53: {t: _STRING_LIT, line: 41, col: 18, span: 8, v: "proto2"},
 		54: {t: ';', line: 41, col: 26, span: 1, v: nil},
-		55: {t: _FLOAT_LIT, line: 44, col: 9, span: 5, v: 1.543, comments: []string{"// some strange cases\n"}},
+		55: {t: _FLOAT_LIT, line: 44, col: 9, span: 5, v: 1.543, comments: []string{"// some strange cases"}},
 		56: {t: _NAME, line: 44, col: 15, span: 3, v: "g12"},
 		57: {t: _FLOAT_LIT, line: 45, col: 9, span: 7, v: 0.0, comments: []string{"/* trailing inline comment */"}, trailCount: 1},
 		58: {t: _FLOAT_LIT, line: 46, col: 9, span: 6, v: 0.1234},
 		59: {t: _FLOAT_LIT, line: 46, col: 16, span: 5, v: 0.5678},
 		60: {t: '.', line: 46, col: 22, span: 1, v: nil},
-		61: {t: _FLOAT_LIT, line: 47, col: 9, span: 5, v: 12e12, comments: []string{"// trailing line comment\n"}, trailCount: 1},
+		61: {t: _FLOAT_LIT, line: 47, col: 9, span: 5, v: 12e12, comments: []string{"// trailing line comment"}, trailCount: 1},
 		62: {t: _FLOAT_LIT, line: 47, col: 15, span: 19, v: math.Inf(1)},
 		63: {t: _NAME, line: 49, col: 9, span: 53, v: "Random_identifier_with_numbers_0123456789_and_letters"},
 		64: {t: '.', line: 49, col: 62, span: 1, v: nil},
 		65: {t: '.', line: 49, col: 63, span: 1, v: nil},
 		66: {t: '.', line: 49, col: 64, span: 1, v: nil},
-		67: {t: _NAME, line: 59, col: 9, span: 3, v: "foo", comments: []string{"// this is a trailing comment\n", "// that spans multiple lines\n", "// over two in fact!\n", "/*\n\t * this is a detached comment\n\t * with lots of extra words and stuff...\n\t */", "// this is an attached leading comment\n"}},
+		67: {t: _NAME, line: 59, col: 9, span: 3, v: "foo", comments: []string{"// this is a trailing comment", "// that spans multiple lines", "// over two in fact!", "/*\n\t * this is a detached comment\n\t * with lots of extra words and stuff...\n\t */", "// this is an attached leading comment"}},
 		68: {t: _STRING_LIT, line: 61, col: 9, span: 7, v: "abc 😊"},
 		69: {t: _STRING_LIT, line: 63, col: 48, span: 7, v: "def 🙁", comments: []string{"/* this is not a trailing\n\t            comment because it ends on\n\t            same line as next token */"}},
 		70: {t: _FLOAT_LIT, line: 65, col: 9, span: 8, v: 1.23e+20},
@@ -265,7 +265,7 @@ foo
 	eofNodeInfo := l.info.TokenInfo(l.eof)
 	finalComments := eofNodeInfo.LeadingComments()
 	if assert.Equal(t, 2, finalComments.Len(), "wrong number of final remaining comments") {
-		assert.Equal(t, "// comment attached to no tokens (upcoming token is EOF!)\n", finalComments.Index(0).RawText(), "incorrect final comment text")
+		assert.Equal(t, "// comment attached to no tokens (upcoming token is EOF!)", finalComments.Index(0).RawText(), "incorrect final comment text")
 		assert.Equal(t, "/* another comment followed by some final whitespace*/", finalComments.Index(1).RawText(), "incorrect final comment text")
 	}
 	assert.Equal(t, "\n\n\t\n\t", eofNodeInfo.LeadingWhitespace(), "incorrect final whitespace")
@@ -528,7 +528,7 @@ message Foo {
 					if assert.Equal(t, 1, info.LeadingComments().Len(), "%s should have a leading comment", name) {
 						assert.Equal(
 							t,
-							fmt.Sprintf("// Leading comment on %s.\n", name),
+							fmt.Sprintf("// Leading comment on %s.", name),
 							info.LeadingComments().Index(0).RawText(),
 						)
 					}
@@ -542,7 +542,7 @@ message Foo {
 					if assert.Equal(t, 1, info.LeadingComments().Len(), "%s should have a leading comment", name) {
 						assert.Equal(
 							t,
-							fmt.Sprintf("// Leading comment on %s.\n", name),
+							fmt.Sprintf("// Leading comment on %s.", name),
 							info.LeadingComments().Index(0).RawText(),
 						)
 					}

--- a/sourceinfo/source_code_info.go
+++ b/sourceinfo/source_code_info.go
@@ -562,9 +562,9 @@ func (s subComments) Index(i int) ast.Comment {
 
 func (sci *sourceCodeInfo) getLeadingComments(n ast.Node) []comments {
 	s := n.Start()
-	prev := sci.file.PreviousToken(s)
 	info := sci.file.TokenInfo(s)
-	if prev == ast.TokenError {
+	prev, ok := sci.file.Tokens().Previous(s)
+	if !ok {
 		return groupComments(info.LeadingComments())
 	}
 	prevInfo := sci.file.TokenInfo(prev)
@@ -574,8 +574,8 @@ func (sci *sourceCodeInfo) getLeadingComments(n ast.Node) []comments {
 
 func (sci *sourceCodeInfo) getTrailingComments(n ast.Node) comments {
 	e := n.End()
-	next := sci.file.NextToken(e)
-	if next == ast.TokenError {
+	next, ok := sci.file.Tokens().Next(e)
+	if !ok {
 		return emptyComments
 	}
 	info := sci.file.TokenInfo(e)

--- a/sourceinfo/source_code_info.go
+++ b/sourceinfo/source_code_info.go
@@ -673,6 +673,9 @@ func combineComments(comments comments) string {
 		txt := c.RawText()
 		if txt[:2] == "//" {
 			buf.WriteString(txt[2:])
+			// protoc includes trailing newline for line comments,
+			// but it's not present in the AST comment, so we add it
+			buf.WriteRune('\n')
 		} else {
 			lines := strings.Split(txt[2:len(txt)-2], "\n")
 			first := true


### PR DESCRIPTION
This is in the same vein as #46: `protoc` preserves the trailing newline for line comments in its source code info.

But that is confusing for users of the AST because the AST ostensibly provides other accessors for querying whitespace between elements: `LeadingWhitespace()` method on `NodeInfo` and `Comment`. By keeping the newline _in_ the comment text, that means that code has to look at _both_ the `LeadingWhitespace()` and also inspect the preceding comment's `RawText()` to determine if there was a newline between elements.

That's icky and is the source of some confusing (and not always-robustly-correct) code in the formatter. We can simplify by keeping the trailing/separating newline out of the comment text, so it is instead part of leading whitespace.

However, we have to remember to then add the newline on the end when generating source code info, since `protoc` includes it.