### PR TITLE
Message-set wire format is not allowed in proto3

### DIFF
--- a/parser/result.go
+++ b/parser/result.go
@@ -517,6 +517,11 @@ func (r *result) addMessageBody(msgd *descriptorpb.DescriptorProto, body *ast.Me
 	if err != nil {
 		return
 	} else if messageSetOpt != nil {
+		if isProto3 {
+			node := r.OptionNode(messageSetOpt)
+			nodeInfo := r.file.NodeInfo(node)
+			_ = handler.HandleErrorf(nodeInfo.Start(), "messages with message-set wire format are not allowed with proto3 syntax")
+		}
 		maxTag = internal.MaxTag // higher limit for messageset wire format
 	}
 

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -45,6 +45,10 @@ func TestBasicValidation(t *testing.T) {
 		"success_message_set_wire_format": {
 			contents: `message Foo { option message_set_wire_format = true; extensions 1 to 100; }`,
 		},
+		"failure_message_set_wire_format_in_proto3": {
+			contents:    `syntax = "proto3"; message Foo { option message_set_wire_format = true; extensions 1 to 100; }`,
+			expectedErr: "test.proto:1:34: messages with message-set wire format are not allowed with proto3 syntax",
+		},
 		"failure_message_set_wire_format_non_ext_field": {
 			contents:    `message Foo { optional double bar = 536870912; option message_set_wire_format = true; }`,
 			expectedErr: "test.proto:1:15: messages with message-set wire format cannot contain non-extension fields",


### PR DESCRIPTION
This is another discrepancy between buf and protoc that I recently noticed. This will also warrant a small change to the language spec to capture this rule.