### PR TITLE
verify that reserved names are valid identifiers

### DIFF
--- a/parser/validate.go
+++ b/parser/validate.go
@@ -251,6 +251,9 @@ func validateMessage(res *result, isProto3 bool, name protoreflect.FullName, md 
 }
 
 func isIdentifier(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
 	for i, r := range s {
 		if i == 0 && r >= '0' && r <= '9' {
 			// can't start with number
@@ -284,11 +287,10 @@ func findMessageReservedNameNode(msgNode ast.MessageDeclNode, name string) ast.N
 
 func findReservedNameNode[T ast.Node](parent ast.Node, decls []T, name string) ast.Node {
 	for _, decl := range decls {
-		// NB: We have to store in empty interface value first before we can do type
+		// NB: We have to convert to empty interface first, before we can do a type
 		// assertion because type assertions on type parameters aren't allowed. (The
 		// compiler cannot yet know whether T is an interface type or not.)
-		var declIface any = decl
-		rsvd, ok := declIface.(*ast.ReservedNode)
+		rsvd, ok := any(decl).(*ast.ReservedNode)
 		if !ok {
 			continue
 		}

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -512,6 +512,64 @@ func TestBasicValidation(t *testing.T) {
 					   } } } }`,
 			expectedErr: `test.proto:10:55: message nesting depth must be less than 32`,
 		},
+		"failure_message_invalid_reserved_name": {
+			contents: `syntax = "proto3";
+					   message Foo {
+					     reserved "foo", "b_a_r9", " blah ";
+					   }`,
+			expectedErr: `test.proto:3:72: message Foo: reserved name " blah " is not a valid identifier`,
+		},
+		"failure_message_invalid_reserved_name2": {
+			contents: `syntax = "proto3";
+					   message Foo {
+					     reserved "foo", "_bar123", "123";
+					   }`,
+			expectedErr: `test.proto:3:73: message Foo: reserved name "123" is not a valid identifier`,
+		},
+		"failure_message_invalid_reserved_name3": {
+			contents: `syntax = "proto3";
+					   message Foo {
+					     reserved "foo" "_bar123" "@y!!";
+					   }`,
+			expectedErr: `test.proto:3:55: message Foo: reserved name "foo_bar123@y!!" is not a valid identifier`,
+		},
+		"success_message_reserved_name": {
+			contents: `syntax = "proto3";
+					   message Foo {
+					     reserved "foo", "_bar123", "A_B_C_1_2_3";
+					   }`,
+		},
+		"failure_enum_invalid_reserved_name": {
+			contents: `syntax = "proto3";
+					   enum Foo {
+					     BAR = 0;
+					     reserved "foo", "b_a_r9", " blah ";
+					   }`,
+			expectedErr: `test.proto:4:72: enum Foo: reserved name " blah " is not a valid identifier`,
+		},
+		"failure_enum_invalid_reserved_name2": {
+			contents: `syntax = "proto3";
+					   enum Foo {
+					     BAR = 0;
+					     reserved "foo", "_bar123", "123";
+					   }`,
+			expectedErr: `test.proto:4:73: enum Foo: reserved name "123" is not a valid identifier`,
+		},
+		"failure_enum_invalid_reserved_name3": {
+			contents: `syntax = "proto3";
+					   enum Foo {
+					     BAR = 0;
+					     reserved "foo" "_bar123" "@y!!";
+					   }`,
+			expectedErr: `test.proto:4:55: enum Foo: reserved name "foo_bar123@y!!" is not a valid identifier`,
+		},
+		"success_enum_reserved_name": {
+			contents: `syntax = "proto3";
+					   enum Foo {
+					     BAR = 0;
+					     reserved "foo", "_bar123", "A_B_C_1_2_3";
+					   }`,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -533,6 +533,13 @@ func TestBasicValidation(t *testing.T) {
 					   }`,
 			expectedErr: `test.proto:3:55: message Foo: reserved name "foo_bar123@y!!" is not a valid identifier`,
 		},
+		"failure_message_invalid_reserved_name4": {
+			contents: `syntax = "proto3";
+					   message Foo {
+					     reserved "";
+					   }`,
+			expectedErr: `test.proto:3:55: message Foo: reserved name "" is not a valid identifier`,
+		},
 		"success_message_reserved_name": {
 			contents: `syntax = "proto3";
 					   message Foo {
@@ -562,6 +569,14 @@ func TestBasicValidation(t *testing.T) {
 					     reserved "foo" "_bar123" "@y!!";
 					   }`,
 			expectedErr: `test.proto:4:55: enum Foo: reserved name "foo_bar123@y!!" is not a valid identifier`,
+		},
+		"failure_enum_invalid_reserved_name4": {
+			contents: `syntax = "proto3";
+					   enum Foo {
+					     BAR = 0;
+					     reserved "";
+					   }`,
+			expectedErr: `test.proto:4:55: enum Foo: reserved name "" is not a valid identifier`,
 		},
 		"success_enum_reserved_name": {
 			contents: `syntax = "proto3";


### PR DESCRIPTION
Currently (latest on master), `protoc` just warns when a reserved name is not a valid identifier. (Current _release_ just ignores invalid names, just like buf does.) But I am hoping to land a change soon that will make it an actual error in `protoc`. 

(For the whole saga of the changes in `protoc` see https://github.com/protocolbuffers/protobuf/issues/6335 and https://github.com/protocolbuffers/protobuf/pull/10586.)

This PR will make it an actual _error_ to use an invalid name. This would be one of two known cases where buf is _more strict_ than `protoc` (the other being that buf validates custom JSON names, but `protoc` does not... at least not _yet_: https://github.com/protocolbuffers/protobuf/issues/5063). But both of these checks should be finding their way into a `protoc` release soon-ish.