### PR TITLE
Fix data race in compiler when resolver provides unlinked descriptor proto

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,12 +87,6 @@ issues:
     # checks from err113 are useful.
     - "err113: do not define dynamic errors.*"
   exclude-rules:
-    # Clone uses unchecked type conversions after invocations of proto.Clone
-    # which is safe because of the guarantees of proto.Clone and the static
-    # type of the input argument.
-    - path: parser/clone(_test)?.go
-      linters:
-        - errcheck
     # Benchmarks can't be run in parallel
     - path: benchmark_test\.go
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,6 +87,12 @@ issues:
     # checks from err113 are useful.
     - "err113: do not define dynamic errors.*"
   exclude-rules:
+    # Clone uses unchecked type conversions after invocations of proto.Clone
+    # which is safe because of the guarantees of proto.Clone and the static
+    # type of the input argument.
+    - path: parser/clone(_test)?.go
+      linters:
+        - errcheck
     # Benchmarks can't be run in parallel
     - path: benchmark_test\.go
       linters:

--- a/internal/norace.go
+++ b/internal/norace.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build race
+//go:build !race
 
-package parser
+package internal
 
-const isRace = true
+const IsRace = false

--- a/internal/race.go
+++ b/internal/race.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !race
+//go:build race
 
-package parser
+package internal
 
-const isRace = false
+const IsRace = true

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -335,7 +335,10 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()).Start(), "extendee is invalid: %s is %s, not a message", dsc.FullName(), descriptorTypeWithArticle(dsc))
 		}
 		f.extendee = extd
-		fld.Extendee = proto.String("." + string(dsc.FullName()))
+		extendeeName := "." + string(dsc.FullName())
+		if fld.GetExtendee() != extendeeName {
+			fld.Extendee = proto.String(extendeeName)
+		}
 		// make sure the tag number is in range
 		found := false
 		tag := protoreflect.FieldNumber(fld.GetNumber())
@@ -403,10 +406,15 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 				return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: %s is a synthetic map entry and may not be referenced explicitly", scope, dsc.FullName())
 			}
 		}
-		fld.TypeName = proto.String("." + string(dsc.FullName()))
-		// if type was tentatively unset, we now know it's actually a message
+		typeName := "." + string(dsc.FullName())
+		if fld.GetTypeName() != typeName {
+			fld.TypeName = proto.String(typeName)
+		}
 		if fld.Type == nil {
+			// if type was tentatively unset, we now know it's actually a message
 			fld.Type = descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum()
+		} else if fld.GetType() != descriptorpb.FieldDescriptorProto_TYPE_MESSAGE && fld.GetType() != descriptorpb.FieldDescriptorProto_TYPE_GROUP {
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: descriptor proto indicates type %v but should be %v", scope, fld.GetType(), descriptorpb.FieldDescriptorProto_TYPE_MESSAGE)
 		}
 		f.msgType = dsc
 	case protoreflect.EnumDescriptor:
@@ -416,9 +424,16 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 			// fields in a proto3 message cannot refer to proto2 enums
 			return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: cannot use proto2 enum %s in a proto3 message", scope, fld.GetTypeName())
 		}
-		fld.TypeName = proto.String("." + string(dsc.FullName()))
-		// the type was tentatively unset, but now we know it's actually an enum
-		fld.Type = descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum()
+		typeName := "." + string(dsc.FullName())
+		if fld.GetTypeName() != typeName {
+			fld.TypeName = proto.String(typeName)
+		}
+		if fld.Type == nil {
+			// the type was tentatively unset, but now we know it's actually an enum
+			fld.Type = descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum()
+		} else if fld.GetType() != descriptorpb.FieldDescriptorProto_TYPE_ENUM {
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: descriptor proto indicates type %v but should be %v", scope, fld.GetType(), descriptorpb.FieldDescriptorProto_TYPE_ENUM)
+		}
 		f.enumType = dsc
 	default:
 		return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: invalid type: %s is %s, not a message or enum", scope, dsc.FullName(), descriptorTypeWithArticle(dsc))
@@ -461,7 +476,10 @@ func resolveMethodTypes(m *mtdDescriptor, handler *reporter.Handler, scopes []sc
 			return err
 		}
 	} else {
-		mtd.InputType = proto.String("." + string(dsc.FullName()))
+		typeName := "." + string(dsc.FullName())
+		if mtd.GetInputType() != typeName {
+			mtd.InputType = proto.String(typeName)
+		}
 		m.inputType = msg
 	}
 
@@ -480,7 +498,10 @@ func resolveMethodTypes(m *mtdDescriptor, handler *reporter.Handler, scopes []sc
 			return err
 		}
 	} else {
-		mtd.OutputType = proto.String("." + string(dsc.FullName()))
+		typeName := "." + string(dsc.FullName())
+		if mtd.GetOutputType() != typeName {
+			mtd.OutputType = proto.String(typeName)
+		}
 		m.outputType = msg
 	}
 

--- a/parser/clone.go
+++ b/parser/clone.go
@@ -1,0 +1,182 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/bufbuild/protocompile/ast"
+	"github.com/bufbuild/protocompile/reporter"
+)
+
+// Clone returns a copy of the given result. Since descriptor protos may be
+// mutated during linking, this can return a defensive copy so that mutations
+// don't impact concurrent operations in an unsafe way. This is called if the
+// parse result could be re-used across concurrent operations and has unresolved
+// references and options which will require mutation by the linker.
+//
+// If the given value has a method with the following signature, it will be
+// called to perform the operation:
+//
+//	Clone() Result
+//
+// If the given value does not provide a Clone method and is not the implementation
+// provided by this package, it is possible for an error to occur in creating the
+// copy, which may result in a panic. This can happen if the AST of the given result
+// is not actually valid and a file descriptor proto cannot be successfully derived
+// from it.
+func Clone(r Result) Result {
+	if cl, ok := r.(interface{ Clone() Result }); ok {
+		return cl.Clone()
+	}
+	if res, ok := r.(*result); ok {
+		newProto := proto.Clone(res.proto).(*descriptorpb.FileDescriptorProto)
+		newNodes := make(map[proto.Message]ast.Node, len(res.nodes))
+		newResult := &result{
+			file:  res.file,
+			proto: newProto,
+			nodes: newNodes,
+		}
+		recreateNodeIndexForFile(res, newResult, res.proto, newProto)
+		return newResult
+	}
+
+	// Can't do the deep-copy we know how to do. So we have to take a
+	// different tactic.
+	if r.AST() == nil {
+		// no AST? all we have to do is copy the proto
+		fileProto := proto.Clone(r.FileDescriptorProto()).(*descriptorpb.FileDescriptorProto)
+		return ResultWithoutAST(fileProto)
+	}
+	// Otherwise, we have an AST, but no way to clone the result's
+	// internals. So just re-create them from scratch.
+	res, err := ResultFromAST(r.AST(), false, reporter.NewHandler(nil))
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func recreateNodeIndexForFile(orig, clone *result, origProto, cloneProto *descriptorpb.FileDescriptorProto) {
+	updateNodeIndexWithOptions[*descriptorpb.FileOptions](orig, clone, origProto, cloneProto)
+	for i, origMd := range origProto.MessageType {
+		cloneMd := cloneProto.MessageType[i]
+		recreateNodeIndexForMessage(orig, clone, origMd, cloneMd)
+	}
+	for i, origEd := range origProto.EnumType {
+		cloneEd := cloneProto.EnumType[i]
+		recreateNodeIndexForEnum(orig, clone, origEd, cloneEd)
+	}
+	for i, origExtd := range origProto.Extension {
+		cloneExtd := cloneProto.Extension[i]
+		updateNodeIndexWithOptions[*descriptorpb.FieldOptions](orig, clone, origExtd, cloneExtd)
+	}
+	for i, origSd := range origProto.Service {
+		cloneSd := cloneProto.Service[i]
+		updateNodeIndexWithOptions[*descriptorpb.ServiceOptions](orig, clone, origSd, cloneSd)
+		for j, origMtd := range origSd.Method {
+			cloneMtd := cloneSd.Method[j]
+			updateNodeIndexWithOptions[*descriptorpb.MethodOptions](orig, clone, origMtd, cloneMtd)
+		}
+	}
+}
+
+func recreateNodeIndexForMessage(orig, clone *result, origProto, cloneProto *descriptorpb.DescriptorProto) {
+	updateNodeIndexWithOptions[*descriptorpb.MessageOptions](orig, clone, origProto, cloneProto)
+	for i, origFld := range origProto.Field {
+		cloneFld := cloneProto.Field[i]
+		updateNodeIndexWithOptions[*descriptorpb.FieldOptions](orig, clone, origFld, cloneFld)
+	}
+	for i, origOod := range origProto.OneofDecl {
+		cloneOod := cloneProto.OneofDecl[i]
+		updateNodeIndexWithOptions[*descriptorpb.OneofOptions](orig, clone, origOod, cloneOod)
+	}
+	for i, origExtr := range origProto.ExtensionRange {
+		cloneExtr := cloneProto.ExtensionRange[i]
+		updateNodeIndexWithOptions[*descriptorpb.ExtensionRangeOptions](orig, clone, origExtr, cloneExtr)
+	}
+	for i, origRr := range origProto.ReservedRange {
+		cloneRr := cloneProto.ReservedRange[i]
+		updateNodeIndex(orig, clone, origRr, cloneRr)
+	}
+	for i, origNmd := range origProto.NestedType {
+		cloneNmd := cloneProto.NestedType[i]
+		recreateNodeIndexForMessage(orig, clone, origNmd, cloneNmd)
+	}
+	for i, origEd := range origProto.EnumType {
+		cloneEd := cloneProto.EnumType[i]
+		recreateNodeIndexForEnum(orig, clone, origEd, cloneEd)
+	}
+	for i, origExtd := range origProto.Extension {
+		cloneExtd := cloneProto.Extension[i]
+		updateNodeIndexWithOptions[*descriptorpb.FieldOptions](orig, clone, origExtd, cloneExtd)
+	}
+}
+
+func recreateNodeIndexForEnum(orig, clone *result, origProto, cloneProto *descriptorpb.EnumDescriptorProto) {
+	updateNodeIndexWithOptions[*descriptorpb.EnumOptions](orig, clone, origProto, cloneProto)
+	for i, origEvd := range origProto.Value {
+		cloneEvd := cloneProto.Value[i]
+		updateNodeIndexWithOptions[*descriptorpb.EnumValueOptions](orig, clone, origEvd, cloneEvd)
+	}
+	for i, origRr := range origProto.ReservedRange {
+		cloneRr := cloneProto.ReservedRange[i]
+		updateNodeIndex(orig, clone, origRr, cloneRr)
+	}
+}
+
+func recreateNodeIndexForOptions(orig, clone *result, origProtos, cloneProtos []*descriptorpb.UninterpretedOption) {
+	for i, origOpt := range origProtos {
+		cloneOpt := cloneProtos[i]
+		updateNodeIndex(orig, clone, origOpt, cloneOpt)
+		for j, origName := range origOpt.Name {
+			cloneName := cloneOpt.Name[j]
+			updateNodeIndex(orig, clone, origName, cloneName)
+		}
+	}
+}
+
+func updateNodeIndex[M proto.Message](orig, clone *result, origProto, cloneProto M) {
+	node := orig.nodes[origProto]
+	if node != nil {
+		clone.nodes[cloneProto] = node
+	}
+}
+
+type pointerMessage[T any] interface {
+	*T
+	proto.Message
+}
+
+type options[T any] interface {
+	// need this type instead of just proto.Message so we can check for nil pointer
+	pointerMessage[T]
+	GetUninterpretedOption() []*descriptorpb.UninterpretedOption
+}
+
+type withOptions[O options[T], T any] interface {
+	proto.Message
+	GetOptions() O
+}
+
+func updateNodeIndexWithOptions[O options[T], M withOptions[O, T], T any](orig, clone *result, origProto, cloneProto M) {
+	updateNodeIndex(orig, clone, origProto, cloneProto)
+	origOpts := origProto.GetOptions()
+	cloneOpts := cloneProto.GetOptions()
+	if origOpts != nil {
+		recreateNodeIndexForOptions(orig, clone, origOpts.GetUninterpretedOption(), cloneOpts.GetUninterpretedOption())
+	}
+}

--- a/parser/clone.go
+++ b/parser/clone.go
@@ -43,7 +43,7 @@ func Clone(r Result) Result {
 		return cl.Clone()
 	}
 	if res, ok := r.(*result); ok {
-		newProto := proto.Clone(res.proto).(*descriptorpb.FileDescriptorProto)
+		newProto := proto.Clone(res.proto).(*descriptorpb.FileDescriptorProto) //nolint:errcheck
 		newNodes := make(map[proto.Message]ast.Node, len(res.nodes))
 		newResult := &result{
 			file:  res.file,
@@ -58,7 +58,7 @@ func Clone(r Result) Result {
 	// different tactic.
 	if r.AST() == nil {
 		// no AST? all we have to do is copy the proto
-		fileProto := proto.Clone(r.FileDescriptorProto()).(*descriptorpb.FileDescriptorProto)
+		fileProto := proto.Clone(r.FileDescriptorProto()).(*descriptorpb.FileDescriptorProto) //nolint:errcheck
 		return ResultWithoutAST(fileProto)
 	}
 	// Otherwise, we have an AST, but no way to clone the result's

--- a/parser/clone_test.go
+++ b/parser/clone_test.go
@@ -1,0 +1,201 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/bufbuild/protocompile/ast"
+	"github.com/bufbuild/protocompile/reporter"
+)
+
+func TestClone(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../internal/testdata/desc_test_complex.proto")
+	require.NoError(t, err)
+	handler := reporter.NewHandler(nil)
+	fileNode, err := Parse("desc_test_complex.proto", bytes.NewReader(data), handler)
+	require.NoError(t, err)
+	result, err := ResultFromAST(fileNode, true, handler)
+	require.NoError(t, err)
+
+	t.Run("known result impl", func(t *testing.T) {
+		t.Parallel()
+		// With this result, we can clone the proto and rebuild the clone's index
+		clonedResult := Clone(result)
+		checkClone(t, result, clonedResult, true)
+	})
+	t.Run("unknown result impl", func(t *testing.T) {
+		t.Parallel()
+		// With this result, we have to rebuild the proto and index from scratch
+		clonedResult := Clone(otherResultImpl{Result: result})
+		checkClone(t, result, clonedResult, false)
+	})
+	t.Run("unknown result impl w/out AST", func(t *testing.T) {
+		t.Parallel()
+		// With this result, we can just clone the proto (no index since no AST)
+		result := ResultWithoutAST(result.FileDescriptorProto())
+		clonedResult := Clone(otherResultImpl{Result: result})
+		checkClone(t, result, clonedResult, true)
+	})
+	t.Run("impl w/ custom clone impl", func(t *testing.T) {
+		t.Parallel()
+		// With this result, we just verify that its Clone method was invoked.
+		orig := &customCloneResultImpl{Result: result}
+		clonedResult := Clone(orig)
+		require.Equal(t, 1, orig.cloneCalled)
+		require.Equal(t, orig.clone, clonedResult)
+	})
+}
+
+func checkClone(t *testing.T, orig, clone Result, isProtoClone bool) {
+	t.Helper()
+	require.NotSame(t, orig, clone)
+	require.NotSame(t, orig.FileDescriptorProto(), clone.FileDescriptorProto())
+	if !proto.Equal(orig.FileDescriptorProto(), clone.FileDescriptorProto()) {
+		diff := cmp.Diff(orig.FileDescriptorProto(), clone.FileDescriptorProto(), protocmp.Transform())
+		require.Empty(t, diff)
+		// should not get here :P
+		t.Fatal("orig and clone file descriptors are not equal but diff is empty(?!?!)")
+	}
+	// AST is expected to be equal since it is never mutated by compilation
+	require.Same(t, orig.AST(), clone.AST())
+
+	origRes := orig.(*result)
+	cloneRes := clone.(*result)
+
+	if origRes.file == nil {
+		require.Empty(t, cloneRes.nodes)
+		return
+	}
+
+	// If they have ASTs, also check their node indices.
+	// First create a reverse index for orig.
+	origRevIndex := map[ast.Node][]proto.Message{}
+	for msg, node := range origRes.nodes {
+		origRevIndex[node] = append(origRevIndex[node], msg)
+	}
+
+	// clone index may be bigger due to extension range options (see below for more info)
+	assert.GreaterOrEqual(t, len(cloneRes.nodes), len(origRes.nodes))
+	cloneRevIndex := map[ast.Node][]proto.Message{}
+	for msg, node := range cloneRes.nodes {
+		cloneRevIndex[node] = append(cloneRevIndex[node], msg)
+	}
+	cloneSyntheticMapFields, cloneSyntheticOneofs := 0, 0
+	for node, cloneMsgs := range cloneRevIndex {
+		origMsgs := origRevIndex[node]
+		if isProtoClone {
+			// For option nodes and field reference nodes, the original may have 1
+			// message but the clone may have >1. This is because when we build a
+			// descriptor where the same options apply to multiple extension ranges,
+			// we refer to the same uninterpreted options and name part messages in
+			// each range. But proto.Clone will create a deep copy at each reference
+			// site. So if 4 extension ranges share the same options, we'd see just
+			// 1 message in the original and 4 messages in the clone.
+			allowMismatch := false
+			switch node.(type) {
+			case *ast.OptionNode:
+				allowMismatch = true
+			case *ast.FieldReferenceNode:
+				allowMismatch = true
+			}
+			if allowMismatch && len(origMsgs) == 1 && len(cloneMsgs) > 1 {
+				continue
+			}
+		} else {
+			// If we didn't use proto.Clone but instead rebuilt the file descriptor,
+			// then we would have synthesized different values for synthetic map field
+			// and oneof nodes. So we may have nodes in the clone that have no entries
+			// in original.
+			allowMismatch := false
+			switch node.(type) {
+			case *ast.SyntheticMapField:
+				cloneSyntheticMapFields++
+				allowMismatch = true
+			case *ast.FieldReferenceNode:
+				cloneSyntheticOneofs++
+				allowMismatch = true
+			}
+			if allowMismatch && len(origMsgs) == 0 {
+				continue
+			}
+		}
+		assert.Equal(t, len(origMsgs), len(cloneMsgs), "mismatch for number of messages associated with %T (expect %+v, got %+v)", node, origMsgs, cloneMsgs)
+	}
+	origSyntheticMapFields, origSyntheticOneofs := 0, 0
+	for node, origMsgs := range origRevIndex {
+		cloneMsgs := cloneRevIndex[node]
+		if !isProtoClone {
+			// If we didn't use proto.Clone but instead rebuilt the file descriptor,
+			// then we would have synthesized different values for synthetic map field
+			// and oneof nodes. So we may have nodes in the original that have no
+			// entries in clone.
+			allowMismatch := false
+			switch node.(type) {
+			case *ast.SyntheticMapField:
+				origSyntheticMapFields++
+				allowMismatch = true
+			case *ast.FieldReferenceNode:
+				origSyntheticOneofs++
+				allowMismatch = true
+			}
+			if allowMismatch && len(cloneMsgs) == 0 {
+				continue
+			}
+		}
+		// we already covered all cases where they are not equal above
+		// except cases that are absent from cloneRevIndex
+		assert.NotZero(t, len(cloneMsgs), "mismatch for number of messages associated with %T (expect %+v, got %+v)", node, origMsgs, cloneMsgs)
+	}
+
+	assert.Equal(t, origSyntheticMapFields, cloneSyntheticMapFields)
+	assert.Equal(t, origSyntheticOneofs, cloneSyntheticOneofs)
+
+	// Now we can make sure the index is a deep copy (e.g. clone
+	// index does not contain pointers into original).
+	for msg := range cloneRes.nodes {
+		_, ok := origRes.nodes[msg]
+		// messages in clone index should NOT appear in original index
+		assert.False(t, ok)
+	}
+}
+
+type otherResultImpl struct {
+	Result
+}
+
+type customCloneResultImpl struct {
+	Result
+	clone       Result
+	cloneCalled int
+}
+
+func (c *customCloneResultImpl) Clone() Result {
+	c.cloneCalled++
+	if c.clone == nil {
+		c.clone = otherResultImpl{c.Result}
+	}
+	return c.clone
+}

--- a/parser/clone_test.go
+++ b/parser/clone_test.go
@@ -82,8 +82,8 @@ func checkClone(t *testing.T, orig, clone Result, isProtoClone bool) {
 	// AST is expected to be equal since it is never mutated by compilation
 	require.Same(t, orig.AST(), clone.AST())
 
-	origRes := orig.(*result)
-	cloneRes := clone.(*result)
+	origRes := orig.(*result)   //nolint:errcheck
+	cloneRes := clone.(*result) //nolint:errcheck
 
 	if origRes.file == nil {
 		require.Empty(t, cloneRes.nodes)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/descriptorpb"
 
+	"github.com/bufbuild/protocompile/internal"
 	"github.com/bufbuild/protocompile/reporter"
 )
 
@@ -313,7 +314,7 @@ func TestPathological(t *testing.T) {
 			// than 60 seconds. To prevent this test from being too slow, we limit to
 			// 3 iterations and no longer than 1 second (which is a stricter deadline).
 			allowedDuration := time.Second
-			if isRace {
+			if internal.IsRace {
 				// We increase that threshold to 10 seconds when the race detector is enabled.
 				// The race detector has been observed to make it take ~8x as long. If coverage
 				// is *also* enabled, the test can take 19x as long(!!). But 10s should still

--- a/parser/result.go
+++ b/parser/result.go
@@ -62,6 +62,11 @@ func ResultFromAST(file *ast.FileNode, validate bool, handler *reporter.Handler)
 	if validate {
 		validateBasic(r, handler)
 	}
+	// Now that we're done validating, we can set any missing labels to optional
+	// (we leave them absent in first pass if label was missing in source, so we
+	// can do validation on presence of label, but final descriptors are expected
+	// to always have them present).
+	fillInMissingLabels(r.proto)
 	return r, handler.Error()
 }
 
@@ -918,3 +923,6 @@ func (r *result) putServiceNode(s *descriptorpb.ServiceDescriptorProto, n *ast.S
 func (r *result) putMethodNode(m *descriptorpb.MethodDescriptorProto, n *ast.RPCNode) {
 	r.nodes[m] = n
 }
+
+// NB: If we ever add other put*Node methods, to index other kinds of elements in the descriptor
+//     proto hierarchy, we need to update the index recreation logic in clone.go, too.

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -447,11 +447,6 @@ func validateField(res *result, isProto3 bool, name protoreflect.FullName, fld *
 		}
 	}
 
-	// finally, set any missing label to optional
-	if fld.Label == nil {
-		fld.Label = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()
-	}
-
 	return nil
 }
 
@@ -474,4 +469,31 @@ func (r tagRanges) Less(i, j int) bool {
 
 func (r tagRanges) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
+}
+
+func fillInMissingLabels(fd *descriptorpb.FileDescriptorProto) {
+	for _, md := range fd.MessageType {
+		fillInMissingLabelsInMsg(md)
+	}
+	for _, extd := range fd.Extension {
+		fillInMissingLabel(extd)
+	}
+}
+
+func fillInMissingLabelsInMsg(md *descriptorpb.DescriptorProto) {
+	for _, fld := range md.Field {
+		fillInMissingLabel(fld)
+	}
+	for _, nmd := range md.NestedType {
+		fillInMissingLabelsInMsg(nmd)
+	}
+	for _, extd := range md.Extension {
+		fillInMissingLabel(extd)
+	}
+}
+
+func fillInMissingLabel(fld *descriptorpb.FieldDescriptorProto) {
+	if fld.Label == nil {
+		fld.Label = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()
+	}
 }

--- a/resolver.go
+++ b/resolver.go
@@ -64,7 +64,7 @@ type SearchResult struct {
 	// proto in one. When a parser result is available, it is more efficient
 	// than using an AST search result, since the descriptor proto need not be
 	// re-created. And it provides better error messages than a descriptor proto
-	// search results, since the AST has greater fidelity with regard to source
+	// search result, since the AST has greater fidelity with regard to source
 	// positions (even if the descriptor proto includes source code info).
 	ParseResult parser.Result
 	// A fully linked descriptor that represents the file. If this field is set,


### PR DESCRIPTION
From looking at the data race errors in bug report #102, this can happen only if a `*descriptorpb.FileDescriptorProto` or `parser.Result` is provided as a search result and is shared across parallel compiler operations.

So, luckily, that means _many_ (most?) usages of the compiler are **safe**, including the way that [`buf`](https://github.com/bufbuild/buf) uses it.

This looks to have always been the case. But I bet the user described this as a new failure because their tests previously didn't all share a search result for `"google/protobuf/descriptor.proto"`. But as of #97, all compile operations will implicitly use a search result for this file. So I suspect the reporter's tests use a resolver that returns a proto for this file and previously only one of the tests actually used it (i.e. only one test actually _imports_ that file).

This is a non-trivial change mainly because I was worried about the performance impact of _always_ cloning values, even if it's not necessary. So the strategy here is to only make a defensive clone of the descriptor proto (or the parser result, which contains a potentially mutable descriptor proto) when necessary. How do we know if it's needed? If it has any type names that are not fully-qualified (field extendees, field types, method input and output types), if it has uninterpreted options, or if it has no source code info but needs it. Under these conditions, the compiler will _mutate_ the proto (to make type names fully-qualified, to interpret options, to add source code info).

_**Edit**: The code now _always_ clones descriptor protos and parser results (which may contain a descriptor proto). That way there's no worry of the mutation logic getting out of sync with the logic that decides whether or not to clone._

The most complicated bit here is actually cloning a parser result, and associated tests, because it has an index that maps elements in the descriptor proto to their corresponding AST nodes. So we have to rebuild that index so it matches the new (cloned) elements in the descriptor proto.

The test added to `compiler_test.go` successfully reproduces the data race that was reported and is fixed with all of the other changes in this branch.

Fixes #102.