### PR TITLE
handful of small API tweaks

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -533,6 +533,13 @@ func (t *task) link(parseRes parser.Result, deps linker.Files) (linker.File, err
 }
 
 func (t *task) asParseResult(name string, r SearchResult) (parser.Result, error) {
+	if r.ParseResult != nil {
+		if r.ParseResult.FileDescriptorProto().GetName() != name {
+			return nil, fmt.Errorf("search result for %q returned descriptor for %q", name, r.ParseResult.FileDescriptorProto().GetName())
+		}
+		return r.ParseResult, nil
+	}
+
 	if r.Proto != nil {
 		if r.Proto.GetName() != name {
 			return nil, fmt.Errorf("search result for %q returned descriptor for %q", name, r.Proto.GetName())

--- a/internal/benchmarks/benchmark_test.go
+++ b/internal/benchmarks/benchmark_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -67,7 +68,7 @@ func TestMain(m *testing.M) {
 		protocPath += ".exe"
 	}
 	if info, err := os.Stat(protocPath); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			_, _ = fmt.Fprintf(os.Stderr, "Path %s not found. Run `make generate` in the project root first.\n", protocPath)
 		} else {
 			_, _ = fmt.Fprintf(os.Stderr, "Error querying for path %s: %v\n", protocPath, err)

--- a/linker/files.go
+++ b/linker/files.go
@@ -78,7 +78,7 @@ func newFile(f protoreflect.FileDescriptor, deps Files) (File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return file{
+	return &file{
 		FileDescriptor: f,
 		descs:          descs,
 		deps:           deps,
@@ -133,23 +133,23 @@ type file struct {
 	deps  Files
 }
 
-func (f file) FindDescriptorByName(name protoreflect.FullName) protoreflect.Descriptor {
+func (f *file) FindDescriptorByName(name protoreflect.FullName) protoreflect.Descriptor {
 	return f.descs[name]
 }
 
-func (f file) FindImportByPath(path string) File {
+func (f *file) FindImportByPath(path string) File {
 	return f.deps.FindFileByPath(path)
 }
 
-func (f file) FindExtensionByNumber(msg protoreflect.FullName, tag protoreflect.FieldNumber) protoreflect.ExtensionTypeDescriptor {
+func (f *file) FindExtensionByNumber(msg protoreflect.FullName, tag protoreflect.FieldNumber) protoreflect.ExtensionTypeDescriptor {
 	return findExtension(f, msg, tag)
 }
 
-func (f file) importsAsFiles() Files {
+func (f *file) importsAsFiles() Files {
 	return f.deps
 }
 
-var _ File = file{}
+var _ File = (*file)(nil)
 
 // Files represents a set of protobuf files. It is a slice of File values, but
 // also provides a method for easily looking up files by path and name.

--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -67,7 +67,7 @@ func (s *Symbols) Import(fd protoreflect.FileDescriptor, handler *reporter.Handl
 		return nil
 	}
 
-	if f, ok := fd.(file); ok {
+	if f, ok := fd.(*file); ok {
 		// unwrap any file instance
 		fd = f.FileDescriptor
 	}


### PR DESCRIPTION
I discovered some issues in the API when trying to port protoparse (buf's old compiler) to actually use protocompile under its hood.

* Allow `parser.Result` to be used as search result. This is more efficient that requiring the caller to supply either an AST or a descriptor proto. The protoparse package has a weird feature (that I intentionally chose to omit from protocompile) to try to infer paths. But that means we have to actually parse the files and all of their dependencies, and then potentially rewrite file names, _before_ linking. This allows that step to supply the `parser.Result`, after potentially modifying the descriptor proto's file name, and allows protocompile to use the result directly (vs. reconstructing the proto from the AST or using a proto without an AST).
* Fix up usage of `os.IsNotExist`. The `os` package [Go docs](https://pkg.go.dev/os#IsNotExist) state that newer code should instead use `errors.Is(err, fs.ErrPermission)`.
* Fix `linker.files` receivers in all methods. This is not a particularly big deal, but it's a large enough struct that it doesn't make much sense to copy around the whole thing on the stack.