### PR TITLE
Remove space for error string in errorWithSpan

### DIFF
--- a/reporter/errors.go
+++ b/reporter/errors.go
@@ -55,7 +55,7 @@ type errorWithSpan struct {
 
 func (e errorWithSpan) Error() string {
 	sourcePos := e.GetPosition()
-	return fmt.Sprintf("%s: %v", sourcePos, e.underlying)
+	return fmt.Sprintf("%s:%v", sourcePos, e.underlying)
 }
 
 func (e errorWithSpan) GetPosition() ast.SourcePos {


### PR DESCRIPTION
This more generally matches the output that linting tools expect, i.e.`PATH:LINE:COLUMN:MESSAGE`.