### PR TITLE
linker: support editions in linker descriptors

### DIFF
--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -2386,7 +2386,7 @@ func TestProto3Enums(t *testing.T) {
 			}
 			_, err := compiler.Compile(context.Background(), "f1.proto", "f2.proto")
 			if o1 != o2 && o2 == "proto3" {
-				expected := "f2.proto:1:54: field foo.bar: cannot use proto2 enum bar in a proto3 message"
+				expected := "f2.proto:1:54: field foo.bar: cannot use enum with closed semantics bar in a proto3 message"
 				if err == nil {
 					t.Errorf("expecting validation error; instead got no error")
 				} else if err.Error() != expected {

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -395,10 +395,14 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 		f.msgType = dsc
 	case protoreflect.EnumDescriptor:
 		proto3 := r.Syntax() == protoreflect.Proto3
-		enumIsProto3 := dsc.Syntax() == protoreflect.Proto3
-		if fld.GetExtendee() == "" && proto3 && !enumIsProto3 {
-			// fields in a proto3 message cannot refer to proto2 enums
-			return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: cannot use proto2 enum %s in a proto3 message", scope, fld.GetTypeName())
+		enumIsClosed := dsc.IsClosed()
+		if fld.GetExtendee() == "" && proto3 && enumIsClosed {
+			// fields in a proto3 message cannot refer to closed enums
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s: cannot use enum with closed semantics %s in a proto3 message", scope, fld.GetTypeName())
+		}
+		if f.Cardinality() == protoreflect.Optional && !f.HasPresence() && enumIsClosed {
+			// fields in a proto3 message cannot refer to closed enums
+			return handler.HandleErrorf(file.NodeInfo(node.FieldType()), "%s.%s: implicit fields may only used enums with open semantics", scope, fld.GetTypeName())
 		}
 		typeName := "." + string(dsc.FullName())
 		if fld.GetTypeName() != typeName {

--- a/linker/symbols_test.go
+++ b/linker/symbols_test.go
@@ -205,7 +205,7 @@ func parseAndLink(t *testing.T, contents string) Result {
 	depAsFile, err := NewFileRecursive(dep)
 	require.NoError(t, err)
 	depFiles := Files{depAsFile}
-	linkResult, err := Link(parseResult, depFiles, nil, h)
+	linkResult, err := Link(parseResult, parseResult, depFiles, nil, h)
 	require.NoError(t, err)
 	return linkResult
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -391,8 +391,8 @@ func TestOptionsEncoding(t *testing.T) {
 			uOpts := proto.UnmarshalOptions{Resolver: linker.ResolverFromFile(fds[0])}
 			err = uOpts.Unmarshal(protoData, canonicalProto)
 			require.NoError(t, err)
-			if !proto.Equal(res.FileDescriptorProto(), canonicalProto) {
-				t.Fatal("canonical proto != proto")
+			if diff := cmp.Diff(res.FileDescriptorProto(), canonicalProto, protocmp.Transform()); diff != "" {
+				t.Fatal("canonical proto != proto:\n%v", diff)
 			}
 
 			// drum roll... make sure the bytes match the protoc output


### PR DESCRIPTION
Open questions:

* Is there a better way to resolve the options. At the moment we clone the parse result which feels extremely expensive.
* Is generating the full google.golang.org/protobuf descriptors in the linker a performance issue?
* Can we get rid of the noOpDescriptors completely or are there cases where the google.golang.org/protobuf descriptor validation is stricter than what protocompile allows?

This is very much work in progress and I would like to have feedback on how to move forward.

This commit does not yet work as it requires an update to google.golang.org/protobuf. Once we agreed on the direction of this change, I'm going to make the necessary changes to google.golang.org/protobuf.