### PR TITLE
Proposal: Support linking with dynamic resolution

### DIFF
--- a/linker/descriptors.go
+++ b/linker/descriptors.go
@@ -141,7 +141,7 @@ type result struct {
 	protoreflect.FileDescriptor
 	parser.Result
 	prefix string
-	deps   Files
+	deps   Dependencies
 
 	// A map of all descriptors keyed by their fully-qualified name (without
 	// any leading dot).

--- a/linker/files.go
+++ b/linker/files.go
@@ -145,6 +145,11 @@ func (f *file) FindExtensionByNumber(msg protoreflect.FullName, tag protoreflect
 
 var _ File = (*file)(nil)
 
+// Dependencies represents a set of protobuf files.
+type Dependencies interface {
+	FindFileByPath(path string) File
+}
+
 // Files represents a set of protobuf files. It is a slice of File values, but
 // also provides a method for easily looking up files by path and name.
 type Files []File
@@ -169,6 +174,8 @@ func (f Files) FindFileByPath(path string) File {
 func (f Files) AsResolver() Resolver {
 	return filesResolver(f)
 }
+
+var _ Dependencies = Files{}
 
 // Resolver is an interface that can resolve various kinds of queries about
 // descriptors. It satisfies the resolver interfaces defined in protodesc

--- a/linker/linker.go
+++ b/linker/linker.go
@@ -41,6 +41,24 @@ import (
 // Note that linking does NOT interpret options. So options messages in the
 // returned value have all values stored in UninterpretedOptions fields.
 func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *reporter.Handler) (Result, error) {
+	return linkAny(parsed, dependencies, symbols, handler)
+}
+
+// LinkDynamic handles linking a parsed descriptor proto into a fully-linked descriptor.
+// If the given parser.Result has imports, they must all be resolvable in the given
+// dependencies.
+//
+// The handler value is used to report any link errors. If any such errors are
+// reported, this function returns a non-nil error. The Result value returned
+// also implements protoreflect.FileDescriptor.
+//
+// Note that linking does NOT interpret options. So options messages in the
+// returned value have all values stored in UninterpretedOptions fields.
+func LinkDynamic(parsed parser.Result, dependencies Dependencies, handler *reporter.Handler) (Result, error) {
+	return linkAny(parsed, dependencies, nil, handler)
+}
+
+func linkAny(parsed parser.Result, dependencies Dependencies, symbols *Symbols, handler *reporter.Handler) (Result, error) {
 	if symbols == nil {
 		symbols = &Symbols{}
 	}


### PR DESCRIPTION
This PR is a proposal to support dynamic resolution of dependencies in `linker`. It is possible to do so with relatively minor changes without api breakage.


It adds linker.LinkDynamic, which supports lookups at runtime and does not depend on a predefined `File` slice.

A new function was added to stay source compatible, otherwise a call with `[]File` would break the api.
It drops the `*Symbols` parameter, as they are usually not known in this use case.

To support reuse of symbols in `compile.go`, a type assertion was added that uses the relevant function for linking.