### PR TITLE
Add SourceSpan and update error reporting to use it

### DIFF
--- a/ast/file_info.go
+++ b/ast/file_info.go
@@ -597,10 +597,6 @@ func (pos SourcePos) String() string {
 	return fmt.Sprintf("%s:%d:%d", pos.Filename, pos.Line, pos.Col)
 }
 
-// func (pos SourcePos) AsSpan() SourceSpan {
-// 	return NewSourceSpan(pos, pos)
-// }
-
 // SourceSpan represents a range of source positions.
 type SourceSpan interface {
 	Start() SourcePos

--- a/ast/file_info.go
+++ b/ast/file_info.go
@@ -597,45 +597,35 @@ func (pos SourcePos) String() string {
 	return fmt.Sprintf("%s:%d:%d", pos.Filename, pos.Line, pos.Col)
 }
 
-func (pos SourcePos) AsSpan() SourceSpan {
-	return emptySpan{Pos: pos}
-}
+// func (pos SourcePos) AsSpan() SourceSpan {
+// 	return NewSourceSpan(pos, pos)
+// }
 
-type emptySpan struct {
-	Pos SourcePos
-}
-
-func (e emptySpan) Start() SourcePos {
-	return e.Pos
-}
-
-func (e emptySpan) End() SourcePos {
-	return e.Pos
-}
-
-type posSpan struct {
-	StartPos SourcePos
-	EndPos   SourcePos
-}
-
-func (p posSpan) Start() SourcePos {
-	return p.StartPos
-}
-
-func (p posSpan) End() SourcePos {
-	return p.EndPos
-}
-
-func NewPosSpan(start SourcePos, end SourcePos) SourceSpan {
-	return posSpan{StartPos: start, EndPos: end}
-}
-
-var _ SourceSpan = emptySpan{}
-
+// SourceSpan represents a range of source positions.
 type SourceSpan interface {
 	Start() SourcePos
 	End() SourcePos
 }
+
+// NewSourceSpan creates a new span that covers the given range.
+func NewSourceSpan(start SourcePos, end SourcePos) SourceSpan {
+	return sourceSpan{StartPos: start, EndPos: end}
+}
+
+type sourceSpan struct {
+	StartPos SourcePos
+	EndPos   SourcePos
+}
+
+func (p sourceSpan) Start() SourcePos {
+	return p.StartPos
+}
+
+func (p sourceSpan) End() SourcePos {
+	return p.EndPos
+}
+
+var _ SourceSpan = sourceSpan{}
 
 // Comments represents a range of sequential comments in a source file
 // (e.g. no interleaving items or AST nodes).

--- a/ast/file_info.go
+++ b/ast/file_info.go
@@ -399,8 +399,7 @@ type Item int
 // ItemInfo provides details about an item's location in the source file and
 // its contents.
 type ItemInfo interface {
-	Start() SourcePos
-	End() SourcePos
+	SourceSpan
 	LeadingWhitespace() string
 	RawText() string
 }
@@ -596,6 +595,46 @@ func (pos SourcePos) String() string {
 		return pos.Filename
 	}
 	return fmt.Sprintf("%s:%d:%d", pos.Filename, pos.Line, pos.Col)
+}
+
+func (pos SourcePos) AsSpan() SourceSpan {
+	return emptySpan{Pos: pos}
+}
+
+type emptySpan struct {
+	Pos SourcePos
+}
+
+func (e emptySpan) Start() SourcePos {
+	return e.Pos
+}
+
+func (e emptySpan) End() SourcePos {
+	return e.Pos
+}
+
+type posSpan struct {
+	StartPos SourcePos
+	EndPos   SourcePos
+}
+
+func (p posSpan) Start() SourcePos {
+	return p.StartPos
+}
+
+func (p posSpan) End() SourcePos {
+	return p.EndPos
+}
+
+func NewPosSpan(start SourcePos, end SourcePos) SourceSpan {
+	return posSpan{StartPos: start, EndPos: end}
+}
+
+var _ SourceSpan = emptySpan{}
+
+type SourceSpan interface {
+	Start() SourcePos
+	End() SourcePos
 }
 
 // Comments represents a range of sequential comments in a source file

--- a/ast/no_source.go
+++ b/ast/no_source.go
@@ -20,6 +20,24 @@ func UnknownPos(filename string) SourcePos {
 	return SourcePos{Filename: filename}
 }
 
+// UnknownSpan is a placeholder span when only the source file
+// name is known.
+func UnknownSpan(filename string) SourceSpan {
+	return unknownSpan{filename: filename}
+}
+
+type unknownSpan struct {
+	filename string
+}
+
+func (s unknownSpan) Start() SourcePos {
+	return UnknownPos(s.filename)
+}
+
+func (s unknownSpan) End() SourcePos {
+	return UnknownPos(s.filename)
+}
+
 // NoSourceNode is a placeholder AST node that implements numerous
 // interfaces in this package. It can be used to represent an AST
 // element for a file whose source is not available.

--- a/compiler.go
+++ b/compiler.go
@@ -447,16 +447,16 @@ func (t *task) asFile(ctx context.Context, name string, r SearchResult) (linker.
 		results := make([]*result, len(fileDescriptorProto.Dependency))
 		checked := map[string]struct{}{}
 		for i, dep := range fileDescriptorProto.Dependency {
-			pos := findImportPos(parseRes, dep)
+			span := findImportSpan(parseRes, dep)
 			if name == dep {
 				// doh! file imports itself
-				handleImportCycle(t.h, pos, []string{name}, dep)
+				handleImportCycle(t.h, span, []string{name}, dep)
 				return nil, t.h.Error()
 			}
 
 			res := t.e.compile(ctx, dep)
 			// check for dependency cycle to prevent deadlock
-			if err := t.e.checkForDependencyCycle(res, []string{name, dep}, pos, checked); err != nil {
+			if err := t.e.checkForDependencyCycle(res, []string{name, dep}, span, checked); err != nil {
 				return nil, err
 			}
 			results[i] = res
@@ -481,7 +481,7 @@ func (t *task) asFile(ctx context.Context, name string, r SearchResult) (linker.
 						// it's usually considered immediately fatal. However, if the reason
 						// we were resolving is due to an import, turn this into an error with
 						// source position that pinpoints the import statement and report it.
-						return nil, reporter.Error(findImportPos(parseRes, res.name), rerr)
+						return nil, reporter.Error(findImportSpan(parseRes, res.name), rerr)
 					}
 					return nil, res.err
 				}
@@ -513,7 +513,7 @@ func (t *task) asFile(ctx context.Context, name string, r SearchResult) (linker.
 	return t.link(parseRes, deps, overrideDescriptorProto)
 }
 
-func (e *executor) checkForDependencyCycle(res *result, sequence []string, pos ast.SourcePos, checked map[string]struct{}) error {
+func (e *executor) checkForDependencyCycle(res *result, sequence []string, span ast.SourceSpan, checked map[string]struct{}) error {
 	if _, ok := checked[res.name]; ok {
 		// already checked this one
 		return nil
@@ -524,7 +524,7 @@ func (e *executor) checkForDependencyCycle(res *result, sequence []string, pos a
 		// is this a cycle?
 		for _, file := range sequence {
 			if file == dep {
-				handleImportCycle(e.h, pos, sequence, dep)
+				handleImportCycle(e.h, span, sequence, dep)
 				return e.h.Error()
 			}
 		}
@@ -535,14 +535,14 @@ func (e *executor) checkForDependencyCycle(res *result, sequence []string, pos a
 		if depRes == nil {
 			continue
 		}
-		if err := e.checkForDependencyCycle(depRes, append(sequence, dep), pos, checked); err != nil {
+		if err := e.checkForDependencyCycle(depRes, append(sequence, dep), span, checked); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func handleImportCycle(h *reporter.Handler, pos ast.SourcePos, importSequence []string, dep string) {
+func handleImportCycle(h *reporter.Handler, span ast.SourceSpan, importSequence []string, dep string) {
 	var buf bytes.Buffer
 	buf.WriteString("cycle found in imports: ")
 	for _, imp := range importSequence {
@@ -550,23 +550,23 @@ func handleImportCycle(h *reporter.Handler, pos ast.SourcePos, importSequence []
 	}
 	_, _ = fmt.Fprintf(&buf, "%q", dep)
 	// error is saved and returned in caller
-	_ = h.HandleErrorf(pos, buf.String())
+	_ = h.HandleErrorf(span, buf.String())
 }
 
-func findImportPos(res parser.Result, dep string) ast.SourcePos {
+func findImportSpan(res parser.Result, dep string) ast.SourceSpan {
 	root := res.AST()
 	if root == nil {
-		return ast.UnknownPos(res.FileNode().Name())
+		return ast.UnknownPos(res.FileNode().Name()).AsSpan()
 	}
 	for _, decl := range root.Decls {
 		if imp, ok := decl.(*ast.ImportNode); ok {
 			if imp.Name.AsString() == dep {
-				return root.NodeInfo(imp.Name).Start()
+				return root.NodeInfo(imp.Name)
 			}
 		}
 	}
 	// this should never happen...
-	return ast.UnknownPos(res.FileNode().Name())
+	return ast.UnknownPos(res.FileNode().Name()).AsSpan()
 }
 
 func (t *task) link(parseRes parser.Result, deps linker.Files, overrideDescriptorProtoRes linker.File) (linker.File, error) {

--- a/compiler.go
+++ b/compiler.go
@@ -556,7 +556,7 @@ func handleImportCycle(h *reporter.Handler, span ast.SourceSpan, importSequence 
 func findImportSpan(res parser.Result, dep string) ast.SourceSpan {
 	root := res.AST()
 	if root == nil {
-		return ast.UnknownPos(res.FileNode().Name()).AsSpan()
+		return ast.UnknownSpan(res.FileNode().Name())
 	}
 	for _, decl := range root.Decls {
 		if imp, ok := decl.(*ast.ImportNode); ok {
@@ -566,7 +566,7 @@ func findImportSpan(res parser.Result, dep string) ast.SourceSpan {
 		}
 	}
 	// this should never happen...
-	return ast.UnknownPos(res.FileNode().Name()).AsSpan()
+	return ast.UnknownSpan(res.FileNode().Name())
 }
 
 func (t *task) link(parseRes parser.Result, deps linker.Files, overrideDescriptorProtoRes linker.File) (linker.File, error) {

--- a/internal/options.go
+++ b/internal/options.go
@@ -51,7 +51,7 @@ func findOption(res hasOptionNode, handler *reporter.Handler, scope string, opts
 			fn := res.FileNode()
 			node := optNode.GetName()
 			nodeInfo := fn.NodeInfo(node)
-			return -1, handler.HandleErrorf(nodeInfo.Start(), "%s: option %s cannot be defined more than once", scope, name)
+			return -1, handler.HandleErrorf(nodeInfo, "%s: option %s cannot be defined more than once", scope, name)
 		}
 		found = i
 	}

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -111,16 +111,16 @@ func (r *result) CheckForUnusedImports(handler *reporter.Handler) {
 			if isPublic {
 				continue
 			}
-			pos := ast.UnknownPos(fd.GetName())
+			span := ast.UnknownPos(fd.GetName()).AsSpan()
 			if file != nil {
 				for _, decl := range file.Decls {
 					imp, ok := decl.(*ast.ImportNode)
 					if ok && imp.Name.AsString() == dep {
-						pos = file.NodeInfo(imp).Start()
+						span = file.NodeInfo(imp)
 					}
 				}
 			}
-			handler.HandleWarningWithPos(pos, errUnusedImport(dep))
+			handler.HandleWarningWithPos(span, errUnusedImport(dep))
 		}
 	}
 }
@@ -209,7 +209,7 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 				if r.Syntax() == protoreflect.Proto3 && !allowedProto3Extendee(d.field.proto.GetExtendee()) {
 					file := r.FileNode()
 					node := r.FieldNode(d.field.proto).FieldExtendee()
-					if err := handler.HandleErrorf(file.NodeInfo(node).Start(), "extend blocks in proto3 can only be used to define custom options"); err != nil {
+					if err := handler.HandleErrorf(file.NodeInfo(node), "extend blocks in proto3 can only be used to define custom options"); err != nil {
 						return err
 					}
 				}
@@ -301,14 +301,14 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 		scope := fmt.Sprintf("extension %s", f.fqn)
 		dsc := r.resolve(fld.GetExtendee(), false, scopes)
 		if dsc == nil {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()).Start(), "unknown extendee type %s", fld.GetExtendee())
+			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "unknown extendee type %s", fld.GetExtendee())
 		}
 		if isSentinelDescriptor(dsc) {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()).Start(), "unknown extendee type %s; resolved to %s which is not defined; consider using a leading dot", fld.GetExtendee(), dsc.FullName())
+			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "unknown extendee type %s; resolved to %s which is not defined; consider using a leading dot", fld.GetExtendee(), dsc.FullName())
 		}
 		extd, ok := dsc.(protoreflect.MessageDescriptor)
 		if !ok {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()).Start(), "extendee is invalid: %s is %s, not a message", dsc.FullName(), descriptorTypeWithArticle(dsc))
+			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "extendee is invalid: %s is %s, not a message", dsc.FullName(), descriptorTypeWithArticle(dsc))
 		}
 		f.extendee = extd
 		extendeeName := "." + string(dsc.FullName())
@@ -326,12 +326,12 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 			}
 		}
 		if !found {
-			if err := handler.HandleErrorf(file.NodeInfo(node.FieldTag()).Start(), "%s: tag %d is not in valid range for extended type %s", scope, tag, dsc.FullName()); err != nil {
+			if err := handler.HandleErrorf(file.NodeInfo(node.FieldTag()), "%s: tag %d is not in valid range for extended type %s", scope, tag, dsc.FullName()); err != nil {
 				return err
 			}
 		} else {
 			// make sure tag is not a duplicate
-			if err := s.AddExtension(packageFor(dsc), dsc.FullName(), tag, file.NodeInfo(node.FieldTag()).Start(), handler); err != nil {
+			if err := s.AddExtension(packageFor(dsc), dsc.FullName(), tag, file.NodeInfo(node.FieldTag()), handler); err != nil {
 				return err
 			}
 		}
@@ -348,10 +348,10 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 
 	dsc := r.resolve(fld.GetTypeName(), true, scopes)
 	if dsc == nil {
-		return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: unknown type %s", scope, fld.GetTypeName())
+		return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: unknown type %s", scope, fld.GetTypeName())
 	}
 	if isSentinelDescriptor(dsc) {
-		return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: unknown type %s; resolved to %s which is not defined; consider using a leading dot", scope, fld.GetTypeName(), dsc.FullName())
+		return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: unknown type %s; resolved to %s which is not defined; consider using a leading dot", scope, fld.GetTypeName(), dsc.FullName())
 	}
 	switch dsc := dsc.(type) {
 	case protoreflect.MessageDescriptor:
@@ -379,7 +379,7 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 				}
 			}
 			if !isValid {
-				return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: %s is a synthetic map entry and may not be referenced explicitly", scope, dsc.FullName())
+				return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: %s is a synthetic map entry and may not be referenced explicitly", scope, dsc.FullName())
 			}
 		}
 		typeName := "." + string(dsc.FullName())
@@ -390,7 +390,7 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 			// if type was tentatively unset, we now know it's actually a message
 			fld.Type = descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum()
 		} else if fld.GetType() != descriptorpb.FieldDescriptorProto_TYPE_MESSAGE && fld.GetType() != descriptorpb.FieldDescriptorProto_TYPE_GROUP {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: descriptor proto indicates type %v but should be %v", scope, fld.GetType(), descriptorpb.FieldDescriptorProto_TYPE_MESSAGE)
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: descriptor proto indicates type %v but should be %v", scope, fld.GetType(), descriptorpb.FieldDescriptorProto_TYPE_MESSAGE)
 		}
 		f.msgType = dsc
 	case protoreflect.EnumDescriptor:
@@ -398,7 +398,7 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 		enumIsProto3 := dsc.Syntax() == protoreflect.Proto3
 		if fld.GetExtendee() == "" && proto3 && !enumIsProto3 {
 			// fields in a proto3 message cannot refer to proto2 enums
-			return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: cannot use proto2 enum %s in a proto3 message", scope, fld.GetTypeName())
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: cannot use proto2 enum %s in a proto3 message", scope, fld.GetTypeName())
 		}
 		typeName := "." + string(dsc.FullName())
 		if fld.GetTypeName() != typeName {
@@ -408,11 +408,11 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 			// the type was tentatively unset, but now we know it's actually an enum
 			fld.Type = descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum()
 		} else if fld.GetType() != descriptorpb.FieldDescriptorProto_TYPE_ENUM {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: descriptor proto indicates type %v but should be %v", scope, fld.GetType(), descriptorpb.FieldDescriptorProto_TYPE_ENUM)
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: descriptor proto indicates type %v but should be %v", scope, fld.GetType(), descriptorpb.FieldDescriptorProto_TYPE_ENUM)
 		}
 		f.enumType = dsc
 	default:
-		return handler.HandleErrorf(file.NodeInfo(node.FieldType()).Start(), "%s: invalid type: %s is %s, not a message or enum", scope, dsc.FullName(), descriptorTypeWithArticle(dsc))
+		return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: invalid type: %s is %s, not a message or enum", scope, dsc.FullName(), descriptorTypeWithArticle(dsc))
 	}
 	return nil
 }
@@ -440,15 +440,15 @@ func resolveMethodTypes(m *mtdDescriptor, handler *reporter.Handler, scopes []sc
 	node := r.MethodNode(mtd)
 	dsc := r.resolve(mtd.GetInputType(), false, scopes)
 	if dsc == nil {
-		if err := handler.HandleErrorf(file.NodeInfo(node.GetInputType()).Start(), "%s: unknown request type %s", scope, mtd.GetInputType()); err != nil {
+		if err := handler.HandleErrorf(file.NodeInfo(node.GetInputType()), "%s: unknown request type %s", scope, mtd.GetInputType()); err != nil {
 			return err
 		}
 	} else if isSentinelDescriptor(dsc) {
-		if err := handler.HandleErrorf(file.NodeInfo(node.GetInputType()).Start(), "%s: unknown request type %s; resolved to %s which is not defined; consider using a leading dot", scope, mtd.GetInputType(), dsc.FullName()); err != nil {
+		if err := handler.HandleErrorf(file.NodeInfo(node.GetInputType()), "%s: unknown request type %s; resolved to %s which is not defined; consider using a leading dot", scope, mtd.GetInputType(), dsc.FullName()); err != nil {
 			return err
 		}
 	} else if msg, ok := dsc.(protoreflect.MessageDescriptor); !ok {
-		if err := handler.HandleErrorf(file.NodeInfo(node.GetInputType()).Start(), "%s: invalid request type: %s is %s, not a message", scope, dsc.FullName(), descriptorTypeWithArticle(dsc)); err != nil {
+		if err := handler.HandleErrorf(file.NodeInfo(node.GetInputType()), "%s: invalid request type: %s is %s, not a message", scope, dsc.FullName(), descriptorTypeWithArticle(dsc)); err != nil {
 			return err
 		}
 	} else {
@@ -462,15 +462,15 @@ func resolveMethodTypes(m *mtdDescriptor, handler *reporter.Handler, scopes []sc
 	// TODO: make input and output type resolution more DRY
 	dsc = r.resolve(mtd.GetOutputType(), false, scopes)
 	if dsc == nil {
-		if err := handler.HandleErrorf(file.NodeInfo(node.GetOutputType()).Start(), "%s: unknown response type %s", scope, mtd.GetOutputType()); err != nil {
+		if err := handler.HandleErrorf(file.NodeInfo(node.GetOutputType()), "%s: unknown response type %s", scope, mtd.GetOutputType()); err != nil {
 			return err
 		}
 	} else if isSentinelDescriptor(dsc) {
-		if err := handler.HandleErrorf(file.NodeInfo(node.GetOutputType()).Start(), "%s: unknown response type %s; resolved to %s which is not defined; consider using a leading dot", scope, mtd.GetOutputType(), dsc.FullName()); err != nil {
+		if err := handler.HandleErrorf(file.NodeInfo(node.GetOutputType()), "%s: unknown response type %s; resolved to %s which is not defined; consider using a leading dot", scope, mtd.GetOutputType(), dsc.FullName()); err != nil {
 			return err
 		}
 	} else if msg, ok := dsc.(protoreflect.MessageDescriptor); !ok {
-		if err := handler.HandleErrorf(file.NodeInfo(node.GetOutputType()).Start(), "%s: invalid response type: %s is %s, not a message", scope, dsc.FullName(), descriptorTypeWithArticle(dsc)); err != nil {
+		if err := handler.HandleErrorf(file.NodeInfo(node.GetOutputType()), "%s: invalid response type: %s is %s, not a message", scope, dsc.FullName(), descriptorTypeWithArticle(dsc)); err != nil {
 			return err
 		}
 	} else {
@@ -499,7 +499,7 @@ opts:
 				node := r.OptionNamePartNode(nm)
 				fqn, err := r.resolveExtensionName(nm.GetNamePart(), scopes)
 				if err != nil {
-					if err := handler.HandleErrorf(file.NodeInfo(node).Start(), "%v%v", mc, err); err != nil {
+					if err := handler.HandleErrorf(file.NodeInfo(node), "%v%v", mc, err); err != nil {
 						return err
 					}
 					continue opts
@@ -549,7 +549,7 @@ func (r *result) resolveOptionValue(handler *reporter.Handler, mc *internal.Mess
 				scopes := scopes[:1] // first scope is file, the rest are enclosing messages
 				fqn, err := r.resolveExtensionName(string(fld.Name.Name.AsIdentifier()), scopes)
 				if err != nil {
-					if err := handler.HandleErrorf(r.FileNode().NodeInfo(fld.Name.Name).Start(), "%v%v", mc, err); err != nil {
+					if err := handler.HandleErrorf(r.FileNode().NodeInfo(fld.Name.Name), "%v%v", mc, err); err != nil {
 						return err
 					}
 				} else {

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -111,7 +111,7 @@ func (r *result) CheckForUnusedImports(handler *reporter.Handler) {
 			if isPublic {
 				continue
 			}
-			span := ast.UnknownPos(fd.GetName()).AsSpan()
+			span := ast.UnknownSpan(fd.GetName())
 			if file != nil {
 				for _, decl := range file.Decls {
 					imp, ok := decl.(*ast.ImportNode)

--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -283,9 +283,9 @@ func (s *packageSymbols) checkFileLocked(f protoreflect.FileDescriptor, handler 
 func sourceSpanForPackage(fd protoreflect.FileDescriptor) ast.SourceSpan {
 	loc := fd.SourceLocations().ByPath([]int32{internal.FilePackageTag})
 	if internal.IsZeroLocation(loc) {
-		return ast.UnknownPos(fd.Path()).AsSpan()
+		return ast.UnknownSpan(fd.Path())
 	}
-	return ast.NewPosSpan(
+	return ast.NewSourceSpan(
 		ast.SourcePos{
 			Filename: fd.Path(),
 			Line:     loc.StartLine,
@@ -302,11 +302,11 @@ func sourceSpanForPackage(fd protoreflect.FileDescriptor) ast.SourceSpan {
 func sourceSpanFor(d protoreflect.Descriptor) ast.SourceSpan {
 	file := d.ParentFile()
 	if file == nil {
-		return ast.UnknownPos(unknownFilePath).AsSpan()
+		return ast.UnknownSpan(unknownFilePath)
 	}
 	path, ok := internal.ComputePath(d)
 	if !ok {
-		return ast.UnknownPos(file.Path()).AsSpan()
+		return ast.UnknownSpan(file.Path())
 	}
 	namePath := path
 	switch d.(type) {
@@ -332,11 +332,11 @@ func sourceSpanFor(d protoreflect.Descriptor) ast.SourceSpan {
 	if internal.IsZeroLocation(loc) {
 		loc = file.SourceLocations().ByPath(path)
 		if internal.IsZeroLocation(loc) {
-			return ast.UnknownPos(file.Path()).AsSpan()
+			return ast.UnknownSpan(file.Path())
 		}
 	}
 
-	return ast.NewPosSpan(
+	return ast.NewSourceSpan(
 		ast.SourcePos{
 			Filename: file.Path(),
 			Line:     loc.StartLine,
@@ -353,11 +353,11 @@ func sourceSpanFor(d protoreflect.Descriptor) ast.SourceSpan {
 func sourceSpanForNumber(fd protoreflect.FieldDescriptor) ast.SourceSpan {
 	file := fd.ParentFile()
 	if file == nil {
-		return ast.UnknownPos(unknownFilePath).AsSpan()
+		return ast.UnknownSpan(unknownFilePath)
 	}
 	path, ok := internal.ComputePath(fd)
 	if !ok {
-		return ast.UnknownPos(file.Path()).AsSpan()
+		return ast.UnknownSpan(file.Path())
 	}
 	numberPath := path
 	numberPath = append(numberPath, internal.FieldNumberTag)
@@ -365,10 +365,10 @@ func sourceSpanForNumber(fd protoreflect.FieldDescriptor) ast.SourceSpan {
 	if internal.IsZeroLocation(loc) {
 		loc = file.SourceLocations().ByPath(path)
 		if internal.IsZeroLocation(loc) {
-			return ast.UnknownPos(file.Path()).AsSpan()
+			return ast.UnknownSpan(file.Path())
 		}
 	}
-	return ast.NewPosSpan(
+	return ast.NewSourceSpan(
 		ast.SourcePos{
 			Filename: file.Path(),
 			Line:     loc.StartLine,
@@ -495,7 +495,7 @@ func packageNameSpan(r *result) ast.SourceSpan {
 			}
 		}
 	}
-	return ast.UnknownPos(r.Path()).AsSpan()
+	return ast.UnknownSpan(r.Path())
 }
 
 func nameSpan(file ast.FileDeclNode, n ast.Node) ast.SourceSpan {

--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -54,7 +54,7 @@ type extNumber struct {
 }
 
 type symbolEntry struct {
-	pos         ast.SourcePos
+	span        ast.SourceSpan
 	isEnumValue bool
 	isPackage   bool
 }
@@ -74,13 +74,13 @@ func (s *Symbols) Import(fd protoreflect.FileDescriptor, handler *reporter.Handl
 		fd = f.FileDescriptor
 	}
 
-	var pkgPos ast.SourcePos
+	var pkgSpan ast.SourceSpan
 	if res, ok := fd.(*result); ok {
-		pkgPos = packageNameStart(res)
+		pkgSpan = packageNameSpan(res)
 	} else {
-		pkgPos = sourcePositionForPackage(fd)
+		pkgSpan = sourceSpanForPackage(fd)
 	}
-	pkg, err := s.importPackages(pkgPos, fd.Package(), handler)
+	pkg, err := s.importPackages(pkgSpan, fd.Package(), handler)
 	if err != nil || pkg == nil {
 		return err
 	}
@@ -121,9 +121,9 @@ func (s *Symbols) importFileWithExtensions(pkg *packageSymbols, fd protoreflect.
 		if !ok || !fld.IsExtension() {
 			return nil
 		}
-		pos := sourcePositionForNumber(fld)
+		span := sourceSpanForNumber(fld)
 		extendee := fld.ContainingMessage()
-		return s.AddExtension(packageFor(extendee), extendee.FullName(), fld.Number(), pos, handler)
+		return s.AddExtension(packageFor(extendee), extendee.FullName(), fld.Number(), span, handler)
 	})
 }
 
@@ -151,7 +151,7 @@ func (s *packageSymbols) importFile(fd protoreflect.FileDescriptor, handler *rep
 	return true, nil
 }
 
-func (s *Symbols) importPackages(pkgPos ast.SourcePos, pkg protoreflect.FullName, handler *reporter.Handler) (*packageSymbols, error) {
+func (s *Symbols) importPackages(pkgSpan ast.SourceSpan, pkg protoreflect.FullName, handler *reporter.Handler) (*packageSymbols, error) {
 	if pkg == "" {
 		return &s.pkgTrie, nil
 	}
@@ -164,7 +164,7 @@ func (s *Symbols) importPackages(pkgPos ast.SourcePos, pkg protoreflect.FullName
 	cur := &s.pkgTrie
 	for _, p := range parts {
 		var err error
-		cur, err = cur.importPackage(pkgPos, protoreflect.FullName(p), handler)
+		cur, err = cur.importPackage(pkgSpan, protoreflect.FullName(p), handler)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (s *Symbols) importPackages(pkgPos ast.SourcePos, pkg protoreflect.FullName
 	return cur, nil
 }
 
-func (s *packageSymbols) importPackage(pkgPos ast.SourcePos, pkg protoreflect.FullName, handler *reporter.Handler) (*packageSymbols, error) {
+func (s *packageSymbols) importPackage(pkgSpan ast.SourceSpan, pkg protoreflect.FullName, handler *reporter.Handler) (*packageSymbols, error) {
 	s.mu.RLock()
 	existing, ok := s.symbols[pkg]
 	var child *packageSymbols
@@ -189,7 +189,7 @@ func (s *packageSymbols) importPackage(pkgPos ast.SourcePos, pkg protoreflect.Fu
 		// package already exists
 		return child, nil
 	} else if ok {
-		return nil, reportSymbolCollision(pkgPos, pkg, false, existing, handler)
+		return nil, reportSymbolCollision(pkgSpan, pkg, false, existing, handler)
 	}
 
 	s.mu.Lock()
@@ -200,12 +200,12 @@ func (s *packageSymbols) importPackage(pkgPos ast.SourcePos, pkg protoreflect.Fu
 		// package already exists
 		return s.children[pkg], nil
 	} else if ok {
-		return nil, reportSymbolCollision(pkgPos, pkg, false, existing, handler)
+		return nil, reportSymbolCollision(pkgSpan, pkg, false, existing, handler)
 	}
 	if s.symbols == nil {
 		s.symbols = map[protoreflect.FullName]symbolEntry{}
 	}
-	s.symbols[pkg] = symbolEntry{pos: pkgPos, isPackage: true}
+	s.symbols[pkg] = symbolEntry{span: pkgSpan, isPackage: true}
 	child = &packageSymbols{}
 	if s.children == nil {
 		s.children = map[protoreflect.FullName]*packageSymbols{}
@@ -239,7 +239,7 @@ func (s *Symbols) getPackage(pkg protoreflect.FullName) *packageSymbols {
 	return cur
 }
 
-func reportSymbolCollision(pos ast.SourcePos, fqn protoreflect.FullName, additionIsEnumVal bool, existing symbolEntry, handler *reporter.Handler) error {
+func reportSymbolCollision(span ast.SourceSpan, fqn protoreflect.FullName, additionIsEnumVal bool, existing symbolEntry, handler *reporter.Handler) error {
 	// because of weird scoping for enum values, provide more context in error message
 	// if this conflict is with an enum value
 	var isPkg, suffix string
@@ -249,12 +249,12 @@ func reportSymbolCollision(pos ast.SourcePos, fqn protoreflect.FullName, additio
 	if existing.isPackage {
 		isPkg = " as a package"
 	}
-	orig := existing.pos
-	conflict := pos
-	if posLess(conflict, orig) {
+	orig := existing.span
+	conflict := span
+	if posLess(conflict.Start(), orig.Start()) {
 		orig, conflict = conflict, orig
 	}
-	return handler.HandleErrorf(conflict, "symbol %q already defined%s at %v%s", fqn, isPkg, orig, suffix)
+	return handler.HandleErrorf(conflict, "symbol %q already defined%s at %v%s", fqn, isPkg, orig.Start(), suffix)
 }
 
 func posLess(a, b ast.SourcePos) bool {
@@ -269,10 +269,10 @@ func posLess(a, b ast.SourcePos) bool {
 
 func (s *packageSymbols) checkFileLocked(f protoreflect.FileDescriptor, handler *reporter.Handler) error {
 	return walk.Descriptors(f, func(d protoreflect.Descriptor) error {
-		pos := sourcePositionFor(d)
+		span := sourceSpanFor(d)
 		if existing, ok := s.symbols[d.FullName()]; ok {
 			_, isEnumVal := d.(protoreflect.EnumValueDescriptor)
-			if err := reportSymbolCollision(pos, d.FullName(), isEnumVal, existing, handler); err != nil {
+			if err := reportSymbolCollision(span, d.FullName(), isEnumVal, existing, handler); err != nil {
 				return err
 			}
 		}
@@ -280,26 +280,33 @@ func (s *packageSymbols) checkFileLocked(f protoreflect.FileDescriptor, handler 
 	})
 }
 
-func sourcePositionForPackage(fd protoreflect.FileDescriptor) ast.SourcePos {
+func sourceSpanForPackage(fd protoreflect.FileDescriptor) ast.SourceSpan {
 	loc := fd.SourceLocations().ByPath([]int32{internal.FilePackageTag})
 	if internal.IsZeroLocation(loc) {
-		return ast.UnknownPos(fd.Path())
+		return ast.UnknownPos(fd.Path()).AsSpan()
 	}
-	return ast.SourcePos{
-		Filename: fd.Path(),
-		Line:     loc.StartLine,
-		Col:      loc.StartColumn,
-	}
+	return ast.NewPosSpan(
+		ast.SourcePos{
+			Filename: fd.Path(),
+			Line:     loc.StartLine,
+			Col:      loc.StartColumn,
+		},
+		ast.SourcePos{
+			Filename: fd.Path(),
+			Line:     loc.EndLine,
+			Col:      loc.EndColumn,
+		},
+	)
 }
 
-func sourcePositionFor(d protoreflect.Descriptor) ast.SourcePos {
+func sourceSpanFor(d protoreflect.Descriptor) ast.SourceSpan {
 	file := d.ParentFile()
 	if file == nil {
-		return ast.UnknownPos(unknownFilePath)
+		return ast.UnknownPos(unknownFilePath).AsSpan()
 	}
 	path, ok := internal.ComputePath(d)
 	if !ok {
-		return ast.UnknownPos(file.Path())
+		return ast.UnknownPos(file.Path()).AsSpan()
 	}
 	namePath := path
 	switch d.(type) {
@@ -325,24 +332,32 @@ func sourcePositionFor(d protoreflect.Descriptor) ast.SourcePos {
 	if internal.IsZeroLocation(loc) {
 		loc = file.SourceLocations().ByPath(path)
 		if internal.IsZeroLocation(loc) {
-			return ast.UnknownPos(file.Path())
+			return ast.UnknownPos(file.Path()).AsSpan()
 		}
 	}
-	return ast.SourcePos{
-		Filename: file.Path(),
-		Line:     loc.StartLine,
-		Col:      loc.StartColumn,
-	}
+
+	return ast.NewPosSpan(
+		ast.SourcePos{
+			Filename: file.Path(),
+			Line:     loc.StartLine,
+			Col:      loc.StartColumn,
+		},
+		ast.SourcePos{
+			Filename: file.Path(),
+			Line:     loc.EndLine,
+			Col:      loc.EndColumn,
+		},
+	)
 }
 
-func sourcePositionForNumber(fd protoreflect.FieldDescriptor) ast.SourcePos {
+func sourceSpanForNumber(fd protoreflect.FieldDescriptor) ast.SourceSpan {
 	file := fd.ParentFile()
 	if file == nil {
-		return ast.UnknownPos(unknownFilePath)
+		return ast.UnknownPos(unknownFilePath).AsSpan()
 	}
 	path, ok := internal.ComputePath(fd)
 	if !ok {
-		return ast.UnknownPos(file.Path())
+		return ast.UnknownPos(file.Path()).AsSpan()
 	}
 	numberPath := path
 	numberPath = append(numberPath, internal.FieldNumberTag)
@@ -350,14 +365,21 @@ func sourcePositionForNumber(fd protoreflect.FieldDescriptor) ast.SourcePos {
 	if internal.IsZeroLocation(loc) {
 		loc = file.SourceLocations().ByPath(path)
 		if internal.IsZeroLocation(loc) {
-			return ast.UnknownPos(file.Path())
+			return ast.UnknownPos(file.Path()).AsSpan()
 		}
 	}
-	return ast.SourcePos{
-		Filename: file.Path(),
-		Line:     loc.StartLine,
-		Col:      loc.StartColumn,
-	}
+	return ast.NewPosSpan(
+		ast.SourcePos{
+			Filename: file.Path(),
+			Line:     loc.StartLine,
+			Col:      loc.StartColumn,
+		},
+		ast.SourcePos{
+			Filename: file.Path(),
+			Line:     loc.EndLine,
+			Col:      loc.EndColumn,
+		},
+	)
 }
 
 func (s *packageSymbols) commitFileLocked(f protoreflect.FileDescriptor) {
@@ -368,10 +390,10 @@ func (s *packageSymbols) commitFileLocked(f protoreflect.FileDescriptor) {
 		s.exts = map[extNumber]ast.SourcePos{}
 	}
 	_ = walk.Descriptors(f, func(d protoreflect.Descriptor) error {
-		pos := sourcePositionFor(d)
+		span := sourceSpanFor(d)
 		name := d.FullName()
 		_, isEnumValue := d.(protoreflect.EnumValueDescriptor)
-		s.symbols[name] = symbolEntry{pos: pos, isEnumValue: isEnumValue}
+		s.symbols[name] = symbolEntry{span: span, isEnumValue: isEnumValue}
 		return nil
 	})
 
@@ -398,14 +420,14 @@ func (s *Symbols) importResultWithExtensions(pkg *packageSymbols, r *result, han
 		}
 		file := r.FileNode()
 		node := r.FieldNode(fd.FieldDescriptorProto())
-		pos := file.NodeInfo(node.FieldTag()).Start()
+		info := file.NodeInfo(node.FieldTag())
 		extendee := fd.ContainingMessage()
-		return s.AddExtension(packageFor(extendee), extendee.FullName(), fd.Number(), pos, handler)
+		return s.AddExtension(packageFor(extendee), extendee.FullName(), fd.Number(), info, handler)
 	})
 }
 
 func (s *Symbols) importResult(r *result, handler *reporter.Handler) error {
-	pkg, err := s.importPackages(packageNameStart(r), r.Package(), handler)
+	pkg, err := s.importPackages(packageNameSpan(r), r.Package(), handler)
 	if err != nil || pkg == nil {
 		return err
 	}
@@ -442,22 +464,22 @@ func (s *packageSymbols) checkResultLocked(r *result, handler *reporter.Handler)
 		_, isEnumVal := d.(*descriptorpb.EnumValueDescriptorProto)
 		file := r.FileNode()
 		node := r.Node(d)
-		pos := nameStart(file, node)
+		span := nameSpan(file, node)
 		// check symbols already in this symbol table
 		if existing, ok := s.symbols[fqn]; ok {
-			if err := reportSymbolCollision(pos, fqn, isEnumVal, existing, handler); err != nil {
+			if err := reportSymbolCollision(span, fqn, isEnumVal, existing, handler); err != nil {
 				return err
 			}
 		}
 
 		// also check symbols from this result (that are not yet in symbol table)
 		if existing, ok := resultSyms[fqn]; ok {
-			if err := reportSymbolCollision(pos, fqn, isEnumVal, existing, handler); err != nil {
+			if err := reportSymbolCollision(span, fqn, isEnumVal, existing, handler); err != nil {
 				return err
 			}
 		}
 		resultSyms[fqn] = symbolEntry{
-			pos:         pos,
+			span:        span,
 			isEnumValue: isEnumVal,
 		}
 
@@ -465,36 +487,36 @@ func (s *packageSymbols) checkResultLocked(r *result, handler *reporter.Handler)
 	})
 }
 
-func packageNameStart(r *result) ast.SourcePos {
+func packageNameSpan(r *result) ast.SourceSpan {
 	if node, ok := r.FileNode().(*ast.FileNode); ok {
 		for _, decl := range node.Decls {
 			if pkgNode, ok := decl.(*ast.PackageNode); ok {
-				return r.FileNode().NodeInfo(pkgNode.Name).Start()
+				return r.FileNode().NodeInfo(pkgNode.Name)
 			}
 		}
 	}
-	return ast.UnknownPos(r.Path())
+	return ast.UnknownPos(r.Path()).AsSpan()
 }
 
-func nameStart(file ast.FileDeclNode, n ast.Node) ast.SourcePos {
+func nameSpan(file ast.FileDeclNode, n ast.Node) ast.SourceSpan {
 	// TODO: maybe ast package needs a NamedNode interface to simplify this?
 	switch n := n.(type) {
 	case ast.FieldDeclNode:
-		return file.NodeInfo(n.FieldName()).Start()
+		return file.NodeInfo(n.FieldName())
 	case ast.MessageDeclNode:
-		return file.NodeInfo(n.MessageName()).Start()
+		return file.NodeInfo(n.MessageName())
 	case ast.OneofDeclNode:
-		return file.NodeInfo(n.OneofName()).Start()
+		return file.NodeInfo(n.OneofName())
 	case ast.EnumValueDeclNode:
-		return file.NodeInfo(n.GetName()).Start()
+		return file.NodeInfo(n.GetName())
 	case *ast.EnumNode:
-		return file.NodeInfo(n.Name).Start()
+		return file.NodeInfo(n.Name)
 	case *ast.ServiceNode:
-		return file.NodeInfo(n.Name).Start()
+		return file.NodeInfo(n.Name)
 	case ast.RPCDeclNode:
-		return file.NodeInfo(n.GetName()).Start()
+		return file.NodeInfo(n.GetName())
 	default:
-		return file.NodeInfo(n).Start()
+		return file.NodeInfo(n)
 	}
 }
 
@@ -506,9 +528,9 @@ func (s *packageSymbols) commitResultLocked(r *result) {
 		s.exts = map[extNumber]ast.SourcePos{}
 	}
 	_ = walk.DescriptorProtos(r.FileDescriptorProto(), func(fqn protoreflect.FullName, d proto.Message) error {
-		pos := nameStart(r.FileNode(), r.Node(d))
+		span := nameSpan(r.FileNode(), r.Node(d))
 		_, isEnumValue := d.(protoreflect.EnumValueDescriptor)
-		s.symbols[fqn] = symbolEntry{pos: pos, isEnumValue: isEnumValue}
+		s.symbols[fqn] = symbolEntry{span: span, isEnumValue: isEnumValue}
 		return nil
 	})
 
@@ -518,21 +540,21 @@ func (s *packageSymbols) commitResultLocked(r *result) {
 	s.files[r] = struct{}{}
 }
 
-func (s *Symbols) AddExtension(pkg, extendee protoreflect.FullName, tag protoreflect.FieldNumber, pos ast.SourcePos, handler *reporter.Handler) error {
+func (s *Symbols) AddExtension(pkg, extendee protoreflect.FullName, tag protoreflect.FieldNumber, span ast.SourceSpan, handler *reporter.Handler) error {
 	if pkg != "" {
 		if !strings.HasPrefix(string(extendee), string(pkg)+".") {
-			return handler.HandleErrorf(pos, "could not register extension: extendee %q does not match package %q", extendee, pkg)
+			return handler.HandleErrorf(span, "could not register extension: extendee %q does not match package %q", extendee, pkg)
 		}
 	}
 	pkgSyms := s.getPackage(pkg)
 	if pkgSyms == nil {
 		// should never happen
-		return handler.HandleErrorf(pos, "could not register extension: missing package symbols for %q", pkg)
+		return handler.HandleErrorf(span, "could not register extension: missing package symbols for %q", pkg)
 	}
-	return pkgSyms.addExtension(extendee, tag, pos, handler)
+	return pkgSyms.addExtension(extendee, tag, span, handler)
 }
 
-func (s *packageSymbols) addExtension(extendee protoreflect.FullName, tag protoreflect.FieldNumber, pos ast.SourcePos, handler *reporter.Handler) error {
+func (s *packageSymbols) addExtension(extendee protoreflect.FullName, tag protoreflect.FieldNumber, span ast.SourceSpan, handler *reporter.Handler) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -542,11 +564,11 @@ func (s *packageSymbols) addExtension(extendee protoreflect.FullName, tag protor
 
 	extNum := extNumber{extendee: extendee, tag: tag}
 	if existing, ok := s.exts[extNum]; ok {
-		if err := handler.HandleErrorf(pos, "extension with tag %d for message %s already defined at %v", tag, extendee, existing); err != nil {
+		if err := handler.HandleErrorf(span, "extension with tag %d for message %s already defined at %v", tag, extendee, existing); err != nil {
 			return err
 		}
 	} else {
-		s.exts[extNum] = pos
+		s.exts[extNum] = span.Start()
 	}
 	return nil
 }

--- a/linker/symbols_test.go
+++ b/linker/symbols_test.go
@@ -37,7 +37,7 @@ func TestSymbolsPackages(t *testing.T) {
 	assert.Equal(t, &s.pkgTrie, s.getPackage(""))
 
 	h := reporter.NewHandler(nil)
-	span := ast.UnknownPos("foo.proto").AsSpan()
+	span := ast.UnknownSpan("foo.proto")
 	pkg, err := s.importPackages(span, "build.buf.foo.bar.baz", h)
 	require.NoError(t, err)
 	// new package has nothing in it
@@ -142,13 +142,13 @@ func TestSymbolExtensions(t *testing.T) {
 
 	var s Symbols
 
-	_, err := s.importPackages(ast.UnknownPos("foo.proto").AsSpan(), "foo.bar", reporter.NewHandler(nil))
+	_, err := s.importPackages(ast.UnknownSpan("foo.proto"), "foo.bar", reporter.NewHandler(nil))
 	require.NoError(t, err)
-	_, err = s.importPackages(ast.UnknownPos("google/protobuf/descriptor.proto").AsSpan(), "google.protobuf", reporter.NewHandler(nil))
+	_, err = s.importPackages(ast.UnknownSpan("google/protobuf/descriptor.proto"), "google.protobuf", reporter.NewHandler(nil))
 	require.NoError(t, err)
 
 	addExt := func(pkg, extendee protoreflect.FullName, num protoreflect.FieldNumber) error {
-		return s.AddExtension(pkg, extendee, num, ast.UnknownPos("foo.proto").AsSpan(), reporter.NewHandler(nil))
+		return s.AddExtension(pkg, extendee, num, ast.UnknownSpan("foo.proto"), reporter.NewHandler(nil))
 	}
 
 	t.Run("mismatch", func(t *testing.T) {

--- a/linker/symbols_test.go
+++ b/linker/symbols_test.go
@@ -37,8 +37,8 @@ func TestSymbolsPackages(t *testing.T) {
 	assert.Equal(t, &s.pkgTrie, s.getPackage(""))
 
 	h := reporter.NewHandler(nil)
-	pos := ast.UnknownPos("foo.proto")
-	pkg, err := s.importPackages(pos, "build.buf.foo.bar.baz", h)
+	span := ast.UnknownPos("foo.proto").AsSpan()
+	pkg, err := s.importPackages(span, "build.buf.foo.bar.baz", h)
 	require.NoError(t, err)
 	// new package has nothing in it
 	assert.Empty(t, pkg.children)
@@ -60,7 +60,8 @@ func TestSymbolsPackages(t *testing.T) {
 
 		entry, ok := cur.symbols[pkgName]
 		require.True(t, ok)
-		assert.Equal(t, pos, entry.pos)
+		assert.Equal(t, span.Start(), entry.span.Start())
+		assert.Equal(t, span.End(), entry.span.End())
 		assert.False(t, entry.isEnumValue)
 		assert.True(t, entry.isPackage)
 
@@ -141,13 +142,13 @@ func TestSymbolExtensions(t *testing.T) {
 
 	var s Symbols
 
-	_, err := s.importPackages(ast.UnknownPos("foo.proto"), "foo.bar", reporter.NewHandler(nil))
+	_, err := s.importPackages(ast.UnknownPos("foo.proto").AsSpan(), "foo.bar", reporter.NewHandler(nil))
 	require.NoError(t, err)
-	_, err = s.importPackages(ast.UnknownPos("google/protobuf/descriptor.proto"), "google.protobuf", reporter.NewHandler(nil))
+	_, err = s.importPackages(ast.UnknownPos("google/protobuf/descriptor.proto").AsSpan(), "google.protobuf", reporter.NewHandler(nil))
 	require.NoError(t, err)
 
 	addExt := func(pkg, extendee protoreflect.FullName, num protoreflect.FieldNumber) error {
-		return s.AddExtension(pkg, extendee, num, ast.UnknownPos("foo.proto"), reporter.NewHandler(nil))
+		return s.AddExtension(pkg, extendee, num, ast.UnknownPos("foo.proto").AsSpan(), reporter.NewHandler(nil))
 	}
 
 	t.Run("mismatch", func(t *testing.T) {

--- a/options/options.go
+++ b/options/options.go
@@ -1015,7 +1015,7 @@ func (interp *interpreter) validateFeatures(
 
 func (interp *interpreter) positionOfFeature(featuresInfo []*interpretedOption, fieldNumbers ...protoreflect.FieldNumber) ast.SourceSpan {
 	if interp.file.AST() == nil {
-		return ast.UnknownPos(interp.file.FileDescriptorProto().GetName()).AsSpan()
+		return ast.UnknownSpan(interp.file.FileDescriptorProto().GetName())
 	}
 	for _, info := range featuresInfo {
 		matched, remainingNumbers, node := matchInterpretedOption(info, fieldNumbers)
@@ -1029,7 +1029,7 @@ func (interp *interpreter) positionOfFeature(featuresInfo []*interpretedOption, 
 			return interp.file.FileNode().NodeInfo(node)
 		}
 	}
-	return ast.UnknownPos(interp.file.FileDescriptorProto().GetName()).AsSpan()
+	return ast.UnknownSpan(interp.file.FileDescriptorProto().GetName())
 }
 
 func matchInterpretedOption(info *interpretedOption, path []protoreflect.FieldNumber) (bool, []protoreflect.FieldNumber, ast.Node) {
@@ -1170,8 +1170,8 @@ func (interp *interpreter) toOptionBytes(mc *internal.MessageContext, results []
 		b, err = res.appendOptionBytes(b)
 		if err != nil {
 			if _, ok := err.(reporter.ErrorWithPos); !ok {
-				pos := ast.SourcePos{Filename: interp.file.AST().Name()}
-				err = reporter.Errorf(pos.AsSpan(), "%sfailed to encode options: %w", mc, err)
+				span := ast.UnknownSpan(interp.file.AST().Name())
+				err = reporter.Errorf(span, "%sfailed to encode options: %w", mc, err)
 			}
 			if err := interp.reporter.HandleError(err); err != nil {
 				return nil, err

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -742,7 +742,8 @@ func (l *protoLex) skipToEndOfBlockComment(lval *protoSymType) (ok, hasErr bool)
 func (l *protoLex) addSourceError(err error) (reporter.ErrorWithPos, bool) {
 	ewp, ok := err.(reporter.ErrorWithPos)
 	if !ok {
-		ewp = reporter.Error(l.prev().AsSpan(), err)
+		// TODO: Store the previous span instead of just the position.
+		ewp = reporter.Error(ast.NewSourceSpan(l.prev(), l.prev()), err)
 	}
 	handlerErr := l.handler.HandleError(ewp)
 	return ewp, handlerErr == nil
@@ -752,10 +753,11 @@ func (l *protoLex) Error(s string) {
 	_, _ = l.addSourceError(errors.New(s))
 }
 
+// TODO: Accept both a start and end offset, and use that to create a span.
 func (l *protoLex) errWithCurrentPos(err error, offset int) reporter.ErrorWithPos {
 	if ewp, ok := err.(reporter.ErrorWithPos); ok {
 		return ewp
 	}
 	pos := l.info.SourcePos(l.input.offset() + offset)
-	return reporter.Error(pos.AsSpan(), err)
+	return reporter.Error(ast.NewSourceSpan(pos, pos), err)
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -742,7 +742,7 @@ func (l *protoLex) skipToEndOfBlockComment(lval *protoSymType) (ok, hasErr bool)
 func (l *protoLex) addSourceError(err error) (reporter.ErrorWithPos, bool) {
 	ewp, ok := err.(reporter.ErrorWithPos)
 	if !ok {
-		ewp = reporter.Error(l.prev(), err)
+		ewp = reporter.Error(l.prev().AsSpan(), err)
 	}
 	handlerErr := l.handler.HandleError(ewp)
 	return ewp, handlerErr == nil
@@ -757,5 +757,5 @@ func (l *protoLex) errWithCurrentPos(err error, offset int) reporter.ErrorWithPo
 		return ewp
 	}
 	pos := l.info.SourcePos(l.input.offset() + offset)
-	return reporter.Error(pos, err)
+	return reporter.Error(pos.AsSpan(), err)
 }

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -97,12 +97,12 @@ func validateImports(res *result, handler *reporter.Handler) error {
 		if !ok {
 			continue
 		}
-		startPos := fileNode.NodeInfo(decl).Start()
+		info := fileNode.NodeInfo(decl)
 		name := imp.Name.AsString()
 		if prev, ok := imports[name]; ok {
-			return handler.HandleErrorf(startPos, "%q was already imported at %v", name, prev)
+			return handler.HandleErrorf(info, "%q was already imported at %v", name, prev)
 		}
-		imports[name] = startPos
+		imports[name] = info.Start()
 	}
 	return nil
 }
@@ -117,7 +117,7 @@ func validateNoFeatures(res *result, syntax syntaxType, scope string, opts []*de
 	} else if index >= 0 {
 		optNode := res.OptionNode(opts[index])
 		optNameNodeInfo := res.file.NodeInfo(optNode.GetName())
-		if err := handler.HandleErrorf(optNameNodeInfo.Start(), "%s: option 'features' may only be used with editions but file uses %s syntax", scope, syntax); err != nil {
+		if err := handler.HandleErrorf(optNameNodeInfo, "%s: option 'features' may only be used with editions but file uses %s syntax", scope, syntax); err != nil {
 			return err
 		}
 	}
@@ -130,7 +130,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 	if syntax == syntaxProto3 && len(md.ExtensionRange) > 0 {
 		n := res.ExtensionRangeNode(md.ExtensionRange[0])
 		nInfo := res.file.NodeInfo(n)
-		if err := handler.HandleErrorf(nInfo.Start(), "%s: extension ranges are not allowed in proto3", scope); err != nil {
+		if err := handler.HandleErrorf(nInfo, "%s: extension ranges are not allowed in proto3", scope); err != nil {
 			return err
 		}
 	}
@@ -140,7 +140,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 	} else if index >= 0 {
 		optNode := res.OptionNode(md.Options.GetUninterpretedOption()[index])
 		optNameNodeInfo := res.file.NodeInfo(optNode.GetName())
-		if err := handler.HandleErrorf(optNameNodeInfo.Start(), "%s: map_entry option should not be set explicitly; use map type instead", scope); err != nil {
+		if err := handler.HandleErrorf(optNameNodeInfo, "%s: map_entry option should not be set explicitly; use map type instead", scope); err != nil {
 			return err
 		}
 	}
@@ -159,7 +159,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 	for i := 1; i < len(rsvd); i++ {
 		if rsvd[i].start < rsvd[i-1].end {
 			rangeNodeInfo := res.file.NodeInfo(rsvd[i].node)
-			if err := handler.HandleErrorf(rangeNodeInfo.Start(), "%s: reserved ranges overlap: %d to %d and %d to %d", scope, rsvd[i-1].start, rsvd[i-1].end-1, rsvd[i].start, rsvd[i].end-1); err != nil {
+			if err := handler.HandleErrorf(rangeNodeInfo, "%s: reserved ranges overlap: %d to %d and %d to %d", scope, rsvd[i-1].start, rsvd[i-1].end-1, rsvd[i].start, rsvd[i].end-1); err != nil {
 				return err
 			}
 		}
@@ -178,7 +178,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 	for i := 1; i < len(exts); i++ {
 		if exts[i].start < exts[i-1].end {
 			rangeNodeInfo := res.file.NodeInfo(exts[i].node)
-			if err := handler.HandleErrorf(rangeNodeInfo.Start(), "%s: extension ranges overlap: %d to %d and %d to %d", scope, exts[i-1].start, exts[i-1].end-1, exts[i].start, exts[i].end-1); err != nil {
+			if err := handler.HandleErrorf(rangeNodeInfo, "%s: extension ranges overlap: %d to %d and %d to %d", scope, exts[i-1].start, exts[i-1].end-1, exts[i].start, exts[i].end-1); err != nil {
 				return err
 			}
 		}
@@ -189,16 +189,16 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 	for i < len(rsvd) && j < len(exts) {
 		if rsvd[i].start >= exts[j].start && rsvd[i].start < exts[j].end ||
 			exts[j].start >= rsvd[i].start && exts[j].start < rsvd[i].end {
-			var pos ast.SourcePos
+			var span ast.SourceSpan
 			if rsvd[i].start >= exts[j].start && rsvd[i].start < exts[j].end {
 				rangeNodeInfo := res.file.NodeInfo(rsvd[i].node)
-				pos = rangeNodeInfo.Start()
+				span = rangeNodeInfo
 			} else {
 				rangeNodeInfo := res.file.NodeInfo(exts[j].node)
-				pos = rangeNodeInfo.Start()
+				span = rangeNodeInfo
 			}
 			// ranges overlap
-			if err := handler.HandleErrorf(pos, "%s: extension range %d to %d overlaps reserved range %d to %d", scope, exts[j].start, exts[j].end-1, rsvd[i].start, rsvd[i].end-1); err != nil {
+			if err := handler.HandleErrorf(span, "%s: extension range %d to %d overlaps reserved range %d to %d", scope, exts[j].start, exts[j].end-1, rsvd[i].start, rsvd[i].end-1); err != nil {
 				return err
 			}
 		}
@@ -217,7 +217,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 		if !isIdentifier(n) {
 			node := findMessageReservedNameNode(res.MessageNode(md), n)
 			nodeInfo := res.file.NodeInfo(node)
-			if err := handler.HandleErrorf(nodeInfo.Start(), "%s: reserved name %q is not a valid identifier", scope, n); err != nil {
+			if err := handler.HandleErrorf(nodeInfo, "%s: reserved name %q is not a valid identifier", scope, n); err != nil {
 				return err
 			}
 		}
@@ -228,13 +228,13 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 		fn := res.FieldNode(fld)
 		if _, ok := rsvdNames[fld.GetName()]; ok {
 			fieldNameNodeInfo := res.file.NodeInfo(fn.FieldName())
-			if err := handler.HandleErrorf(fieldNameNodeInfo.Start(), "%s: field %s is using a reserved name", scope, fld.GetName()); err != nil {
+			if err := handler.HandleErrorf(fieldNameNodeInfo, "%s: field %s is using a reserved name", scope, fld.GetName()); err != nil {
 				return err
 			}
 		}
 		if existing := fieldTags[fld.GetNumber()]; existing != "" {
 			fieldTagNodeInfo := res.file.NodeInfo(fn.FieldTag())
-			if err := handler.HandleErrorf(fieldTagNodeInfo.Start(), "%s: fields %s and %s both have the same tag %d", scope, existing, fld.GetName(), fld.GetNumber()); err != nil {
+			if err := handler.HandleErrorf(fieldTagNodeInfo, "%s: fields %s and %s both have the same tag %d", scope, existing, fld.GetName(), fld.GetNumber()); err != nil {
 				return err
 			}
 		}
@@ -243,7 +243,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 		r := sort.Search(len(rsvd), func(index int) bool { return rsvd[index].end > fld.GetNumber() })
 		if r < len(rsvd) && rsvd[r].start <= fld.GetNumber() {
 			fieldTagNodeInfo := res.file.NodeInfo(fn.FieldTag())
-			if err := handler.HandleErrorf(fieldTagNodeInfo.Start(), "%s: field %s is using tag %d which is in reserved range %d to %d", scope, fld.GetName(), fld.GetNumber(), rsvd[r].start, rsvd[r].end-1); err != nil {
+			if err := handler.HandleErrorf(fieldTagNodeInfo, "%s: field %s is using tag %d which is in reserved range %d to %d", scope, fld.GetName(), fld.GetNumber(), rsvd[r].start, rsvd[r].end-1); err != nil {
 				return err
 			}
 		}
@@ -251,7 +251,7 @@ func validateMessage(res *result, syntax syntaxType, name protoreflect.FullName,
 		e := sort.Search(len(exts), func(index int) bool { return exts[index].end > fld.GetNumber() })
 		if e < len(exts) && exts[e].start <= fld.GetNumber() {
 			fieldTagNodeInfo := res.file.NodeInfo(fn.FieldTag())
-			if err := handler.HandleErrorf(fieldTagNodeInfo.Start(), "%s: field %s is using tag %d which is in extension range %d to %d", scope, fld.GetName(), fld.GetNumber(), exts[e].start, exts[e].end-1); err != nil {
+			if err := handler.HandleErrorf(fieldTagNodeInfo, "%s: field %s is using tag %d which is in extension range %d to %d", scope, fld.GetName(), fld.GetNumber(), exts[e].start, exts[e].end-1); err != nil {
 				return err
 			}
 		}
@@ -320,7 +320,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 	if len(ed.Value) == 0 {
 		enNode := res.EnumNode(ed)
 		enNodeInfo := res.file.NodeInfo(enNode)
-		if err := handler.HandleErrorf(enNodeInfo.Start(), "%s: enums must define at least one value", scope); err != nil {
+		if err := handler.HandleErrorf(enNodeInfo, "%s: enums must define at least one value", scope); err != nil {
 			return err
 		}
 	}
@@ -347,7 +347,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 		if !valid {
 			optNode := res.OptionNode(allowAliasOpt)
 			optNodeInfo := res.file.NodeInfo(optNode.GetValue())
-			if err := handler.HandleErrorf(optNodeInfo.Start(), "%s: expecting bool value for allow_alias option", scope); err != nil {
+			if err := handler.HandleErrorf(optNodeInfo, "%s: expecting bool value for allow_alias option", scope); err != nil {
 				return err
 			}
 		}
@@ -356,7 +356,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 	if syntax == syntaxProto3 && len(ed.Value) > 0 && ed.Value[0].GetNumber() != 0 {
 		evNode := res.EnumValueNode(ed.Value[0])
 		evNodeInfo := res.file.NodeInfo(evNode.GetNumber())
-		if err := handler.HandleErrorf(evNodeInfo.Start(), "%s: proto3 requires that first value in enum have numeric value of 0", scope); err != nil {
+		if err := handler.HandleErrorf(evNodeInfo, "%s: proto3 requires that first value in enum have numeric value of 0", scope); err != nil {
 			return err
 		}
 	}
@@ -372,7 +372,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 			} else {
 				evNode := res.EnumValueNode(evd)
 				evNodeInfo := res.file.NodeInfo(evNode.GetNumber())
-				if err := handler.HandleErrorf(evNodeInfo.Start(), "%s: values %s and %s both have the same numeric value %d; use allow_alias option if intentional", scope, existing, evd.GetName(), evd.GetNumber()); err != nil {
+				if err := handler.HandleErrorf(evNodeInfo, "%s: values %s and %s both have the same numeric value %d; use allow_alias option if intentional", scope, existing, evd.GetName(), evd.GetNumber()); err != nil {
 					return err
 				}
 			}
@@ -382,7 +382,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 	if allowAlias && !hasAlias {
 		optNode := res.OptionNode(allowAliasOpt)
 		optNodeInfo := res.file.NodeInfo(optNode.GetValue())
-		if err := handler.HandleErrorf(optNodeInfo.Start(), "%s: allow_alias is true but no values are aliases", scope); err != nil {
+		if err := handler.HandleErrorf(optNodeInfo, "%s: allow_alias is true but no values are aliases", scope); err != nil {
 			return err
 		}
 	}
@@ -397,7 +397,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 	for i := 1; i < len(rsvd); i++ {
 		if rsvd[i].start <= rsvd[i-1].end {
 			rangeNodeInfo := res.file.NodeInfo(rsvd[i].node)
-			if err := handler.HandleErrorf(rangeNodeInfo.Start(), "%s: reserved ranges overlap: %d to %d and %d to %d", scope, rsvd[i-1].start, rsvd[i-1].end, rsvd[i].start, rsvd[i].end); err != nil {
+			if err := handler.HandleErrorf(rangeNodeInfo, "%s: reserved ranges overlap: %d to %d and %d to %d", scope, rsvd[i-1].start, rsvd[i-1].end, rsvd[i].start, rsvd[i].end); err != nil {
 				return err
 			}
 		}
@@ -411,7 +411,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 		if !isIdentifier(n) {
 			node := findEnumReservedNameNode(res.EnumNode(ed), n)
 			nodeInfo := res.file.NodeInfo(node)
-			if err := handler.HandleErrorf(nodeInfo.Start(), "%s: reserved name %q is not a valid identifier", scope, n); err != nil {
+			if err := handler.HandleErrorf(nodeInfo, "%s: reserved name %q is not a valid identifier", scope, n); err != nil {
 				return err
 			}
 		}
@@ -421,7 +421,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 		evn := res.EnumValueNode(ev)
 		if _, ok := rsvdNames[ev.GetName()]; ok {
 			enumValNodeInfo := res.file.NodeInfo(evn.GetName())
-			if err := handler.HandleErrorf(enumValNodeInfo.Start(), "%s: value %s is using a reserved name", scope, ev.GetName()); err != nil {
+			if err := handler.HandleErrorf(enumValNodeInfo, "%s: value %s is using a reserved name", scope, ev.GetName()); err != nil {
 				return err
 			}
 		}
@@ -429,7 +429,7 @@ func validateEnum(res *result, syntax syntaxType, name protoreflect.FullName, ed
 		r := sort.Search(len(rsvd), func(index int) bool { return rsvd[index].end >= ev.GetNumber() })
 		if r < len(rsvd) && rsvd[r].start <= ev.GetNumber() {
 			enumValNodeInfo := res.file.NodeInfo(evn.GetNumber())
-			if err := handler.HandleErrorf(enumValNodeInfo.Start(), "%s: value %s is using number %d which is in reserved range %d to %d", scope, ev.GetName(), ev.GetNumber(), rsvd[r].start, rsvd[r].end); err != nil {
+			if err := handler.HandleErrorf(enumValNodeInfo, "%s: value %s is using number %d which is in reserved range %d to %d", scope, ev.GetName(), ev.GetNumber(), rsvd[r].start, rsvd[r].end); err != nil {
 				return err
 			}
 		}
@@ -459,19 +459,19 @@ func validateField(res *result, syntax syntaxType, name protoreflect.FullName, f
 	if syntax != syntaxProto2 {
 		if fld.GetType() == descriptorpb.FieldDescriptorProto_TYPE_GROUP {
 			groupNodeInfo := res.file.NodeInfo(node.GetGroupKeyword())
-			if err := handler.HandleErrorf(groupNodeInfo.Start(), "%s: groups are not allowed in proto3 or editions", scope); err != nil {
+			if err := handler.HandleErrorf(groupNodeInfo, "%s: groups are not allowed in proto3 or editions", scope); err != nil {
 				return err
 			}
 		} else if fld.Label != nil && fld.GetLabel() == descriptorpb.FieldDescriptorProto_LABEL_REQUIRED {
 			fieldLabelNodeInfo := res.file.NodeInfo(node.FieldLabel())
-			if err := handler.HandleErrorf(fieldLabelNodeInfo.Start(), "%s: label 'required' is not allowed in proto3 or editions", scope); err != nil {
+			if err := handler.HandleErrorf(fieldLabelNodeInfo, "%s: label 'required' is not allowed in proto3 or editions", scope); err != nil {
 				return err
 			}
 		}
 		if syntax == syntaxEditions {
 			if fld.Label != nil && fld.GetLabel() == descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL {
 				fieldLabelNodeInfo := res.file.NodeInfo(node.FieldLabel())
-				if err := handler.HandleErrorf(fieldLabelNodeInfo.Start(), "%s: label 'optional' is not allowed in editions; use option features.field_presence instead", scope); err != nil {
+				if err := handler.HandleErrorf(fieldLabelNodeInfo, "%s: label 'optional' is not allowed in editions; use option features.field_presence instead", scope); err != nil {
 					return err
 				}
 			}
@@ -480,7 +480,7 @@ func validateField(res *result, syntax syntaxType, name protoreflect.FullName, f
 			} else if index >= 0 {
 				optNode := res.OptionNode(fld.Options.GetUninterpretedOption()[index])
 				optNameNodeInfo := res.file.NodeInfo(optNode.GetName())
-				if err := handler.HandleErrorf(optNameNodeInfo.Start(), "%s: packed option is not allowed in editions; use option features.repeated_field_encoding instead", scope); err != nil {
+				if err := handler.HandleErrorf(optNameNodeInfo, "%s: packed option is not allowed in editions; use option features.repeated_field_encoding instead", scope); err != nil {
 					return err
 				}
 			}
@@ -490,7 +490,7 @@ func validateField(res *result, syntax syntaxType, name protoreflect.FullName, f
 			} else if index >= 0 {
 				optNode := res.OptionNode(fld.Options.GetUninterpretedOption()[index])
 				optNameNodeInfo := res.file.NodeInfo(optNode.GetName())
-				if err := handler.HandleErrorf(optNameNodeInfo.Start(), "%s: default values are not allowed in proto3", scope); err != nil {
+				if err := handler.HandleErrorf(optNameNodeInfo, "%s: default values are not allowed in proto3", scope); err != nil {
 					return err
 				}
 			}
@@ -498,13 +498,13 @@ func validateField(res *result, syntax syntaxType, name protoreflect.FullName, f
 	} else {
 		if fld.Label == nil && fld.OneofIndex == nil {
 			fieldNameNodeInfo := res.file.NodeInfo(node.FieldName())
-			if err := handler.HandleErrorf(fieldNameNodeInfo.Start(), "%s: field has no label; proto2 requires explicit 'optional' label", scope); err != nil {
+			if err := handler.HandleErrorf(fieldNameNodeInfo, "%s: field has no label; proto2 requires explicit 'optional' label", scope); err != nil {
 				return err
 			}
 		}
 		if fld.GetExtendee() != "" && fld.Label != nil && fld.GetLabel() == descriptorpb.FieldDescriptorProto_LABEL_REQUIRED {
 			fieldLabelNodeInfo := res.file.NodeInfo(node.FieldLabel())
-			if err := handler.HandleErrorf(fieldLabelNodeInfo.Start(), "%s: extension fields cannot be 'required'", scope); err != nil {
+			if err := handler.HandleErrorf(fieldLabelNodeInfo, "%s: extension fields cannot be 'required'", scope); err != nil {
 				return err
 			}
 		}

--- a/reporter/errors.go
+++ b/reporter/errors.go
@@ -30,26 +30,29 @@ var ErrInvalidSource = errors.New("parse failed: invalid proto source")
 // about the location in the file that caused the error.
 type ErrorWithPos interface {
 	error
-	// GetPosition returns the source position that caused the underlying error.
+	// GetPosition returns the start source position that caused the underlying error.
 	GetPosition() ast.SourcePos
+	// GetEndPosition returns the end source position that caused the underlying error.
+	GetEndPosition() ast.SourcePos
 	// Unwrap returns the underlying error.
 	Unwrap() error
 }
 
 // Error creates a new ErrorWithPos from the given error and source position.
-func Error(pos ast.SourcePos, err error) ErrorWithPos {
-	return errorWithSourcePos{pos: pos, underlying: err}
+func Error(span ast.SourceSpan, err error) ErrorWithPos {
+	return errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: err}
 }
 
 // Errorf creates a new ErrorWithPos whose underlying error is created using the
 // given message format and arguments (via fmt.Errorf).
-func Errorf(pos ast.SourcePos, format string, args ...interface{}) ErrorWithPos {
-	return errorWithSourcePos{pos: pos, underlying: fmt.Errorf(format, args...)}
+func Errorf(span ast.SourceSpan, format string, args ...interface{}) ErrorWithPos {
+	return errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: fmt.Errorf(format, args...)}
 }
 
 type errorWithSourcePos struct {
 	underlying error
-	pos        ast.SourcePos
+	startPos   ast.SourcePos
+	endPos     ast.SourcePos
 }
 
 func (e errorWithSourcePos) Error() string {
@@ -58,7 +61,11 @@ func (e errorWithSourcePos) Error() string {
 }
 
 func (e errorWithSourcePos) GetPosition() ast.SourcePos {
-	return e.pos
+	return e.startPos
+}
+
+func (e errorWithSourcePos) GetEndPosition() ast.SourcePos {
+	return e.endPos
 }
 
 func (e errorWithSourcePos) Unwrap() error {

--- a/reporter/errors.go
+++ b/reporter/errors.go
@@ -39,18 +39,18 @@ type ErrorWithPos interface {
 
 // Error creates a new ErrorWithPos from the given error and source position.
 func Error(span ast.SourceSpan, err error) ErrorWithPos {
-	return errorWithSpan{span: span, underlying: err}
+	return errorWithSpan{SourceSpan: span, underlying: err}
 }
 
 // Errorf creates a new ErrorWithPos whose underlying error is created using the
 // given message format and arguments (via fmt.Errorf).
 func Errorf(span ast.SourceSpan, format string, args ...interface{}) ErrorWithPos {
-	return errorWithSpan{span: span, underlying: fmt.Errorf(format, args...)}
+	return errorWithSpan{SourceSpan: span, underlying: fmt.Errorf(format, args...)}
 }
 
 type errorWithSpan struct {
+	ast.SourceSpan
 	underlying error
-	span       ast.SourceSpan
 }
 
 func (e errorWithSpan) Error() string {
@@ -59,15 +59,7 @@ func (e errorWithSpan) Error() string {
 }
 
 func (e errorWithSpan) GetPosition() ast.SourcePos {
-	return e.span.Start()
-}
-
-func (e errorWithSpan) Start() ast.SourcePos {
-	return e.span.Start()
-}
-
-func (e errorWithSpan) End() ast.SourcePos {
-	return e.span.End()
+	return e.Start()
 }
 
 func (e errorWithSpan) Unwrap() error {

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -155,9 +155,9 @@ func (h *Handler) HandleError(err error) error {
 func (h *Handler) HandleErrorWithPos(span ast.SourceSpan, err error) error {
 	if ewp, ok := err.(ErrorWithPos); ok {
 		// replace existing position with given one
-		err = errorWithSpan{span: span, underlying: ewp.Unwrap()}
+		err = errorWithSpan{SourceSpan: span, underlying: ewp.Unwrap()}
 	} else {
-		err = errorWithSpan{span: span, underlying: err}
+		err = errorWithSpan{SourceSpan: span, underlying: err}
 	}
 	return h.HandleError(err)
 }
@@ -194,9 +194,9 @@ func (h *Handler) HandleWarningWithPos(span ast.SourceSpan, err error) {
 	ewp, ok := err.(ErrorWithPos)
 	if ok {
 		// replace existing position with given one
-		ewp = errorWithSpan{span: span, underlying: ewp.Unwrap()}
+		ewp = errorWithSpan{SourceSpan: span, underlying: ewp.Unwrap()}
 	} else {
-		ewp = errorWithSpan{span: span, underlying: err}
+		ewp = errorWithSpan{SourceSpan: span, underlying: err}
 	}
 	h.HandleWarning(ewp)
 }

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -152,12 +152,12 @@ func (h *Handler) HandleError(err error) error {
 // If the handler has already aborted (by returning a non-nil error from a prior
 // call to HandleError or HandleErrorf), that same error is returned and the
 // given error is not reported.
-func (h *Handler) HandleErrorWithPos(pos ast.SourcePos, err error) error {
+func (h *Handler) HandleErrorWithPos(span ast.SourceSpan, err error) error {
 	if ewp, ok := err.(ErrorWithPos); ok {
 		// replace existing position with given one
-		err = errorWithSourcePos{pos: pos, underlying: ewp.Unwrap()}
+		err = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: ewp.Unwrap()}
 	} else {
-		err = errorWithSourcePos{pos: pos, underlying: err}
+		err = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: err}
 	}
 	return h.HandleError(err)
 }
@@ -168,8 +168,8 @@ func (h *Handler) HandleErrorWithPos(pos ast.SourcePos, err error) error {
 // If the handler has already aborted (by returning a non-nil error from a call
 // to HandleError or HandleErrorf), that same error is returned and the given
 // error is not reported.
-func (h *Handler) HandleErrorf(pos ast.SourcePos, format string, args ...interface{}) error {
-	return h.HandleError(Errorf(pos, format, args...))
+func (h *Handler) HandleErrorf(span ast.SourceSpan, format string, args ...interface{}) error {
+	return h.HandleError(Errorf(span, format, args...))
 }
 
 // HandleWarning handles the given warning. This will delegate to the handler's
@@ -190,21 +190,21 @@ func (h *Handler) HandleWarning(err ErrorWithPos) {
 
 // HandleWarningWithPos handles a warning with the given source position. This will
 // delegate to the handler's configured reporter.
-func (h *Handler) HandleWarningWithPos(pos ast.SourcePos, err error) {
+func (h *Handler) HandleWarningWithPos(span ast.SourceSpan, err error) {
 	ewp, ok := err.(ErrorWithPos)
 	if ok {
 		// replace existing position with given one
-		ewp = errorWithSourcePos{pos: pos, underlying: ewp.Unwrap()}
+		ewp = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: ewp.Unwrap()}
 	} else {
-		ewp = errorWithSourcePos{pos: pos, underlying: err}
+		ewp = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: err}
 	}
 	h.HandleWarning(ewp)
 }
 
 // HandleWarningf handles a warning with the given source position, creating the
 // actual error value using the given message format and arguments.
-func (h *Handler) HandleWarningf(pos ast.SourcePos, format string, args ...interface{}) {
-	h.HandleWarning(Errorf(pos, format, args...))
+func (h *Handler) HandleWarningf(span ast.SourceSpan, format string, args ...interface{}) {
+	h.HandleWarning(Errorf(span, format, args...))
 }
 
 // Error returns the handler result. If any errors have been reported then this

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -155,9 +155,9 @@ func (h *Handler) HandleError(err error) error {
 func (h *Handler) HandleErrorWithPos(span ast.SourceSpan, err error) error {
 	if ewp, ok := err.(ErrorWithPos); ok {
 		// replace existing position with given one
-		err = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: ewp.Unwrap()}
+		err = errorWithSpan{span: span, underlying: ewp.Unwrap()}
 	} else {
-		err = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: err}
+		err = errorWithSpan{span: span, underlying: err}
 	}
 	return h.HandleError(err)
 }
@@ -194,9 +194,9 @@ func (h *Handler) HandleWarningWithPos(span ast.SourceSpan, err error) {
 	ewp, ok := err.(ErrorWithPos)
 	if ok {
 		// replace existing position with given one
-		ewp = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: ewp.Unwrap()}
+		ewp = errorWithSpan{span: span, underlying: ewp.Unwrap()}
 	} else {
-		ewp = errorWithSourcePos{startPos: span.Start(), endPos: span.End(), underlying: err}
+		ewp = errorWithSpan{span: span, underlying: err}
 	}
 	h.HandleWarning(ewp)
 }


### PR DESCRIPTION
See https://github.com/bufbuild/protocompile/issues/201

This adds a new function to ErrorWithPos.GetEndPosition(), that should will allow IDEs to highlight the entire span that is problematic (instead of just the token found at the start position).