### PR TITLE
Drop support for Go 1.18 now that Go 1.21 has been released

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18.x,1.19.x,1.20.x]
+        go-version: [1.19.x,1.20.x,1.21.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -42,5 +42,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.20.x'
+        if: matrix.go-version == '1.21.x'
         run: make checkgenerate lint

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.18.x,1.19.x]
+        go-version: [1.19.x,1.20.x,1.21.x]
     steps:
       - name: Set git to use LF
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protocompile
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
This will unblock #173, too, since v1.16 is when buf moved up to requiring Go 1.19.