### PR TITLE
Fix panic bug in parser

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -67,6 +67,7 @@ func TestJunkParse(t *testing.T) {
 	for name, input := range inputs {
 		name, input := name, input
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			errHandler := reporter.NewHandler(reporter.NewReporter(
 				// returning nil means this will keep trying to parse after any error
 				func(err reporter.ErrorWithPos) error { return nil },

--- a/parser/proto.y
+++ b/parser/proto.y
@@ -492,22 +492,12 @@ listLiteral : '[' listElements ']' {
 	}
 
 listElements : listElement {
-		if $1 == nil {
-			$$ = nil
-		} else {
-			$$ = &valueSlices{vals: []ast.ValueNode{$1}}
-		}
+		$$ = &valueSlices{vals: []ast.ValueNode{$1}}
 	}
 	| listElements ',' listElement {
-		if $3 == nil {
-			$$ = $1
-		} else if $1 == nil {
-			$$ = &valueSlices{vals: []ast.ValueNode{$3}}
-		} else {
-			$1.vals = append($1.vals, $3)
-			$1.commas = append($1.commas, $2)
-			$$ = $1
-		}
+		$1.vals = append($1.vals, $3)
+		$1.commas = append($1.commas, $2)
+		$$ = $1
 	}
 
 listElement : scalarValue

--- a/parser/proto.y
+++ b/parser/proto.y
@@ -427,14 +427,14 @@ messageLiteralFieldEntry : messageLiteralField {
 	}
 
 messageLiteralField : messageLiteralFieldName ':' value {
-		if $1 != nil {
+		if $1 != nil && $2 != nil {
 			$$ = ast.NewMessageFieldNode($1, $2, $3)
 		} else {
 			$$ = nil
 		}
 	}
 	| messageLiteralFieldName messageValue {
-		if $1 != nil {
+		if $1 != nil && $2 != nil {
 			$$ = ast.NewMessageFieldNode($1, nil, $2)
 		} else {
 			$$ = nil
@@ -488,16 +488,26 @@ listLiteral : '[' listElements ']' {
 		$$ = ast.NewArrayLiteralNode($1, nil, nil, $2)
 	}
 	| '[' error ']' {
-		$$ = nil
+		$$ = ast.NewArrayLiteralNode($1, nil, nil, $3)
 	}
 
 listElements : listElement {
-		$$ = &valueSlices{vals: []ast.ValueNode{$1}}
+		if $1 == nil {
+			$$ = nil
+		} else {
+			$$ = &valueSlices{vals: []ast.ValueNode{$1}}
+		}
 	}
 	| listElements ',' listElement {
-		$1.vals = append($1.vals, $3)
-		$1.commas = append($1.commas, $2)
-		$$ = $1
+		if $3 == nil {
+			$$ = $1
+		} else if $1 == nil {
+			$$ = &valueSlices{vals: []ast.ValueNode{$3}}
+		} else {
+			$1.vals = append($1.vals, $3)
+			$1.commas = append($1.commas, $2)
+			$$ = $1
+		}
 	}
 
 listElement : scalarValue
@@ -514,7 +524,7 @@ listOfMessagesLiteral : '[' messageLiterals ']' {
 		$$ = ast.NewArrayLiteralNode($1, nil, nil, $2)
 	}
 	| '[' error ']' {
-		$$ = nil
+		$$ = ast.NewArrayLiteralNode($1, nil, nil, $3)
 	}
 
 messageLiterals : messageLiteral {

--- a/parser/proto.y.go
+++ b/parser/proto.y.go
@@ -1552,7 +1552,7 @@ protodefault:
 	case 68:
 		protoDollar = protoS[protopt-3 : protopt+1]
 		{
-			if protoDollar[1].ref != nil {
+			if protoDollar[1].ref != nil && protoDollar[2].b != nil {
 				protoVAL.msgLitFld = ast.NewMessageFieldNode(protoDollar[1].ref, protoDollar[2].b, protoDollar[3].v)
 			} else {
 				protoVAL.msgLitFld = nil
@@ -1561,7 +1561,7 @@ protodefault:
 	case 69:
 		protoDollar = protoS[protopt-2 : protopt+1]
 		{
-			if protoDollar[1].ref != nil {
+			if protoDollar[1].ref != nil && protoDollar[2].v != nil {
 				protoVAL.msgLitFld = ast.NewMessageFieldNode(protoDollar[1].ref, nil, protoDollar[2].v)
 			} else {
 				protoVAL.msgLitFld = nil
@@ -1624,19 +1624,29 @@ protodefault:
 	case 85:
 		protoDollar = protoS[protopt-3 : protopt+1]
 		{
-			protoVAL.v = nil
+			protoVAL.v = ast.NewArrayLiteralNode(protoDollar[1].b, nil, nil, protoDollar[3].b)
 		}
 	case 86:
 		protoDollar = protoS[protopt-1 : protopt+1]
 		{
-			protoVAL.sl = &valueSlices{vals: []ast.ValueNode{protoDollar[1].v}}
+			if protoDollar[1].v == nil {
+				protoVAL.sl = nil
+			} else {
+				protoVAL.sl = &valueSlices{vals: []ast.ValueNode{protoDollar[1].v}}
+			}
 		}
 	case 87:
 		protoDollar = protoS[protopt-3 : protopt+1]
 		{
-			protoDollar[1].sl.vals = append(protoDollar[1].sl.vals, protoDollar[3].v)
-			protoDollar[1].sl.commas = append(protoDollar[1].sl.commas, protoDollar[2].b)
-			protoVAL.sl = protoDollar[1].sl
+			if protoDollar[3].v == nil {
+				protoVAL.sl = protoDollar[1].sl
+			} else if protoDollar[1].sl == nil {
+				protoVAL.sl = &valueSlices{vals: []ast.ValueNode{protoDollar[3].v}}
+			} else {
+				protoDollar[1].sl.vals = append(protoDollar[1].sl.vals, protoDollar[3].v)
+				protoDollar[1].sl.commas = append(protoDollar[1].sl.commas, protoDollar[2].b)
+				protoVAL.sl = protoDollar[1].sl
+			}
 		}
 	case 90:
 		protoDollar = protoS[protopt-3 : protopt+1]
@@ -1655,7 +1665,7 @@ protodefault:
 	case 92:
 		protoDollar = protoS[protopt-3 : protopt+1]
 		{
-			protoVAL.v = nil
+			protoVAL.v = ast.NewArrayLiteralNode(protoDollar[1].b, nil, nil, protoDollar[3].b)
 		}
 	case 93:
 		protoDollar = protoS[protopt-1 : protopt+1]

--- a/parser/proto.y.go
+++ b/parser/proto.y.go
@@ -1629,24 +1629,14 @@ protodefault:
 	case 86:
 		protoDollar = protoS[protopt-1 : protopt+1]
 		{
-			if protoDollar[1].v == nil {
-				protoVAL.sl = nil
-			} else {
-				protoVAL.sl = &valueSlices{vals: []ast.ValueNode{protoDollar[1].v}}
-			}
+			protoVAL.sl = &valueSlices{vals: []ast.ValueNode{protoDollar[1].v}}
 		}
 	case 87:
 		protoDollar = protoS[protopt-3 : protopt+1]
 		{
-			if protoDollar[3].v == nil {
-				protoVAL.sl = protoDollar[1].sl
-			} else if protoDollar[1].sl == nil {
-				protoVAL.sl = &valueSlices{vals: []ast.ValueNode{protoDollar[3].v}}
-			} else {
-				protoDollar[1].sl.vals = append(protoDollar[1].sl.vals, protoDollar[3].v)
-				protoDollar[1].sl.commas = append(protoDollar[1].sl.commas, protoDollar[2].b)
-				protoVAL.sl = protoDollar[1].sl
-			}
+			protoDollar[1].sl.vals = append(protoDollar[1].sl.vals, protoDollar[3].v)
+			protoDollar[1].sl.commas = append(protoDollar[1].sl.commas, protoDollar[2].b)
+			protoVAL.sl = protoDollar[1].sl
 		}
 	case 90:
 		protoDollar = protoS[protopt-3 : protopt+1]


### PR DESCRIPTION
I reviewed the grammar, looking for all error productions that end up using a placeholder token value of `nil`, which could then trigger panics like this.

This one case -- calling `ast.NewMessageFieldNode` -- is the only place that wasn't properly checking for a nil value. There were actually two different productions, so I added two test cases, each one triggering a panic on a different line `proto.y.go` corresponding to the two erroneous productions.

I made some other changes in here, to avoid this kind of error, but none of them were actually necessary since all of them were already adequately covered by nil checks. I left them in anyway.

Resolves #196.