### PR TITLE
make: fix generate rule when $PATH contains spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ lintfix: $(BIN)/golangci-lint ## Automatically fix some lint errors
 
 .PHONY: generate
 generate: $(BIN)/license-header $(BIN)/goyacc test-descriptors ## Regenerate code and licenses
-	PATH=$(BIN):$(PATH) $(GO) generate ./...
+	PATH="$(BIN):$(PATH)" $(GO) generate ./...
 	@# We want to operate on a list of modified and new files, excluding
 	@# deleted and ignored files. git-ls-files can't do this alone. comm -23 takes
 	@# two files and prints the union, dropping lines common to both (-3) and


### PR DESCRIPTION
Quotes are missing, so any spaces will start being interpreted as part of the command itself.