### PR TITLE
The fastscan package should return syntax errors when they are found

### DIFF
--- a/internal/benchmarks/benchmark_test.go
+++ b/internal/benchmarks/benchmark_test.go
@@ -408,7 +408,7 @@ func BenchmarkGoogleapisFastScan(b *testing.B) {
 					if err != nil {
 						return err
 					}
-					res, err := fastscan.Scan(r)
+					res, err := fastscan.Scan(filename, r)
 					_ = r.Close()
 					if err != nil {
 						return err

--- a/parser/fastscan/fastscan.go
+++ b/parser/fastscan/fastscan.go
@@ -15,8 +15,12 @@
 package fastscan
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"strings"
+
+	"github.com/bufbuild/protocompile/ast"
 )
 
 var closeSymbol = map[tokenType]tokenType{
@@ -30,26 +34,115 @@ var closeSymbol = map[tokenType]tokenType{
 // information extracted from the file.
 type Result struct {
 	PackageName string
-	Imports     []string
+	Imports     []Import
+}
+
+// Import represents an import in a Protobuf source file.
+type Import struct {
+	// Path of the imported file.
+	Path string
+	// Indicate if public or weak keyword was used in import statement.
+	IsPublic, IsWeak bool
+}
+
+// SyntaxError is returned from Scan when one or more syntax errors are observed.
+// Scan does not fully parse the source, so there are many kinds of syntax errors
+// that will not be recognized. A full parser should be used to reliably detect
+// errors in the source. But if the scanner happens to see things that are clearly
+// wrong while scanning for the package and imports, it will return them.
+type SyntaxError struct {
+	errs []singleSyntaxError
+}
+
+// Error implements the error interface, returning an error message with the
+// details of the syntax error issues.
+func (e *SyntaxError) Error() string {
+	var buf bytes.Buffer
+	for i := range e.errs {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		buf.WriteString(e.errs[i].Error())
+	}
+	return buf.String()
+}
+
+// Len returns the number of different locations where a syntax error was
+// identified.
+func (e *SyntaxError) Len() int {
+	return len(e.errs)
+}
+
+// Get returns details for a syntax error at a single location.
+func (e *SyntaxError) Get(i int) error {
+	return &e.errs[i]
+}
+
+// GetPosition returns the location in the source file where a syntax error
+// was identified.
+func (e *SyntaxError) GetPosition(i int) ast.SourcePos {
+	return ast.SourcePos{
+		Filename: e.errs[i].filename,
+		Line:     e.errs[i].line,
+		Col:      e.errs[i].col,
+	}
+}
+
+// Unwrap returns an error for each location where a syntax error was
+// identified.
+func (e *SyntaxError) Unwrap() []error {
+	slice := make([]error, len(e.errs))
+	for i := range e.errs {
+		slice[i] = &e.errs[i]
+	}
+	return slice
+}
+
+func newSyntaxError(errs []singleSyntaxError) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return &SyntaxError{errs: errs}
+}
+
+type singleSyntaxError struct {
+	msg       string
+	filename  string
+	line, col int
+}
+
+func (s *singleSyntaxError) Error() string {
+	file := s.filename
+	if file == "" {
+		file = "<input>"
+	}
+	return fmt.Sprintf("%s:%d:%d: %s", file, s.line, s.col, s.msg)
 }
 
 // Scan scans the given reader, which should contain Protobuf source, and
 // returns the set of imports declared in the file. The result also contains the
 // value of any package declaration in the file. It returns an error if there is
-// an I/O error reading from r. In the event of such an error, it will still return
-// a result that contains as much information as was found before the I/O error
-// occurred.
-func Scan(r io.Reader) (Result, error) {
+// an I/O error reading from r or if syntax errors are recognized while scanning.
+// In the event of such an error, it will still return a result that contains as
+// much information as was found (either before the I/O error occurred, or all
+// that could be parsed despite syntax errors). The results are not necessarily
+// valid, in that the parsed package name might not be a legal package name in
+// protobuf or the imports may not refer to valid paths. Full validation of the
+// source should be done using a full parser.
+func Scan(filename string, r io.Reader) (Result, error) {
 	var res Result
 
 	var currentImport []string     // if non-nil, parsing an import statement
+	var isPublic, isWeak bool      // if public or weak keyword observed in current import statement
 	var packageComponents []string // if non-nil, parsing a package statement
+	var syntaxErrs []singleSyntaxError
 
 	// current stack of open blocks -- those starting with {, [, (, or < for
 	// which we haven't yet encountered the closing }, ], ), or >
 	var contextStack []tokenType
 	declarationStart := true
 
+	var prevLine, prevCol int
 	lexer := newLexer(r)
 	for {
 		token, text, err := lexer.Lex()
@@ -57,16 +150,42 @@ func Scan(r io.Reader) (Result, error) {
 			return res, err
 		}
 		if token == eofToken {
-			return res, nil
+			return res, newSyntaxError(syntaxErrs)
 		}
 
 		if currentImport != nil {
 			switch token {
 			case stringToken:
 				currentImport = append(currentImport, text.(string))
+			case identifierToken:
+				ident := text.(string) //nolint:errcheck
+				if len(currentImport) == 0 && (ident == "public" || ident == "weak") {
+					isPublic = ident == "public"
+					isWeak = ident == "weak"
+					break
+				}
+				fallthrough
 			default:
 				if len(currentImport) > 0 {
-					res.Imports = append(res.Imports, strings.Join(currentImport, ""))
+					if token != semicolonToken {
+						syntaxErrs = append(syntaxErrs, singleSyntaxError{
+							msg:  fmt.Sprintf("unexpected %s; expecting semicolon", token.describe()),
+							line: lexer.prevTokenLine + 1,
+							col:  lexer.prevTokenCol + 1,
+						})
+					}
+					res.Imports = append(res.Imports, Import{
+						Path:     strings.Join(currentImport, ""),
+						IsPublic: isPublic,
+						IsWeak:   isWeak,
+					})
+				} else {
+					syntaxErrs = append(syntaxErrs, singleSyntaxError{
+						msg:      fmt.Sprintf("unexpected %s; expecting import path string", token.describe()),
+						filename: filename,
+						line:     lexer.prevTokenLine + 1,
+						col:      lexer.prevTokenCol + 1,
+					})
 				}
 				currentImport = nil
 			}
@@ -75,12 +194,52 @@ func Scan(r io.Reader) (Result, error) {
 		if packageComponents != nil {
 			switch token {
 			case identifierToken:
+				if len(packageComponents) > 0 && packageComponents[len(packageComponents)-1] != "." {
+					syntaxErrs = append(syntaxErrs, singleSyntaxError{
+						msg:  "package name should have a period between name components",
+						line: lexer.prevTokenLine + 1,
+						col:  lexer.prevTokenCol + 1,
+					})
+				}
 				packageComponents = append(packageComponents, text.(string))
 			case periodToken:
+				if len(packageComponents) == 0 {
+					syntaxErrs = append(syntaxErrs, singleSyntaxError{
+						msg:  "package name should not begin with a period",
+						line: lexer.prevTokenLine + 1,
+						col:  lexer.prevTokenCol + 1,
+					})
+				} else if packageComponents[len(packageComponents)-1] == "." {
+					syntaxErrs = append(syntaxErrs, singleSyntaxError{
+						msg:  "package name should not have two periods in a row",
+						line: lexer.prevTokenLine + 1,
+						col:  lexer.prevTokenCol + 1,
+					})
+				}
 				packageComponents = append(packageComponents, ".")
 			default:
 				if len(packageComponents) > 0 {
+					if token != semicolonToken {
+						syntaxErrs = append(syntaxErrs, singleSyntaxError{
+							msg:  fmt.Sprintf("unexpected %s; expecting semicolon", token.describe()),
+							line: lexer.prevTokenLine + 1,
+							col:  lexer.prevTokenCol + 1,
+						})
+					}
+					if packageComponents[len(packageComponents)-1] == "." {
+						syntaxErrs = append(syntaxErrs, singleSyntaxError{
+							msg:  "package name should not end with a period",
+							line: prevLine + 1,
+							col:  prevCol + 1,
+						})
+					}
 					res.PackageName = strings.Join(packageComponents, "")
+				} else {
+					syntaxErrs = append(syntaxErrs, singleSyntaxError{
+						msg:  fmt.Sprintf("unexpected %s; expecting package name", token.describe()),
+						line: lexer.prevTokenLine + 1,
+						col:  lexer.prevTokenCol + 1,
+					})
 				}
 				packageComponents = nil
 			}
@@ -97,6 +256,7 @@ func Scan(r io.Reader) (Result, error) {
 			if declarationStart && len(contextStack) == 0 {
 				if text == "import" {
 					currentImport = []string{}
+					isPublic, isWeak = false, false
 				} else if text == "package" {
 					packageComponents = []string{}
 				}
@@ -104,5 +264,6 @@ func Scan(r io.Reader) (Result, error) {
 		}
 
 		declarationStart = token == closeBraceToken || token == semicolonToken
+		prevLine, prevCol = lexer.prevTokenLine, lexer.prevTokenCol
 	}
 }

--- a/parser/fastscan/fastscan_test.go
+++ b/parser/fastscan/fastscan_test.go
@@ -1,0 +1,185 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastscan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name            string
+		input           string
+		expectedImports []Import
+		expectedPackage string
+		expectedErrors  []string
+	}{
+		{
+			name: "simple",
+			input: `syntax = "proto2";
+				package abc.xyz;
+				import "foo/bar/baz.proto";
+				import "google/protobuf/descriptor.proto";
+				import "xyz/123.proto";
+				message Foo {}
+				service Bar { rpc Baz(Foo) returns (Foo); }
+			`,
+			expectedImports: []Import{
+				{Path: "foo/bar/baz.proto"},
+				{Path: "google/protobuf/descriptor.proto"},
+				{Path: "xyz/123.proto"},
+			},
+			expectedPackage: "abc.xyz",
+		},
+		{
+			name: "out of order",
+			input: `syntax = "proto2";
+				import "foo/bar/baz.proto";
+				message Foo {}
+				import "google/protobuf/descriptor.proto";
+				service Bar { rpc Baz(Foo) returns (Foo); }
+				import "xyz/123.proto";
+				package abc.xyz;
+			`,
+			expectedImports: []Import{
+				{Path: "foo/bar/baz.proto"},
+				{Path: "google/protobuf/descriptor.proto"},
+				{Path: "xyz/123.proto"},
+			},
+			expectedPackage: "abc.xyz",
+		},
+		{
+			name: "last package wins",
+			input: `syntax = "proto2";
+				package foo.bar;
+				message Foo {}
+				package abc.xyz;
+			`,
+			expectedImports: nil,
+			expectedPackage: "abc.xyz",
+		},
+		{
+			name: "syntax errors prevent parsing some imports",
+			input: `syntax = "proto2";
+				package abc.xyz;
+				import "foo/bar/baz.proto":
+				import "google/protobuf/descriptor.proto":
+				import "xyz/123.proto";
+				message Foo {}
+				service Bar { rpc Baz(Foo) returns (Foo); }
+			`,
+			expectedImports: []Import{
+				{Path: "foo/bar/baz.proto"},
+			},
+			expectedPackage: "abc.xyz",
+			expectedErrors: []string{
+				`<input>:3:59: unexpected ':'; expecting semicolon`,
+			},
+		},
+		{
+			name: "syntax errors imports",
+			input: `syntax = "proto2";
+				import "foo/bar/baz.proto";
+				import "xyz/123.proto"
+				message Foo {}
+				import "google/protobuf/descriptor.proto":
+				service Bar { rpc Baz(Foo) returns (Foo); }
+				import foo "blah/blah/blah.proto";
+			`,
+			expectedImports: []Import{
+				{Path: "foo/bar/baz.proto"},
+				{Path: "xyz/123.proto"},
+				{Path: "google/protobuf/descriptor.proto"},
+			},
+			expectedPackage: "",
+			expectedErrors: []string{
+				`<input>:4:33: unexpected identifier; expecting semicolon`,
+				`<input>:5:74: unexpected ':'; expecting semicolon`,
+				`<input>:7:40: unexpected identifier; expecting import path string`,
+			},
+		},
+		{
+			name: "syntax errors package",
+			input: `syntax = "proto3";
+				package .abc.xyz;
+				package "abc.com";
+				package abc.com. ;
+				package foo.bar 123
+				message Foo {}
+				package foo . . bar;
+				package foo bar;
+				package foo . bar;
+			`,
+			expectedImports: nil,
+			expectedPackage: "foo.bar",
+			expectedErrors: []string{
+				`<input>:2:41: package name should not begin with a period`,
+				`<input>:3:41: unexpected string literal; expecting package name`,
+				`<input>:4:48: package name should not end with a period`,
+				`<input>:5:49: unexpected numeric literal; expecting semicolon`,
+				`<input>:7:47: package name should not have two periods in a row`,
+				`<input>:8:45: package name should have a period between name components`,
+			},
+		},
+		{
+			name: "nothing",
+			input: `syntax = "proto2";
+				message Foo {}
+			`,
+			expectedImports: nil,
+			expectedPackage: "",
+		},
+		{
+			name: "public and weak imports",
+			input: `syntax = "proto2";
+				package abc.xyz;
+				import public "foo/bar/baz.proto";
+				import weak "google/protobuf/descriptor.proto";
+			`,
+			expectedImports: []Import{
+				{Path: "foo/bar/baz.proto", IsPublic: true},
+				{Path: "google/protobuf/descriptor.proto", IsWeak: true},
+			},
+			expectedPackage: "abc.xyz",
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := Scan("", strings.NewReader(testCase.input))
+			assert.Equal(t, testCase.expectedPackage, result.PackageName)
+			assert.Equal(t, testCase.expectedImports, result.Imports)
+			if len(testCase.expectedErrors) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			var syntaxErr *SyntaxError
+			require.ErrorAs(t, err, &syntaxErr)
+			assert.Len(t, testCase.expectedErrors, syntaxErr.Len())
+			for i := 0; i < len(testCase.expectedErrors) && i < syntaxErr.Len(); i++ {
+				// Not using require here because we want to accumulate info about other errors
+				// instead of failing fast.
+				//nolint:testifylint
+				assert.ErrorContains(t, syntaxErr.Get(i), testCase.expectedErrors[i])
+			}
+		})
+	}
+}

--- a/parser/fastscan/fastscan_test.go
+++ b/parser/fastscan/fastscan_test.go
@@ -171,14 +171,14 @@ func TestScan(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			var syntaxErr *SyntaxError
+			var syntaxErr SyntaxError
 			require.ErrorAs(t, err, &syntaxErr)
-			assert.Len(t, testCase.expectedErrors, syntaxErr.Len())
-			for i := 0; i < len(testCase.expectedErrors) && i < syntaxErr.Len(); i++ {
+			assert.Len(t, syntaxErr, len(testCase.expectedErrors))
+			for i := 0; i < len(testCase.expectedErrors) && i < len(syntaxErr); i++ {
 				// Not using require here because we want to accumulate info about other errors
 				// instead of failing fast.
 				//nolint:testifylint
-				assert.ErrorContains(t, syntaxErr.Get(i), testCase.expectedErrors[i])
+				assert.ErrorContains(t, syntaxErr[i], testCase.expectedErrors[i])
 			}
 		})
 	}


### PR DESCRIPTION
This means the lexer should track source positions for better error messages when reporting syntax errors.

This also adds tests for the fastscan package. The new syntax error checks caught a bug in the scanner: it was failing to correctly process public and weak imports. So that is fixed in this PR, too.