### PR TITLE
Retain custom options as known fields, even with custom `descriptor.proto`

### DIFF
--- a/internal/benchmarks/go.mod
+++ b/internal/benchmarks/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/bufbuild/protocompile v0.0.0-20221004230924-06a336f5b6be
 	github.com/igrmk/treemap/v2 v2.0.1
-	github.com/jhump/protoreflect v1.13.0
+	github.com/jhump/protoreflect v1.14.1
 	github.com/stretchr/testify v1.8.0
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8
 )

--- a/internal/benchmarks/go.sum
+++ b/internal/benchmarks/go.sum
@@ -39,8 +39,8 @@ github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSl
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
 github.com/jhump/protoreflect v1.11.0/go.mod h1:U7aMIjN0NWq9swDP7xDdoMfRHb35uiuTd3Z9nFXJf5E=
-github.com/jhump/protoreflect v1.13.0 h1:zrrZqa7JAc2YGgPSzZZkmUXJ5G6NRPdxOg/9t7ISImA=
-github.com/jhump/protoreflect v1.13.0/go.mod h1:JytZfP5d0r8pVNLZvai7U/MCuTWITgrI4tTg7puQFKI=
+github.com/jhump/protoreflect v1.14.1 h1:N88q7JkxTHWFEqReuTsYH1dPIwXxA0ITNQp7avLY10s=
+github.com/jhump/protoreflect v1.14.1/go.mod h1:JytZfP5d0r8pVNLZvai7U/MCuTWITgrI4tTg7puQFKI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/linker/descriptors.go
+++ b/linker/descriptors.go
@@ -206,7 +206,7 @@ func asSourceLocations(srcInfoProtos []*descriptorpb.SourceCodeInfo_Location) []
 func pathStr(p protoreflect.SourcePath) string {
 	var buf bytes.Buffer
 	for _, v := range p {
-		fmt.Fprintf(&buf, "%x:", v)
+		_, _ = fmt.Fprintf(&buf, "%x:", v)
 	}
 	return buf.String()
 }
@@ -1867,10 +1867,6 @@ func (r *result) FindExtensionByNumber(msg protoreflect.FullName, tag protorefle
 func (r *result) FindDescriptorByName(name protoreflect.FullName) protoreflect.Descriptor {
 	fqn := strings.TrimPrefix(string(name), ".")
 	return r.descriptors[fqn]
-}
-
-func (r *result) importsAsFiles() Files {
-	return r.deps
 }
 
 func (r *result) hasSource() bool {

--- a/linker/files.go
+++ b/linker/files.go
@@ -28,7 +28,7 @@ import (
 
 // File is like a super-powered protoreflect.FileDescriptor. It includes helpful
 // methods for looking up elements in the descriptor and can be used to create a
-// resolver for all of the file's transitive closure of dependencies. (See
+// resolver for all the file's transitive closure of dependencies. (See
 // ResolverFromFile.)
 type File interface {
 	protoreflect.FileDescriptor
@@ -42,10 +42,6 @@ type File interface {
 	// that extends the given message name. If no such extension is defined in this
 	// file, nil is returned.
 	FindExtensionByNumber(message protoreflect.FullName, tag protoreflect.FieldNumber) protoreflect.ExtensionTypeDescriptor
-	// Imports returns this file's imports. These are only the files directly
-	// imported by the file. Indirect transitive dependencies will not be in
-	// the returned slice.
-	importsAsFiles() Files
 }
 
 // NewFile converts a protoreflect.FileDescriptor to a File. The given deps must
@@ -147,10 +143,6 @@ func (f *file) FindExtensionByNumber(msg protoreflect.FullName, tag protoreflect
 	return findExtension(f, msg, tag)
 }
 
-func (f *file) importsAsFiles() Files {
-	return f.deps
-}
-
 var _ File = (*file)(nil)
 
 // Files represents a set of protobuf files. It is a slice of File values, but
@@ -187,58 +179,51 @@ type Resolver interface {
 	protoregistry.ExtensionTypeResolver
 }
 
-// ResolverFromFile returns a Resolver that uses the given file plus all of its
-// imports as the source of descriptors. If a given query cannot be answered with
-// these files, the query will fail with a protoregistry.NotFound error. This
-// does not recursively search the entire transitive closure; it only searches
-// the given file and its immediate dependencies. This is useful for resolving
-// elements visible to the file.
-//
-// If the given file is the result of a call to Link, then all dependencies
-// provided in the call to Link are searched (which could actually include more
-// than just the file's direct imports).
+// ResolverFromFile returns a Resolver that can resolve any element that is
+// visible to the given file. It will search the given file, its imports, and
+// any transitive public imports.
 //
 // Note that this function does not compute any additional indexes for efficient
 // search, so queries generally take linear time, O(n) where n is the number of
-// files in the transitive closure of the given file. Queries for an extension
+// files whose elements are visible to the given file. Queries for an extension
 // by number are linear with the number of messages and extensions defined across
-// all the files.
+// those files.
 func ResolverFromFile(f File) Resolver {
-	return fileResolver{
-		f:    f,
-		deps: f.importsAsFiles().AsResolver(),
-	}
+	return fileResolver{f: f}
 }
 
 type fileResolver struct {
-	f    File
-	deps Resolver
+	f File
 }
 
 func (r fileResolver) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
-	if r.f.Path() == path {
-		return r.f, nil
-	}
-	return r.deps.FindFileByPath(path)
+	return resolveInFile(r.f, false, nil, func(f File) (protoreflect.FileDescriptor, error) {
+		if f.Path() == path {
+			return f, nil
+		}
+		return nil, protoregistry.NotFound
+	})
 }
 
 func (r fileResolver) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
-	d := r.f.FindDescriptorByName(name)
-	if d != nil {
-		return d, nil
-	}
-	return r.deps.FindDescriptorByName(name)
+	return resolveInFile(r.f, false, nil, func(f File) (protoreflect.Descriptor, error) {
+		if d := f.FindDescriptorByName(name); d != nil {
+			return d, nil
+		}
+		return nil, protoregistry.NotFound
+	})
 }
 
 func (r fileResolver) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
-	d := r.f.FindDescriptorByName(message)
-	if d != nil {
-		if md, ok := d.(protoreflect.MessageDescriptor); ok {
-			return dynamicpb.NewMessageType(md), nil
+	return resolveInFile(r.f, false, nil, func(f File) (protoreflect.MessageType, error) {
+		d := f.FindDescriptorByName(message)
+		if d != nil {
+			if md, ok := d.(protoreflect.MessageDescriptor); ok {
+				return dynamicpb.NewMessageType(md), nil
+			}
 		}
 		return nil, protoregistry.NotFound
-	}
-	return r.deps.FindMessageByName(message)
+	})
 }
 
 func (r fileResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
@@ -248,35 +233,32 @@ func (r fileResolver) FindMessageByURL(url string) (protoreflect.MessageType, er
 
 func messageNameFromURL(url string) string {
 	lastSlash := strings.LastIndexByte(url, '/')
-	var fullName string
-	if lastSlash >= 0 {
-		fullName = url[lastSlash+1:]
-	} else {
-		fullName = url
-	}
-	return fullName
+	return url[lastSlash+1:]
 }
 
 func (r fileResolver) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
-	d := r.f.FindDescriptorByName(field)
-	if d != nil {
-		if extd, ok := d.(protoreflect.ExtensionTypeDescriptor); ok {
-			return extd.Type(), nil
-		}
-		if fld, ok := d.(protoreflect.FieldDescriptor); ok && fld.IsExtension() {
-			return dynamicpb.NewExtensionType(fld), nil
+	return resolveInFile(r.f, false, nil, func(f File) (protoreflect.ExtensionType, error) {
+		d := f.FindDescriptorByName(field)
+		if d != nil {
+			if extd, ok := d.(protoreflect.ExtensionTypeDescriptor); ok {
+				return extd.Type(), nil
+			}
+			if fld, ok := d.(protoreflect.FieldDescriptor); ok && fld.IsExtension() {
+				return dynamicpb.NewExtensionType(fld), nil
+			}
 		}
 		return nil, protoregistry.NotFound
-	}
-	return r.deps.FindExtensionByName(field)
+	})
 }
 
 func (r fileResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
-	ext := findExtension(r.f, message, field)
-	if ext != nil {
-		return ext.Type(), nil
-	}
-	return r.deps.FindExtensionByNumber(message, field)
+	return resolveInFile(r.f, false, nil, func(f File) (protoreflect.ExtensionType, error) {
+		ext := findExtension(f, message, field)
+		if ext != nil {
+			return ext.Type(), nil
+		}
+		return nil, protoregistry.NotFound
+	})
 }
 
 type filesResolver []File

--- a/linker/linker.go
+++ b/linker/linker.go
@@ -106,24 +106,7 @@ func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *r
 type Result interface {
 	File
 	parser.Result
-	// ResolveEnumType returns an enum descriptor for the given named enum that
-	// is available in this file. If no such element is available or if the
-	// named element is not an enum, nil is returned.
-	ResolveEnumType(protoreflect.FullName) protoreflect.EnumDescriptor
-	// ResolveMessageType returns a message descriptor for the given named
-	// message that is available in this file. If no such element is available
-	// or if the named element is not a message, nil is returned.
-	ResolveMessageType(protoreflect.FullName) protoreflect.MessageDescriptor
-	// ResolveOptionsType returns a message descriptor for the given options
-	// type. This is like ResolveMessageType but searches the result's entire
-	// set of transitive dependencies without regard for visibility. If no
-	// such element is available or if the named element is not a message, nil
-	// is returned.
-	ResolveOptionsType(protoreflect.FullName) protoreflect.MessageDescriptor
-	// ResolveExtension returns an extension descriptor for the given named
-	// extension that is available in this file. If no such element is available
-	// or if the named element is not an extension, nil is returned.
-	ResolveExtension(protoreflect.FullName) protoreflect.ExtensionTypeDescriptor
+
 	// ResolveMessageLiteralExtensionName returns the fully qualified name for
 	// an identifier for extension field names in message literals.
 	ResolveMessageLiteralExtensionName(ast.IdentValueNode) string

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -20,53 +20,14 @@ import (
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
-	"google.golang.org/protobuf/types/dynamicpb"
 
 	"github.com/bufbuild/protocompile/ast"
 	"github.com/bufbuild/protocompile/internal"
 	"github.com/bufbuild/protocompile/reporter"
 	"github.com/bufbuild/protocompile/walk"
 )
-
-func (r *result) ResolveMessageType(name protoreflect.FullName) protoreflect.MessageDescriptor {
-	d := r.resolveElement(name)
-	if md, ok := d.(protoreflect.MessageDescriptor); ok {
-		return md
-	}
-	return nil
-}
-
-func (r *result) ResolveOptionsType(name protoreflect.FullName) protoreflect.MessageDescriptor {
-	d, _ := ResolverFromFile(r).FindDescriptorByName(name)
-	md, _ := d.(protoreflect.MessageDescriptor)
-	if md != nil && md.ParentFile() != nil {
-		r.markUsed(md.ParentFile().Path())
-	}
-	return md
-}
-
-func (r *result) ResolveEnumType(name protoreflect.FullName) protoreflect.EnumDescriptor {
-	d := r.resolveElement(name)
-	if ed, ok := d.(protoreflect.EnumDescriptor); ok {
-		return ed
-	}
-	return nil
-}
-
-func (r *result) ResolveExtension(name protoreflect.FullName) protoreflect.ExtensionTypeDescriptor {
-	d := r.resolveElement(name)
-	if ed, ok := d.(protoreflect.ExtensionDescriptor); ok {
-		if !ed.IsExtension() {
-			return nil
-		}
-		if td, ok := ed.(protoreflect.ExtensionTypeDescriptor); ok {
-			return td
-		}
-		return dynamicpb.NewExtensionType(ed).TypeDescriptor()
-	}
-	return nil
-}
 
 func (r *result) ResolveMessageLiteralExtensionName(node ast.IdentValueNode) string {
 	return r.optionQualifiedNames[node]
@@ -76,11 +37,48 @@ func (r *result) resolveElement(name protoreflect.FullName) protoreflect.Descrip
 	if len(name) > 0 && name[0] == '.' {
 		name = name[1:]
 	}
-	importedFd, res := resolveElement(r, name, false, nil)
-	if importedFd != nil {
-		r.markUsed(importedFd.Path())
-	}
+	res, _ := resolveInFile(r, false, nil, func(f File) (protoreflect.Descriptor, error) {
+		d := resolveElementInFile(name, f)
+		if d != nil {
+			return d, nil
+		}
+		return nil, protoregistry.NotFound
+	})
 	return res
+}
+
+func resolveInFile[T any](f File, publicImportsOnly bool, checked []string, fn func(File) (T, error)) (T, error) {
+	var zero T
+	path := f.Path()
+	for _, str := range checked {
+		if str == path {
+			// already checked
+			return zero, protoregistry.NotFound
+		}
+	}
+	checked = append(checked, path)
+
+	res, err := fn(f)
+	if err == nil {
+		return res, nil
+	}
+	imports := f.Imports()
+	for i, l := 0, imports.Len(); i < l; i++ {
+		imp := imports.Get(i)
+		if publicImportsOnly && !imp.IsPublic {
+			continue
+		}
+		res, err := resolveInFile(f.FindImportByPath(imp.Path()), true, checked, fn)
+		if err == nil {
+			if !imp.IsPublic {
+				if r, ok := f.(*result); ok {
+					r.markUsed(imp.Path())
+				}
+			}
+			return res, nil
+		}
+	}
+	return zero, err
 }
 
 func (r *result) markUsed(importPath string) {
@@ -115,38 +113,6 @@ func (r *result) CheckForUnusedImports(handler *reporter.Handler) {
 			handler.HandleWarningWithPos(pos, errUnusedImport(dep))
 		}
 	}
-}
-
-func resolveElement(f File, fqn protoreflect.FullName, publicImportsOnly bool, checked []string) (imported File, d protoreflect.Descriptor) {
-	path := f.Path()
-	for _, str := range checked {
-		if str == path {
-			// already checked
-			return nil, nil
-		}
-	}
-	checked = append(checked, path)
-
-	r := resolveElementInFile(fqn, f)
-	if r != nil {
-		// not imported, but present in f
-		return nil, r
-	}
-
-	// When publicImportsOnly = false, we are searching only directly imported symbols. But
-	// we also need to search transitive public imports due to semantics of public imports.
-	for i := 0; i < f.Imports().Len(); i++ {
-		dep := f.Imports().Get(i)
-		if dep.IsPublic || !publicImportsOnly {
-			depFile := f.FindImportByPath(dep.Path())
-			_, d := resolveElement(depFile, fqn, true, checked)
-			if d != nil {
-				return depFile, d
-			}
-		}
-	}
-
-	return nil, nil
 }
 
 func descriptorTypeWithArticle(d protoreflect.Descriptor) string {


### PR DESCRIPTION
An issue was introduced in #97 -- if a custom `descriptor.proto` is used, then custom options may come across in the final compilation result as unrecognized fields. Here's a test failure in `buf`: [link](https://github.com/bufbuild/buf/actions/runs/4345212597/jobs/7589606886). The first commit in this PR is a repro case. 

The issue was two-fold: the options in question come from _public_ imports, and this only happens when an _override_ set of options are used. This happens because we have to use a [dynamic message](https://pkg.go.dev/google.golang.org/protobuf/types/dynamicpb) to represent the override definition of the options. But the result is ultimately a `descriptorpb.FileDescriptorProto`, which needs a reference to the generated type (not a dynamic message). So in this case, we _serialize_ the interpreted options message to bytes and then _de-serialize_ that into the generated type.

This one's a little complicated. But the root issue is that we used `linker.ResolverFromFile` as if it correctly implemented visibility rules, but it didn't. So when de-serializing the bytes in the above conversion, it failed to recognize the custom option, that was visible to the file via a public import.

So **now**, it does implement visibility rules exactly: so it can resolve any symbol that is visible to the given file. That means any symbol defined in that file or in an import _OR_ in a transitive public import.

We already had logic in here for the visibility rules, which were used for other parts of linking and type lookup. So I've now updated it so that everything runs on the same rails -- e.g. the resolver implementation in `linker.ResolverFromFile` calls into the same code that already correctly implemented the rules.

While consolidating, there were suddenly some unused/unnecessary methods. For example, the handful of `Resolve*` methods on the `linker.Result` were now redundant. So I've removed them. There was also an unexported method on the `linker.Files` interface, which was now unused so I removed it, too. I know these aren't backwards-compatible changes, but this is still pre-v1.0 and these are interfaces which users are highly unlikely to actually implement.

While going through this, I also took an opportunity to do some cleanup after #97. Instead of treating an override `descriptor.proto` as if it were an implicit dependency used by the linker, it's now an option for the options interpreter (which is the only place that uses it, so seemed more natural). 