### PR TITLE
unwrap FileImport when converting descriptor to descriptor proto

### DIFF
--- a/protoutil/protos.go
+++ b/protoutil/protos.go
@@ -101,6 +101,9 @@ func ProtoFromDescriptor(d protoreflect.Descriptor) proto.Message {
 // inexpensive and non-lossy operation. File descriptors from other sources
 // however may be expensive (to re-create a proto) and even lossy.
 func ProtoFromFileDescriptor(d protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+	if imp, ok := d.(protoreflect.FileImport); ok {
+		d = imp.FileDescriptor
+	}
 	type canProto interface {
 		FileDescriptorProto() *descriptorpb.FileDescriptorProto
 	}


### PR DESCRIPTION
The `protoreflect.FileImport` struct embeds a `protoreflect.FileDescriptor`. So it implements the interface, but doesn't implement any other interface that might allow it to be efficiently converted to a `FileDescriptorProto`.

So we unwrap it first, and then see if the embedded value implements an efficient way to convert.

This is actually needed for more than just efficiency: `protodesc.ToFileDescriptorProto` is lossy. In particular, it drops the `proto3_optional` value for extensions. (This is _generally_ safe, since that flag does not actually impact semantics for extensions, only for non-extension fields. But there are some use cases that want to preserve attributes like this from the source descriptor proto.)