### PR TITLE
Sleep not necessary: race detector consistently detects race without it

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -370,10 +369,6 @@ func TestDataRace(t *testing.T) {
 				return err
 			})
 			grp.Go(func() error {
-				// We need to start this *after* the one above, but we can't
-				// use any sychronizing event or that would not be a race.
-				// So we assume a one second delay is sufficient.
-				time.Sleep(time.Second)
 				_, err := compiler2.Compile(ctx, "desc_test_complex.proto")
 				return err
 			})


### PR DESCRIPTION
Tiny fix to reduce total test time a wee bit. The sleep was there with the hopes of ordering reads after writes, but race detector does not need it since the concurrent operations consistently step on each other's toes trying to resolve unlinked proto.