### PR TITLE
More precise "go generate" directive

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -25,7 +25,8 @@ import (
 	"github.com/bufbuild/protocompile/reporter"
 )
 
-//go:generate goyacc -o proto.y.go -l -p proto proto.y
+// The path ../.tmp/bin/goyacc is built when using `make generate` from repo root.
+//go:generate ../.tmp/bin/goyacc -o proto.y.go -l -p proto proto.y
 
 func init() {
 	protoErrorVerbose = true


### PR DESCRIPTION
The path to `goyacc` relies on `$PATH` but should more precisely refer to the version built by the `Makefile`.