### PR TITLE
Retract v0.5.0 due to deadlock error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v0.5.0	// Contains deadlock error
+)


### PR DESCRIPTION
I'm not sure if this will get respected immediately. From reading how `retract` works, it looks like I should have added this before cutting a v0.5.1 release.

But I do have a couple of other PRs in here this week, so maybe we can release those later this week and get the retraction properly "published" to go module servers...