### PR TITLE
only allow a single Any message in options

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,10 +73,13 @@ linters:
     - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
     - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
+    - rowserrcheck      # no SQL code in protocompile
     - scopelint         # deprecated by author
+    - sqlclosecheck     # no SQL code in protocompile
     - structcheck       # deprecated by author
     - testpackage       # internal tests are fine
     - varcheck          # deprecated by author
+    - wastedassign      # not supported with generics
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -1067,6 +1067,30 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			expectedErr: "foo.proto:9:6: message foo.bar.Baz: option (foo.bar.any): could not resolve type reference type.googleapis.com/Foo",
 		},
+		"failure_any_message_literal_duplicate": {
+			input: map[string]string{
+				"foo.proto": `
+					syntax = "proto3";
+					package foo.bar;
+					import "google/protobuf/any.proto";
+					import "google/protobuf/descriptor.proto";
+					message Foo { string a = 1; int32 b = 2; }
+					extend google.protobuf.MessageOptions { optional google.protobuf.Any any = 10001; }
+					message Baz {
+					  option (any) = {
+					    [type.googleapis.com/foo.bar.Foo] <
+					      a: "abc"
+					      b: 123
+					    >
+					    [type.googleapis.com/foo.bar.Foo] <
+					      a: "abc"
+					      b: 123
+					    >
+					  };
+					}`,
+			},
+			expectedErr: "foo.proto:13:6: message foo.bar.Baz: option (foo.bar.any): multiple any type references are not allowed",
+		},
 		"failure_scope_type_name": {
 			input: map[string]string{
 				"foo.proto": `

--- a/options/options.go
+++ b/options/options.go
@@ -1401,8 +1401,6 @@ func (interp *interpreter) messageLiteralValue(mc *internal.MessageContext, fiel
 		} else {
 			mc.OptAggPath = origPath + "." + fieldNode.Name.Value()
 		}
-
-		// TODO: ensure that len(fieldNodes) == 1 (can't have multiple any fields)
 		if fieldNode.Name.IsAnyTypeReference() {
 			if fmd.FullName() != "google.protobuf.Any" {
 				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vtype references are only allowed for google.protobuf.Any, but this type is %s", mc, fmd.FullName())

--- a/options/options.go
+++ b/options/options.go
@@ -1408,18 +1408,18 @@ func (interp *interpreter) messageLiteralValue(mc *internal.MessageContext, fiel
 				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vmultiple any type references are not allowed", mc)
 			}
 			foundAnyNode = true
-			// TODO: Support other URLs dynamically -- the caller of protoparse
-			// should be able to provide a fldNode custom resolver that can resolve type
-			// URLs into message descriptors. The default resolver would be
-			// implemented as below, only accepting "type.googleapis.com" and
-			// "type.googleprod.com" as hosts/prefixes and using the compiled
-			// file's transitive closure to find the named message.
 			if fmd.FullName() != "google.protobuf.Any" {
 				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vtype references are only allowed for google.protobuf.Any, but this type is %s", mc, fmd.FullName())
 			}
 			urlPrefix := fieldNode.Name.URLPrefix.AsIdentifier()
 			msgName := fieldNode.Name.Name.AsIdentifier()
 			fullURL := fmt.Sprintf("%s/%s", urlPrefix, msgName)
+			// TODO: Support other URLs dynamically -- the caller of protoparse
+			// should be able to provide a fldNode custom resolver that can resolve type
+			// URLs into message descriptors. The default resolver would be
+			// implemented as below, only accepting "type.googleapis.com" and
+			// "type.googleprod.com" as hosts/prefixes and using the compiled
+			// file's transitive closure to find the named message.
 			if urlPrefix != "type.googleapis.com" && urlPrefix != "type.googleprod.com" {
 				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vcould not resolve type reference %s", mc, fullURL)
 			}

--- a/options/options.go
+++ b/options/options.go
@@ -1404,13 +1404,13 @@ func (interp *interpreter) messageLiteralValue(mc *internal.MessageContext, fiel
 
 		// TODO: ensure that len(fieldNodes) == 1 (can't have multiple any fields)
 		if fieldNode.Name.IsAnyTypeReference() {
+			if fmd.FullName() != "google.protobuf.Any" {
+				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vtype references are only allowed for google.protobuf.Any, but this type is %s", mc, fmd.FullName())
+			}
 			if foundAnyNode {
 				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vmultiple any type references are not allowed", mc)
 			}
 			foundAnyNode = true
-			if fmd.FullName() != "google.protobuf.Any" {
-				return interpretedFieldValue{}, reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix).Start(), "%vtype references are only allowed for google.protobuf.Any, but this type is %s", mc, fmd.FullName())
-			}
 			urlPrefix := fieldNode.Name.URLPrefix.AsIdentifier()
 			msgName := fieldNode.Name.Name.AsIdentifier()
 			fullURL := fmt.Sprintf("%s/%s", urlPrefix, msgName)


### PR DESCRIPTION
Update protocompile to fail on multiple Any messages in a custom option.
Verified that protoc fails on the same input (albeit with a different
error message).