### PR TITLE
Extension resolution in message literals

### DIFF
--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -526,6 +526,13 @@ func (r *result) resolveOptionValue(handler *reporter.Handler, mc *internal.Mess
 		for _, fld := range optVal {
 			// check for extension name
 			if fld.Name.IsExtension() {
+				// Confusingly, an extension reference inside a message literal cannot refer to
+				// elements in the same enclosing message without a qualifier. Basically, we
+				// treat this as if there were no message scopes, so only the package name is
+				// used for resolving relative references. (Inconsistent protoc behavior, but
+				// likely due to how it re-uses C++ text format implementation, and normal text
+				// format doesn't expect that kind of relative reference.)
+				scopes := scopes[:1] // first scope is file, the rest are enclosing messages
 				fqn, err := r.resolveExtensionName(string(fld.Name.Name.AsIdentifier()), scopes)
 				if err != nil {
 					if err := handler.HandleErrorf(r.FileNode().NodeInfo(fld.Name.Name).Start(), "%v%v", mc, err); err != nil {


### PR DESCRIPTION
Recently, I noticed a discrepancy between buf and protoc. I can't remember why I was playing with something like this, but I discovered that the C++ text format does not resolve references in quite the same way as the parser. That leads to a strange inconsistency between resolving extensions in option _names_ vs. those that appear inside message literals in option _values_.

This adds a test that correctly mirrors `protoc` behavior. And then adds a small one-liner fix (but with 6 lines of comments to explain why the hell that one line is there).

Next I need to update the language spec with this subtle detail.