### PR TITLE
Don't need the "tools" module in the workspace; it messes w/ benchmark deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18.x,1.19.x]
+        go-version: [1.18.x,1.19.x,1.20.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -35,12 +35,12 @@ jobs:
         run: make test
       - name: Benchmarks
         # no need to run benchmarks for every Go version
-        if: matrix.go-version == '1.19.x'
+        if: matrix.go-version == '1.20.x'
         run: make benchmarks
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.19.x'
-        run: make checkgenerate lint
+        if: matrix.go-version == '1.20.x'
+        run: make build checkgenerate lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
         # For the same reason, only check generated code on the most recent
         # supported version.
         if: matrix.go-version == '1.20.x'
-        run: make build checkgenerate lint
+        run: make checkgenerate lint

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ clean: ## Delete intermediate build artifacts
 	git clean -Xdf
 
 .PHONY: test
-test: $(PROTOC) ## Run unit tests
+test: build ## Run unit tests
 	$(GO) test -vet=off -race -cover ./...
 
 .PHONY: benchmarks
-benchmarks: ## Run benchmarks
+benchmarks: build ## Run benchmarks
 	cd internal/benchmarks && $(GO) test -bench=. -benchmem -v ./...
 
 .PHONY: build
@@ -102,18 +102,18 @@ checkgenerate:
 
 $(BIN)/license-header: internal/tools/go.mod internal/tools/go.sum
 	@mkdir -p $(@D)
-	GOWORK=off cd $(TOOLS_MOD_DIR) && \
-		$(GO) build -o $@ github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header
+	cd $(TOOLS_MOD_DIR) && \
+		GOWORK=off $(GO) build -o $@ github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header
 
 $(BIN)/golangci-lint: internal/tools/go.mod internal/tools/go.sum
 	@mkdir -p $(@D)
-	GOWORK=off cd $(TOOLS_MOD_DIR) && \
-		$(GO) build -o $@ github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd $(TOOLS_MOD_DIR) && \
+		GOWORK=off $(GO) build -o $@ github.com/golangci/golangci-lint/cmd/golangci-lint
 
 $(BIN)/goyacc: internal/tools/go.mod internal/tools/go.sum
 	@mkdir -p $(@D)
-	GOWORK=off cd $(TOOLS_MOD_DIR) && \
-		$(GO) build -o $@ golang.org/x/tools/cmd/goyacc
+	cd $(TOOLS_MOD_DIR) && \
+		GOWORK=off $(GO) build -o $@ golang.org/x/tools/cmd/goyacc
 
 internal/testdata/protoc/cache/protoc-$(PROTOC_VERSION).zip:
 	@mkdir -p $(@D)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean: ## Delete intermediate build artifacts
 	git clean -Xdf
 
 .PHONY: test
-test: build ## Run unit tests
+test: ## Run unit tests
 	$(GO) test -vet=off -race -cover ./...
 
 .PHONY: benchmarks

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean: ## Delete intermediate build artifacts
 	git clean -Xdf
 
 .PHONY: test
-test: ## Run unit tests
+test: $(PROTOC) ## Run unit tests
 	$(GO) test -vet=off -race -cover ./...
 
 .PHONY: benchmarks

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: $(PROTOC) ## Run unit tests
 	$(GO) test -vet=off -race -cover ./...
 
 .PHONY: benchmarks
-benchmarks: build ## Run benchmarks
+benchmarks: ## Run benchmarks
 	cd internal/benchmarks && $(GO) test -bench=. -benchmem -v ./...
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -102,18 +102,18 @@ checkgenerate:
 
 $(BIN)/license-header: internal/tools/go.mod internal/tools/go.sum
 	@mkdir -p $(@D)
-	cd $(TOOLS_MOD_DIR) && \
-	$(GO) build -o $@ github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header
+	GOWORK=off cd $(TOOLS_MOD_DIR) && \
+		$(GO) build -o $@ github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header
 
 $(BIN)/golangci-lint: internal/tools/go.mod internal/tools/go.sum
 	@mkdir -p $(@D)
-	cd $(TOOLS_MOD_DIR) && \
-	$(GO) build -o $@ github.com/golangci/golangci-lint/cmd/golangci-lint
+	GOWORK=off cd $(TOOLS_MOD_DIR) && \
+		$(GO) build -o $@ github.com/golangci/golangci-lint/cmd/golangci-lint
 
 $(BIN)/goyacc: internal/tools/go.mod internal/tools/go.sum
 	@mkdir -p $(@D)
-	cd $(TOOLS_MOD_DIR) && \
-	$(GO) build -o $@ golang.org/x/tools/cmd/goyacc
+	GOWORK=off cd $(TOOLS_MOD_DIR) && \
+		$(GO) build -o $@ golang.org/x/tools/cmd/goyacc
 
 internal/testdata/protoc/cache/protoc-$(PROTOC_VERSION).zip:
 	@mkdir -p $(@D)

--- a/go.work
+++ b/go.work
@@ -3,5 +3,4 @@ go 1.19
 use (
 	.
 	./internal/benchmarks
-	./internal/tools
 )


### PR DESCRIPTION
When we include `./internal/tools` in the workspace, then running benchmarks in `./internal/benchmarks` ends up including the tool module's deps -- which transitively include a much newer version of "protoparse" (the older compiler) than is desired for the benchmarks.

The easiest solution I can see is to just remove it from the `go.work` file.

But, when we do that, the `go` tool is unhappy to work in that directory -- it looks upwards for `go.work`, sees it, but since `./internal/tools` is not in there, it assumes its "main module context" is the root module. And then it complains because `/internal/tools` does not exist in the `github.com/bufbuild/protocompile` module...  (╯°□°）╯︵ ┻━┻

So we also have to add `GOWORK=off` to any invocation of the `go` tool int the tools directory.