### PR TITLE
improve errors when string literal contains bad escapes

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -495,8 +495,19 @@ func (l *protoLex) readIdentifier() {
 
 func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 	var buf bytes.Buffer
+	var escapeErrors []reporter.ErrorWithPos
+	reportErr := func(msg, badEscape string) {
+		var err error
+		if strings.HasSuffix(msg, "%s") {
+			err = fmt.Errorf(msg, badEscape)
+		} else {
+			err = errors.New(msg)
+		}
+		escapeErrors = append(escapeErrors, l.errWithCurrentPos(err, -len(badEscape)))
+		buf.WriteString(badEscape)
+	}
 	for {
-		c, _, err := l.input.readRune()
+		c, sz, err := l.input.readRune()
 		if err != nil {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
@@ -510,7 +521,8 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 			break
 		}
 		if c == 0 {
-			return "", errors.New("null character ('\\0') not allowed in string literal")
+			reportErr("null character ('\\0') not allowed in string literal", string(rune(0)))
+			continue
 		}
 		if c == '\\' {
 			// escape sequence
@@ -521,9 +533,14 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 			switch {
 			case c == 'x' || c == 'X':
 				// hex escape
-				c, _, err := l.input.readRune()
+				c1, sz1, err := l.input.readRune()
 				if err != nil {
 					return "", err
+				}
+				if c1 == quote || c1 == '\\' {
+					l.input.unreadRune(sz1)
+					reportErr("invalid hex escape: %s", "\\"+string(c))
+					continue
 				}
 				c2, sz2, err := l.input.readRune()
 				if err != nil {
@@ -532,13 +549,14 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 				var hex string
 				if (c2 < '0' || c2 > '9') && (c2 < 'a' || c2 > 'f') && (c2 < 'A' || c2 > 'F') {
 					l.input.unreadRune(sz2)
-					hex = string(c)
+					hex = string(c1)
 				} else {
-					hex = string([]rune{c, c2})
+					hex = string([]rune{c1, c2})
 				}
 				i, err := strconv.ParseInt(hex, 16, 32)
 				if err != nil {
-					return "", fmt.Errorf("invalid hex escape: \\x%q", hex)
+					reportErr("invalid hex escape: %s", "\\"+string(c)+hex)
+					continue
 				}
 				buf.WriteByte(byte(i))
 			case c >= '0' && c <= '7':
@@ -565,43 +583,68 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 				}
 				i, err := strconv.ParseInt(octal, 8, 32)
 				if err != nil {
-					return "", fmt.Errorf("invalid octal escape: \\%q", octal)
+					reportErr("invalid octal escape: %s", "\\"+octal)
+					continue
 				}
 				if i > 0xff {
-					return "", fmt.Errorf("octal escape is out range, must be between 0 and 377: \\%q", octal)
+					reportErr("octal escape is out range, must be between 0 and 377: %s", "\\"+octal)
+					continue
 				}
 				buf.WriteByte(byte(i))
 			case c == 'u':
 				// short unicode escape
 				u := make([]rune, 4)
 				for i := range u {
-					c, _, err := l.input.readRune()
+					c2, sz2, err := l.input.readRune()
 					if err != nil {
 						return "", err
 					}
-					u[i] = c
+					if c2 == quote || c2 == '\\' {
+						l.input.unreadRune(sz2)
+						u = u[:i]
+						break
+					}
+					u[i] = c2
 				}
-				i, err := strconv.ParseInt(string(u), 16, 32)
+				codepointStr := string(u)
+				if len(u) < 4 {
+					reportErr("invalid unicode escape: %s", "\\u"+codepointStr)
+					continue
+				}
+				i, err := strconv.ParseInt(codepointStr, 16, 32)
 				if err != nil {
-					return "", fmt.Errorf("invalid unicode escape: \\u%q", string(u))
+					reportErr("invalid unicode escape: %s", "\\u"+codepointStr)
+					continue
 				}
 				buf.WriteRune(rune(i))
 			case c == 'U':
 				// long unicode escape
 				u := make([]rune, 8)
 				for i := range u {
-					c, _, err := l.input.readRune()
+					c2, sz2, err := l.input.readRune()
 					if err != nil {
 						return "", err
 					}
-					u[i] = c
+					if c2 == quote || c2 == '\\' {
+						l.input.unreadRune(sz2)
+						u = u[:i]
+						break
+					}
+					u[i] = c2
+				}
+				codepointStr := string(u)
+				if len(u) < 8 {
+					reportErr("invalid unicode escape: %s", "\\U"+codepointStr)
+					continue
 				}
 				i, err := strconv.ParseInt(string(u), 16, 32)
 				if err != nil {
-					return "", fmt.Errorf("invalid unicode escape: \\U%q", string(u))
+					reportErr("invalid unicode escape: %s", "\\U"+codepointStr)
+					continue
 				}
 				if i > 0x10ffff || i < 0 {
-					return "", fmt.Errorf("unicode escape is out of range, must be between 0 and 0x10ffff: \\U%q", string(u))
+					reportErr("unicode escape is out of range, must be between 0 and 0x10ffff: %s", "\\U"+codepointStr)
+					continue
 				}
 				buf.WriteRune(rune(i))
 			case c == 'a':
@@ -627,11 +670,28 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 			case c == '?':
 				buf.WriteByte('?')
 			default:
-				return "", fmt.Errorf("invalid escape sequence: %q", "\\"+string(c))
+				var badEscape string
+				if c == quote || c == '\\' {
+					l.input.unreadRune(sz)
+					badEscape = "\\"
+				} else {
+					badEscape = "\\" + string(c)
+				}
+				reportErr("invalid escape sequence: %s", badEscape)
+				continue
 			}
 		} else {
 			buf.WriteRune(c)
 		}
+	}
+	if len(escapeErrors) > 0 {
+		// Report all but the last. Return that one for caller to report.
+		// If error handler does not accept all of them, it will at least
+		// get the first error.
+		for i := 0; i < len(escapeErrors)-1; i++ {
+			_ = l.addSourceError(escapeErrors[i])
+		}
+		return "", escapeErrors[len(escapeErrors)-1]
 	}
 	return buf.String(), nil
 }
@@ -690,4 +750,12 @@ func (l *protoLex) addSourceError(err error) reporter.ErrorWithPos {
 
 func (l *protoLex) Error(s string) {
 	_ = l.addSourceError(errors.New(s))
+}
+
+func (l *protoLex) errWithCurrentPos(err error, offset int) reporter.ErrorWithPos {
+	if ewp, ok := err.(reporter.ErrorWithPos); ok {
+		return ewp
+	}
+	pos := l.info.SourcePos(l.input.offset() + offset)
+	return reporter.Error(pos, err)
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -503,8 +503,9 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 		} else {
 			err = errors.New(msg)
 		}
+		// we've now consumed the bad escape and lexer position is after it, so we need
+		// to back up to the beginning of the escape to report the correct position
 		escapeErrors = append(escapeErrors, l.errWithCurrentPos(err, -len(badEscape)))
-		buf.WriteString(badEscape)
 	}
 	for {
 		c, sz, err := l.input.readRune()

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -508,7 +508,7 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 		escapeErrors = append(escapeErrors, l.errWithCurrentPos(err, -len(badEscape)))
 	}
 	for {
-		c, sz, err := l.input.readRune()
+		c, _, err := l.input.readRune()
 		if err != nil {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
@@ -671,14 +671,7 @@ func (l *protoLex) readStringLiteral(quote rune) (string, error) {
 			case c == '?':
 				buf.WriteByte('?')
 			default:
-				var badEscape string
-				if c == quote || c == '\\' {
-					l.input.unreadRune(sz)
-					badEscape = "\\"
-				} else {
-					badEscape = "\\" + string(c)
-				}
-				reportErr("invalid escape sequence: %s", badEscape)
+				reportErr("invalid escape sequence: %s", "\\"+string(c))
 				continue
 			}
 		} else {


### PR DESCRIPTION
The lexer was _bailing_ on tokenizing a string literal as soon as it hit a bad escape. That meant that the parser could keep going (trying to recover, in order to report more, subsequent syntax errors) but was in a bad state.

Given the following test file as input:
```proto
syntax = "proto3";

package foo;

import "validate/validate.proto";

message Message {
    string fqn = 1 [(validate.rules).string.pattern = "(?si)^((?P<namespace>([a0-z9]+[a0-z9_]*[a0-z9]+){1,256})\.)?(?P<name>([a0-z9]+[a0-z9_]*[a0-z9]+){1,256})(\+(?P<aggrFn>([a-z]+_*[a-z]+)))?(@-(?P<version>([0-9]+)))?(\[(?P<encoding>([a-z]+_*[a-z]+))])?$"];    
}
```

The parser would generate this long list of errors:
```
foo/foo.proto:8:55:invalid escape sequence: "\\."
foo/foo.proto:8:55:syntax error: unexpected error
foo/foo.proto:8:115:invalid character
foo/foo.proto:8:117:invalid character
foo/foo.proto:8:142:invalid character
foo/foo.proto:8:161:invalid character
foo/foo.proto:8:164:invalid character
foo/foo.proto:8:182:invalid character
foo/foo.proto:8:192:invalid character
foo/foo.proto:8:194:invalid character
foo/foo.proto:8:197:invalid character
foo/foo.proto:8:218:invalid character
foo/foo.proto:8:220:invalid character
foo/foo.proto:8:223:invalid character
foo/foo.proto:8:243:invalid character
foo/foo.proto:8:254:invalid character
foo/foo.proto:8:255:invalid character
foo/foo.proto:8:256:encountered end-of-line before end of string literal
```

Since it has aborted, but still has the rest of the string literal as input, it then complains about invalid punctuation symbols in the string literal. When it sees the closing quote, it mistakenly interprets that as the opening quote of a new string literal, but then encounters a newline.

Meanwhile, `protoc` was doing a better job of only reporting sensible errors:
```
test.proto:8:113: Invalid escape sequence in string literal.
test.proto:8:162: Invalid escape sequence in string literal.
test.proto:8:221: Invalid escape sequence in string literal.
```

So this patch updates the string literal handling so that the lexer _always_ consumes the entire string literal token, even if there are errors inside. In order to report all of the errors without failing fast, it must accumulate all of the errors and then report them at the end. The new test case shows the improved expected error messages and verifies that the entire literal is consumed to avoid the swath of confusing errors afterwards.