### PR TITLE
Support extension declarations

### DIFF
--- a/ast/enum.go
+++ b/ast/enum.go
@@ -102,7 +102,7 @@ var _ EnumElement = (*EmptyDeclNode)(nil)
 // enum values. This allows NoSourceNode to be used in place of *EnumValueNode
 // for some usages.
 type EnumValueDeclNode interface {
-	NodeWithCompactOptions
+	NodeWithOptions
 	GetName() Node
 	GetNumber() Node
 }
@@ -176,7 +176,7 @@ func (e *EnumValueNode) GetNumber() Node {
 	return e.Number
 }
 
-func (e *EnumValueNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+func (e *EnumValueNode) RangeOptions(fn func(*OptionNode) bool) {
 	for _, opt := range e.Options.Options {
 		if !fn(opt) {
 			return

--- a/ast/enum.go
+++ b/ast/enum.go
@@ -76,6 +76,16 @@ func NewEnumNode(keyword *KeywordNode, name *IdentNode, openBrace *RuneNode, dec
 	}
 }
 
+func (n *EnumNode) RangeOptions(fn func(*OptionNode) bool) {
+	for _, decl := range n.Decls {
+		if opt, ok := decl.(*OptionNode); ok {
+			if !fn(opt) {
+				return
+			}
+		}
+	}
+}
+
 // EnumElement is an interface implemented by all AST nodes that can
 // appear in the body of an enum declaration.
 type EnumElement interface {
@@ -92,7 +102,7 @@ var _ EnumElement = (*EmptyDeclNode)(nil)
 // enum values. This allows NoSourceNode to be used in place of *EnumValueNode
 // for some usages.
 type EnumValueDeclNode interface {
-	Node
+	NodeWithCompactOptions
 	GetName() Node
 	GetNumber() Node
 }
@@ -164,4 +174,12 @@ func (e *EnumValueNode) GetName() Node {
 
 func (e *EnumValueNode) GetNumber() Node {
 	return e.Number
+}
+
+func (e *EnumValueNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+	for _, opt := range e.Options.Options {
+		if !fn(opt) {
+			return
+		}
+	}
 }

--- a/ast/field.go
+++ b/ast/field.go
@@ -27,7 +27,7 @@ import "fmt"
 // This also allows NoSourceNode and SyntheticMapField to be used in place of
 // one of the above for some usages.
 type FieldDeclNode interface {
-	NodeWithCompactOptions
+	NodeWithOptions
 	FieldLabel() Node
 	FieldName() Node
 	FieldType() Node
@@ -172,7 +172,7 @@ func (n *FieldNode) GetOptions() *CompactOptionsNode {
 	return n.Options
 }
 
-func (n *FieldNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+func (n *FieldNode) RangeOptions(fn func(*OptionNode) bool) {
 	for _, opt := range n.Options.Options {
 		if !fn(opt) {
 			return
@@ -346,7 +346,7 @@ func (n *GroupNode) GetOptions() *CompactOptionsNode {
 	return n.Options
 }
 
-func (n *GroupNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+func (n *GroupNode) RangeOptions(fn func(*OptionNode) bool) {
 	for _, opt := range n.Options.Options {
 		if !fn(opt) {
 			return
@@ -354,11 +354,23 @@ func (n *GroupNode) RangeCompactOptions(fn func(*OptionNode) bool) {
 	}
 }
 
-func (n *GroupNode) MessageName() Node {
+func (n *GroupNode) AsMessage() *SyntheticGroupMessageNode {
+	return (*SyntheticGroupMessageNode)(n)
+}
+
+// SyntheticGroupMessageNode is a view of a GroupNode that implements MessageDeclNode.
+// Since a group field implicitly defines a message type, this node represents
+// that message type while the corresponding GroupNode represents the field.
+//
+// This type is considered synthetic since it never appears in a file's AST, but
+// is only returned from other accessors (e.g. GroupNode.AsMessage).
+type SyntheticGroupMessageNode GroupNode
+
+func (n *SyntheticGroupMessageNode) MessageName() Node {
 	return n.Name
 }
 
-func (n *GroupNode) RangeOptions(fn func(*OptionNode) bool) {
+func (n *SyntheticGroupMessageNode) RangeOptions(fn func(*OptionNode) bool) {
 	for _, decl := range n.Decls {
 		if opt, ok := decl.(*OptionNode); ok {
 			if !fn(opt) {
@@ -479,7 +491,11 @@ var _ OneofElement = (*EmptyDeclNode)(nil)
 
 // SyntheticOneof is not an actual node in the AST but a synthetic node
 // that represents the oneof implied by a proto3 optional field.
+//
+// This type is considered synthetic since it never appears in a file's AST,
+// but is only returned from other functions (e.g. NewSyntheticOneof).
 type SyntheticOneof struct {
+	// The proto3 optional field that implies the presence of this oneof.
 	Field *FieldNode
 }
 
@@ -670,7 +686,7 @@ func (n *MapFieldNode) GetOptions() *CompactOptionsNode {
 	return n.Options
 }
 
-func (n *MapFieldNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+func (n *MapFieldNode) RangeOptions(fn func(*OptionNode) bool) {
 	for _, opt := range n.Options.Options {
 		if !fn(opt) {
 			return
@@ -678,11 +694,8 @@ func (n *MapFieldNode) RangeCompactOptions(fn func(*OptionNode) bool) {
 	}
 }
 
-func (n *MapFieldNode) MessageName() Node {
-	return n.Name
-}
-
-func (n *MapFieldNode) RangeOptions(_ func(*OptionNode) bool) {
+func (n *MapFieldNode) AsMessage() *SyntheticMapEntryNode {
+	return (*SyntheticMapEntryNode)(n)
 }
 
 func (n *MapFieldNode) KeyField() *SyntheticMapField {
@@ -693,9 +706,28 @@ func (n *MapFieldNode) ValueField() *SyntheticMapField {
 	return NewSyntheticMapField(n.MapType.ValueType, 2)
 }
 
+// SyntheticMapEntryNode is a view of a MapFieldNode that implements MessageDeclNode.
+// Since a map field implicitly defines a message type for the map entry,
+// this node represents that message type.
+//
+// This type is considered synthetic since it never appears in a file's AST, but
+// is only returned from other accessors (e.g. MapFieldNode.AsMessage).
+type SyntheticMapEntryNode MapFieldNode
+
+func (n *SyntheticMapEntryNode) MessageName() Node {
+	return n.Name
+}
+
+func (n *SyntheticMapEntryNode) RangeOptions(_ func(*OptionNode) bool) {
+}
+
 // SyntheticMapField is not an actual node in the AST but a synthetic node
 // that implements FieldDeclNode. These are used to represent the implicit
 // field declarations of the "key" and "value" fields in a map entry.
+//
+// This type is considered synthetic since it never appears in a file's AST,
+// but is only returned from other accessors and functions (e.g.
+// MapFieldNode.KeyField, MapFieldNode.ValueField, and NewSyntheticMapField).
 type SyntheticMapField struct {
 	Ident IdentValueNode
 	Tag   *UintLiteralNode
@@ -759,5 +791,5 @@ func (n *SyntheticMapField) GetOptions() *CompactOptionsNode {
 	return nil
 }
 
-func (n *SyntheticMapField) RangeCompactOptions(_ func(*OptionNode) bool) {
+func (n *SyntheticMapField) RangeOptions(_ func(*OptionNode) bool) {
 }

--- a/ast/file.go
+++ b/ast/file.go
@@ -19,7 +19,7 @@ import "fmt"
 // FileDeclNode is a placeholder interface for AST nodes that represent files.
 // This allows NoSourceNode to be used in place of *FileNode for some usages.
 type FileDeclNode interface {
-	Node
+	NodeWithOptions
 	Name() string
 	NodeInfo(n Node) NodeInfo
 }
@@ -134,6 +134,16 @@ func (f *FileNode) Items() Sequence[Item] {
 
 func (f *FileNode) Tokens() Sequence[Token] {
 	return f.fileInfo.Tokens()
+}
+
+func (f *FileNode) RangeOptions(fn func(*OptionNode) bool) {
+	for _, decl := range f.Decls {
+		if opt, ok := decl.(*OptionNode); ok {
+			if !fn(opt) {
+				return
+			}
+		}
+	}
 }
 
 // FileElement is an interface implemented by all AST nodes that are

--- a/ast/message.go
+++ b/ast/message.go
@@ -19,8 +19,8 @@ import "fmt"
 // MessageDeclNode is a node in the AST that defines a message type. This
 // includes normal message fields as well as implicit messages:
 //   - *MessageNode
-//   - *GroupNode (the group is a field and inline message type)
-//   - *MapFieldNode (map fields implicitly define a MapEntry message type)
+//   - *SyntheticGroupMessageNode (the group is a field and inline message type)
+//   - *SyntheticMapEntryNode (map fields implicitly define a MapEntry message type)
 //
 // This also allows NoSourceNode to be used in place of one of the above
 // for some usages.
@@ -30,8 +30,8 @@ type MessageDeclNode interface {
 }
 
 var _ MessageDeclNode = (*MessageNode)(nil)
-var _ MessageDeclNode = (*GroupNode)(nil)
-var _ MessageDeclNode = (*MapFieldNode)(nil)
+var _ MessageDeclNode = (*SyntheticGroupMessageNode)(nil)
+var _ MessageDeclNode = (*SyntheticMapEntryNode)(nil)
 var _ MessageDeclNode = NoSourceNode{}
 
 // MessageNode represents a message declaration. Example:

--- a/ast/message.go
+++ b/ast/message.go
@@ -25,7 +25,7 @@ import "fmt"
 // This also allows NoSourceNode to be used in place of one of the above
 // for some usages.
 type MessageDeclNode interface {
-	Node
+	NodeWithOptions
 	MessageName() Node
 }
 
@@ -90,6 +90,16 @@ func NewMessageNode(keyword *KeywordNode, name *IdentNode, openBrace *RuneNode, 
 
 func (n *MessageNode) MessageName() Node {
 	return n.Name
+}
+
+func (n *MessageNode) RangeOptions(fn func(*OptionNode) bool) {
+	for _, decl := range n.Decls {
+		if opt, ok := decl.(*OptionNode); ok {
+			if !fn(opt) {
+				return
+			}
+		}
+	}
 }
 
 // MessageBody represents the body of a message. It is used by both

--- a/ast/no_source.go
+++ b/ast/no_source.go
@@ -124,6 +124,10 @@ func (n NoSourceNode) MessageName() Node {
 	return n
 }
 
+func (n NoSourceNode) OneofName() Node {
+	return n
+}
+
 func (n NoSourceNode) GetInputType() Node {
 	return n
 }
@@ -134,4 +138,10 @@ func (n NoSourceNode) GetOutputType() Node {
 
 func (n NoSourceNode) Value() interface{} {
 	return nil
+}
+
+func (n NoSourceNode) RangeCompactOptions(func(*OptionNode) bool) {
+}
+
+func (n NoSourceNode) RangeOptions(func(*OptionNode) bool) {
 }

--- a/ast/no_source.go
+++ b/ast/no_source.go
@@ -140,8 +140,5 @@ func (n NoSourceNode) Value() interface{} {
 	return nil
 }
 
-func (n NoSourceNode) RangeCompactOptions(func(*OptionNode) bool) {
-}
-
 func (n NoSourceNode) RangeOptions(func(*OptionNode) bool) {
 }

--- a/ast/options.go
+++ b/ast/options.go
@@ -407,30 +407,7 @@ var _ NodeWithOptions = OneofDeclNode(nil)
 var _ NodeWithOptions = (*EnumNode)(nil)
 var _ NodeWithOptions = (*ServiceNode)(nil)
 var _ NodeWithOptions = RPCDeclNode(nil)
+var _ NodeWithOptions = FieldDeclNode(nil)
+var _ NodeWithOptions = EnumValueDeclNode(nil)
+var _ NodeWithOptions = (*ExtensionRangeNode)(nil)
 var _ NodeWithOptions = NoSourceNode{}
-
-// NodeWithCompactOptions represents a node in the AST that contains
-// compact options.
-type NodeWithCompactOptions interface {
-	Node
-	RangeCompactOptions(func(*OptionNode) bool)
-}
-
-var _ NodeWithCompactOptions = FieldDeclNode(nil)
-var _ NodeWithCompactOptions = EnumValueDeclNode(nil)
-var _ NodeWithCompactOptions = (*ExtensionRangeNode)(nil)
-var _ NodeWithCompactOptions = NoSourceNode{}
-
-// AsNodeWithOptions returns a NodeWithOptions whose RangeOptions method
-// iterates through the given node's compact options.
-func AsNodeWithOptions(n NodeWithCompactOptions) NodeWithOptions {
-	return nodeWithOptsFromCompact{n}
-}
-
-type nodeWithOptsFromCompact struct {
-	NodeWithCompactOptions
-}
-
-func (n nodeWithOptsFromCompact) RangeOptions(f func(*OptionNode) bool) {
-	n.NodeWithCompactOptions.RangeCompactOptions(f)
-}

--- a/ast/options.go
+++ b/ast/options.go
@@ -43,12 +43,12 @@ type OptionNode struct {
 	Semicolon *RuneNode // absent for compact options
 }
 
-func (n *OptionNode) fileElement()    {}
-func (n *OptionNode) msgElement()     {}
-func (n *OptionNode) oneofElement()   {}
-func (n *OptionNode) enumElement()    {}
-func (n *OptionNode) serviceElement() {}
-func (n *OptionNode) methodElement()  {}
+func (*OptionNode) fileElement()    {}
+func (*OptionNode) msgElement()     {}
+func (*OptionNode) oneofElement()   {}
+func (*OptionNode) enumElement()    {}
+func (*OptionNode) serviceElement() {}
+func (*OptionNode) methodElement()  {}
 
 // NewOptionNode creates a new *OptionNode for a full option declaration (as
 // used in files, messages, oneofs, enums, services, and methods). All arguments
@@ -392,4 +392,45 @@ func (e *CompactOptionsNode) GetElements() []*OptionNode {
 		return nil
 	}
 	return e.Options
+}
+
+// NodeWithOptions represents a node in the AST that contains
+// option statements.
+type NodeWithOptions interface {
+	Node
+	RangeOptions(func(*OptionNode) bool)
+}
+
+var _ NodeWithOptions = FileDeclNode(nil)
+var _ NodeWithOptions = MessageDeclNode(nil)
+var _ NodeWithOptions = OneofDeclNode(nil)
+var _ NodeWithOptions = (*EnumNode)(nil)
+var _ NodeWithOptions = (*ServiceNode)(nil)
+var _ NodeWithOptions = RPCDeclNode(nil)
+var _ NodeWithOptions = NoSourceNode{}
+
+// NodeWithCompactOptions represents a node in the AST that contains
+// compact options.
+type NodeWithCompactOptions interface {
+	Node
+	RangeCompactOptions(func(*OptionNode) bool)
+}
+
+var _ NodeWithCompactOptions = FieldDeclNode(nil)
+var _ NodeWithCompactOptions = EnumValueDeclNode(nil)
+var _ NodeWithCompactOptions = (*ExtensionRangeNode)(nil)
+var _ NodeWithCompactOptions = NoSourceNode{}
+
+// AsNodeWithOptions returns a NodeWithOptions whose RangeOptions method
+// iterates through the given node's compact options.
+func AsNodeWithOptions(n NodeWithCompactOptions) NodeWithOptions {
+	return nodeWithOptsFromCompact{n}
+}
+
+type nodeWithOptsFromCompact struct {
+	NodeWithCompactOptions
+}
+
+func (n nodeWithOptsFromCompact) RangeOptions(f func(*OptionNode) bool) {
+	n.NodeWithCompactOptions.RangeCompactOptions(f)
 }

--- a/ast/ranges.go
+++ b/ast/ranges.go
@@ -33,7 +33,7 @@ type ExtensionRangeNode struct {
 	Semicolon *RuneNode
 }
 
-func (e *ExtensionRangeNode) msgElement() {}
+func (*ExtensionRangeNode) msgElement() {}
 
 // NewExtensionRangeNode creates a new *ExtensionRangeNode. All args must be
 // non-nil except opts, which may be nil.
@@ -87,6 +87,14 @@ func NewExtensionRangeNode(keyword *KeywordNode, ranges []*RangeNode, commas []*
 		Commas:    commas,
 		Options:   opts,
 		Semicolon: semicolon,
+	}
+}
+
+func (e *ExtensionRangeNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+	for _, opt := range e.Options.Options {
+		if !fn(opt) {
+			return
+		}
 	}
 }
 

--- a/ast/ranges.go
+++ b/ast/ranges.go
@@ -90,7 +90,7 @@ func NewExtensionRangeNode(keyword *KeywordNode, ranges []*RangeNode, commas []*
 	}
 }
 
-func (e *ExtensionRangeNode) RangeCompactOptions(fn func(*OptionNode) bool) {
+func (e *ExtensionRangeNode) RangeOptions(fn func(*OptionNode) bool) {
 	for _, opt := range e.Options.Options {
 		if !fn(opt) {
 			return

--- a/ast/service.go
+++ b/ast/service.go
@@ -76,6 +76,16 @@ func NewServiceNode(keyword *KeywordNode, name *IdentNode, openBrace *RuneNode, 
 	}
 }
 
+func (n *ServiceNode) RangeOptions(fn func(*OptionNode) bool) {
+	for _, decl := range n.Decls {
+		if opt, ok := decl.(*OptionNode); ok {
+			if !fn(opt) {
+				return
+			}
+		}
+	}
+}
+
 // ServiceElement is an interface implemented by all AST nodes that can
 // appear in the body of a service declaration.
 type ServiceElement interface {
@@ -91,7 +101,7 @@ var _ ServiceElement = (*EmptyDeclNode)(nil)
 // declarations. This allows NoSourceNode to be used in place of *RPCNode
 // for some usages.
 type RPCDeclNode interface {
-	Node
+	NodeWithOptions
 	GetName() Node
 	GetInputType() Node
 	GetOutputType() Node
@@ -229,6 +239,16 @@ func (n *RPCNode) GetInputType() Node {
 
 func (n *RPCNode) GetOutputType() Node {
 	return n.Output.MessageType
+}
+
+func (n *RPCNode) RangeOptions(fn func(*OptionNode) bool) {
+	for _, decl := range n.Decls {
+		if opt, ok := decl.(*OptionNode); ok {
+			if !fn(opt) {
+				return
+			}
+		}
+	}
 }
 
 // RPCElement is an interface implemented by all AST nodes that can

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -255,6 +255,13 @@ func VisitChildren(n CompositeNode, v Visitor) error {
 //
 // Visitors can be supplied to a Walk operation or passed to a call
 // to Visit or VisitChildren.
+//
+// Note that there are some AST node types defined in this package
+// that do not have corresponding visit methods. These are synthetic
+// node types, that have specialized use from the parser, but never
+// appear in an actual AST (which is always rooted at FileNode).
+// These include SyntheticMapField, SyntheticOneof,
+// SyntheticGroupMessageNode, and SyntheticMapEntryNode.
 type Visitor interface {
 	// VisitFileNode is invoked when visiting a *FileNode in the AST.
 	VisitFileNode(*FileNode) error

--- a/compiler.go
+++ b/compiler.go
@@ -585,7 +585,7 @@ func (t *task) link(parseRes parser.Result, deps linker.Files, overrideDescripto
 		return nil, err
 	}
 	// now that options are interpreted, we can do some additional checks
-	if err := file.ValidateOptions(t.h); err != nil {
+	if err := file.ValidateOptions(t.h, t.e.sym); err != nil {
 		return nil, err
 	}
 	if t.r.explicitFile {

--- a/internal/tags.go
+++ b/internal/tags.go
@@ -61,6 +61,9 @@ const (
 	// FileOptionsTag is the tag number of the options element in a file
 	// descriptor proto.
 	FileOptionsTag = 8
+	// FileOptionsFeaturesTag is the tag number of the features field in the
+	// FileOptions proto.
+	FileOptionsFeaturesTag = 50
 	// FileSourceCodeInfoTag is the tag number of the source code info element
 	// in a file descriptor proto.
 	FileSourceCodeInfoTag = 9
@@ -97,6 +100,9 @@ const (
 	// MessageOptionsTag is the tag number of the options element in a message
 	// descriptor proto.
 	MessageOptionsTag = 7
+	// MessageOptionsFeaturesTag is the tag number of the features field in the
+	// MessageOptions proto.
+	MessageOptionsFeaturesTag = 12
 	// MessageOneofsTag is the tag number of the one-ofs element in a message
 	// descriptor proto.
 	MessageOneofsTag = 8
@@ -115,6 +121,30 @@ const (
 	// ExtensionRangeOptionsTag is the tag number of the options element in an
 	// extension range proto.
 	ExtensionRangeOptionsTag = 3
+	// ExtensionRangeOptionsDeclarationTag is the tag number of the declaration
+	// field in the ExtensionRangeOptions proto.
+	ExtensionRangeOptionsDeclarationTag = 2
+	// ExtensionRangeOptionsVerificationTag is the tag number of the verification
+	// field in the ExtensionRangeOptions proto.
+	ExtensionRangeOptionsVerificationTag = 3
+	// ExtensionRangeOptionsDeclarationNumberTag is the tag number of the number
+	// field in the ExtensionRangeOptions.Declaration proto.
+	ExtensionRangeOptionsDeclarationNumberTag = 1
+	// ExtensionRangeOptionsDeclarationFullNameTag is the tag number of the full_name
+	// field in the ExtensionRangeOptions.Declaration proto.
+	ExtensionRangeOptionsDeclarationFullNameTag = 2
+	// ExtensionRangeOptionsDeclarationTypeTag is the tag number of the type
+	// field in the ExtensionRangeOptions.Declaration proto.
+	ExtensionRangeOptionsDeclarationTypeTag = 3
+	// ExtensionRangeOptionsDeclarationReservedTag is the tag number of the reserved
+	// field in the ExtensionRangeOptions.Declaration proto.
+	ExtensionRangeOptionsDeclarationReservedTag = 5
+	// ExtensionRangeOptionsDeclarationRepeatedTag is the tag number of the repeated
+	// field in the ExtensionRangeOptions.Declaration proto.
+	ExtensionRangeOptionsDeclarationRepeatedTag = 6
+	// ExtensionRangeOptionsFeaturesTag is the tag number of the features field in the
+	// ExtensionRangeOptions proto.
+	ExtensionRangeOptionsFeaturesTag = 50
 	// ReservedRangeStartTag is the tag number of the start index in a reserved
 	// range proto. This field number is the same for both "flavors" of reserved
 	// ranges: DescriptorProto.ReservedRange and EnumDescriptorProto.EnumReservedRange.
@@ -147,6 +177,9 @@ const (
 	// FieldOptionsTag is the tag number of the options element in a field
 	// descriptor proto.
 	FieldOptionsTag = 8
+	// FieldOptionsFeaturesTag is the tag number of the features field in the
+	// FieldOptions proto.
+	FieldOptionsFeaturesTag = 21
 	// FieldOneofIndexTag is the tag number of the oneof index element in a
 	// field descriptor proto.
 	FieldOneofIndexTag = 9
@@ -162,6 +195,9 @@ const (
 	// OneofOptionsTag is the tag number of the options element in a one-of
 	// descriptor proto.
 	OneofOptionsTag = 2
+	// OneofOptionsFeaturesTag is the tag number of the features field in the
+	// OneofOptions proto.
+	OneofOptionsFeaturesTag = 1
 	// EnumNameTag is the tag number of the name element in an enum descriptor
 	// proto.
 	EnumNameTag = 1
@@ -171,6 +207,9 @@ const (
 	// EnumOptionsTag is the tag number of the options element in an enum
 	// descriptor proto.
 	EnumOptionsTag = 3
+	// EnumOptionsFeaturesTag is the tag number of the features field in the
+	// EnumOptions proto.
+	EnumOptionsFeaturesTag = 7
 	// EnumReservedRangesTag is the tag number of the reserved ranges element in
 	// an enum descriptor proto.
 	EnumReservedRangesTag = 4
@@ -186,6 +225,9 @@ const (
 	// EnumValOptionsTag is the tag number of the options element in an enum
 	// value descriptor proto.
 	EnumValOptionsTag = 3
+	// EnumValOptionsFeaturesTag is the tag number of the features field in the
+	// EnumValueOptions proto.
+	EnumValOptionsFeaturesTag = 2
 	// ServiceNameTag is the tag number of the name element in a service
 	// descriptor proto.
 	ServiceNameTag = 1
@@ -195,6 +237,9 @@ const (
 	// ServiceOptionsTag is the tag number of the options element in a service
 	// descriptor proto.
 	ServiceOptionsTag = 3
+	// ServiceOptionsFeaturesTag is the tag number of the features field in the
+	// ServiceOptions proto.
+	ServiceOptionsFeaturesTag = 34
 	// MethodNameTag is the tag number of the name element in a method
 	// descriptor proto.
 	MethodNameTag = 1
@@ -207,6 +252,9 @@ const (
 	// MethodOptionsTag is the tag number of the options element in a method
 	// descriptor proto.
 	MethodOptionsTag = 4
+	// MethodOptionsFeaturesTag is the tag number of the features field in the
+	// MethodOptions proto.
+	MethodOptionsFeaturesTag = 35
 	// MethodInputStreamTag is the tag number of the input stream flag in a
 	// method descriptor proto.
 	MethodInputStreamTag = 5

--- a/linker/linker.go
+++ b/linker/linker.go
@@ -114,7 +114,7 @@ type Result interface {
 	// be done after options are interpreted. Any errors or warnings encountered
 	// will be reported via the given handler. If any error is reported, this
 	// function returns a non-nil error.
-	ValidateOptions(handler *reporter.Handler) error
+	ValidateOptions(handler *reporter.Handler, symbols *Symbols) error
 	// CheckForUnusedImports is used to report warnings for unused imports. This
 	// should be called after options have been interpreted. Otherwise, the logic
 	// could incorrectly report imports as unused if the only symbol used were a

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -2305,7 +2305,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:4:29: extension range cannot have declarations and have verification of UNVERIFIED`,
+			expectedErr: `test.proto:4:17: extension range cannot have declarations and have verification of UNVERIFIED`,
 		},
 		"failure_extension_declaration_without_verification2": {
 			input: map[string]string{
@@ -2340,7 +2340,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:5:29: extension declaration is missing required field number`,
+			expectedErr: `test.proto:5:17: extension declaration is missing required field number`,
 		},
 		"failure_extension_declaration_with_incorrect_number": {
 			input: map[string]string{
@@ -2358,7 +2358,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:6:33: extension declaration has number outside the range: 2 not in [1,1]`,
+			expectedErr: `test.proto:6:25: extension declaration has number outside the range: 2 not in [1,1]`,
 		},
 		"failure_extension_declaration_with_number_out_of_range": {
 			input: map[string]string{
@@ -2376,7 +2376,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:6:33: extension declaration has number outside the range: 99 not in [100,500]`,
+			expectedErr: `test.proto:6:25: extension declaration has number outside the range: 99 not in [100,500]`,
 		},
 		"failure_extension_declaration_with_number_out_of_range2": {
 			input: map[string]string{
@@ -2394,7 +2394,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:6:33: extension declaration has number outside the range: 501 not in [100,500]`,
+			expectedErr: `test.proto:6:25: extension declaration has number outside the range: 501 not in [100,500]`,
 		},
 		"failure_extension_declaration_with_number_out_of_range_multiple_ranges": {
 			input: map[string]string{
@@ -2412,7 +2412,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:6:33: extension declaration has number outside the range: 3 not in [5,10]; when using declarations, extends statements should indicate only a single span of field numbers`,
+			expectedErr: `test.proto:6:25: extension declaration has number outside the range: 3 not in [5,10]; when using declarations, extends statements should indicate only a single span of field numbers`,
 		},
 		"failure_extension_declaration_without_name": {
 			input: map[string]string{
@@ -2429,7 +2429,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:5:29: extension declaration that is not marked reserved must have a full_name`,
+			expectedErr: `test.proto:5:17: extension declaration that is not marked reserved must have a full_name`,
 		},
 		"failure_extension_declaration_with_name_without_dot": {
 			input: map[string]string{
@@ -2447,7 +2447,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:7:36: extension declaration full name "foo.bar" should start with a leading dot (.)`,
+			expectedErr: `test.proto:7:25: extension declaration full name "foo.bar" should start with a leading dot (.)`,
 		},
 		"failure_extension_declaration_with_invalid_name": {
 			input: map[string]string{
@@ -2465,7 +2465,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:7:36: extension declaration full name ".123.5-7.Foobar" is not a valid qualified name`,
+			expectedErr: `test.proto:7:25: extension declaration full name ".123.5-7.Foobar" is not a valid qualified name`,
 		},
 		"failure_extension_declaration_without_type": {
 			input: map[string]string{
@@ -2482,7 +2482,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:5:29: extension declaration that is not marked reserved must have a type`,
+			expectedErr: `test.proto:5:17: extension declaration that is not marked reserved must have a type`,
 		},
 		"failure_extension_declaration_with_type_without_dot": {
 			input: map[string]string{
@@ -2500,7 +2500,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:8:31: extension declaration type "foo.Bar" must be a builtin type or start with a leading dot (.)`,
+			expectedErr: `test.proto:8:25: extension declaration type "foo.Bar" must be a builtin type or start with a leading dot (.)`,
 		},
 		"failure_extension_declaration_with_invalid_type": {
 			input: map[string]string{
@@ -2518,7 +2518,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr:            `test.proto:8:31: extension declaration type ".123.Foobar" is not a valid qualified name`,
+			expectedErr:            `test.proto:8:25: extension declaration type ".123.Foobar" is not a valid qualified name`,
 			expectedDiffWithProtoc: true, // Oops. protoc's name validation seems incomplete
 		},
 		"failure_extension_declaration_with_reserved_should_not_have_name": {
@@ -2537,7 +2537,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:8:36: extension declaration is marked reserved so full_name should not be present`,
+			expectedErr: `test.proto:8:25: extension declaration is marked reserved so full_name should not be present`,
 		},
 		"failure_extension_declaration_with_reserved_should_not_have_type": {
 			input: map[string]string{
@@ -2555,7 +2555,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:8:31: extension declaration is marked reserved so type should not be present`,
+			expectedErr: `test.proto:8:25: extension declaration is marked reserved so type should not be present`,
 		},
 		// This exercises the code that finds the relevant node to make sure it track indexes of
 		// repeated fields correctly.
@@ -2584,7 +2584,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:12:31: extension declaration is marked reserved so type should not be present`,
+			expectedErr: `test.proto:12:25: extension declaration is marked reserved so type should not be present`,
 		},
 		"failure_extension_declarations_repeated_tags": {
 			input: map[string]string{
@@ -2608,7 +2608,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:12:33: extension for tag number 1 already declared at test.proto:7:33`,
+			expectedErr: `test.proto:12:25: extension for tag number 1 already declared at test.proto:7:25`,
 		},
 		"failure_extension_declared_multiple_times": {
 			input: map[string]string{
@@ -2632,7 +2632,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:13:36: extension foo.Bar already declared as extending foo.A with tag 1 at test.proto:8:36`,
+			expectedErr: `test.proto:13:25: extension foo.Bar already declared as extending foo.A with tag 1 at test.proto:8:25`,
 		},
 		"failure_extension_declared_multiple_times_across_files": {
 			input: map[string]string{
@@ -2670,7 +2670,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test2.proto:8:36: extension foo.Baz already declared as extending foo.A with tag 5 at test1.proto:13:36`,
+			expectedErr: `test2.proto:8:25: extension foo.Baz already declared as extending foo.A with tag 5 at test1.proto:13:25`,
 			// protoc only validates that the same name doesn't appear again inside
 			// the same extendable message
 			expectedDiffWithProtoc: true,
@@ -2694,7 +2694,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:13:29: cannot use field number 1 for an extension because it is reserved in declaration at test.proto:8:35`,
+			expectedErr: `test.proto:13:29: cannot use field number 1 for an extension because it is reserved in declaration at test.proto:8:25`,
 		},
 		"failure_extension_name_does_not_match_declaration": {
 			input: map[string]string{
@@ -2716,7 +2716,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:14:25: expected extension with number 1 to be named .foo.bar, not foo.s, per declaration at test.proto:8:36`,
+			expectedErr: `test.proto:14:25: expected extension with number 1 to be named .foo.bar, not foo.s, per declaration at test.proto:8:25`,
 		},
 		"failure_extension_type_does_not_match_declaration": {
 			input: map[string]string{
@@ -2738,7 +2738,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:14:18: expected extension with number 1 to have type string, not uint32, per declaration at test.proto:9:31`,
+			expectedErr: `test.proto:14:18: expected extension with number 1 to have type string, not uint32, per declaration at test.proto:9:25`,
 		},
 		"failure_extension_label_does_not_match_declaration": {
 			input: map[string]string{
@@ -2761,7 +2761,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:15:9: expected extension with number 1 to be repeated, not optional, per declaration at test.proto:10:35`,
+			expectedErr: `test.proto:15:9: expected extension with number 1 to be repeated, not optional, per declaration at test.proto:10:25`,
 		},
 		"failure_extension_label_does_not_match_declaration2": {
 			input: map[string]string{
@@ -2783,7 +2783,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:14:9: expected extension with number 1 to be optional, not repeated, per declaration at test.proto:6:29`,
+			expectedErr: `test.proto:14:9: expected extension with number 1 to be optional, not repeated, per declaration at test.proto:6:17`,
 		},
 		"failure_extension_matches_no_declaration": {
 			input: map[string]string{

--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -38,6 +38,14 @@ const unknownFilePath = "<unknown file>"
 // This type is thread-safe.
 type Symbols struct {
 	pkgTrie packageSymbols
+
+	// We don't know the packages for these symbols, so we can't
+	// keep them in the pkgTrie. In vast majority of cases, this
+	// will always be empty/unused. When used, it ensures that
+	// multiple extension declarations don't refer to the same
+	// extension.
+	extDeclsMu sync.Mutex
+	extDecls   map[protoreflect.FullName]extDecl
 }
 
 type packageSymbols struct {
@@ -59,6 +67,12 @@ type symbolEntry struct {
 	isPackage   bool
 }
 
+type extDecl struct {
+	pos      ast.SourcePos
+	extendee protoreflect.FullName
+	tag      protoreflect.FieldNumber
+}
+
 // Import populates the symbol table with all symbols/elements and extension
 // tags present in the given file descriptor. If s is nil or if fd has already
 // been imported into s, this returns immediately without doing anything. If any
@@ -69,6 +83,10 @@ func (s *Symbols) Import(fd protoreflect.FileDescriptor, handler *reporter.Handl
 		return nil
 	}
 
+	if f, ok := fd.(protoreflect.FileImport); ok {
+		// unwrap any import instance
+		fd = f.FileDescriptor
+	}
 	if f, ok := fd.(*file); ok {
 		// unwrap any file instance
 		fd = f.FileDescriptor
@@ -540,6 +558,9 @@ func (s *packageSymbols) commitResultLocked(r *result) {
 	s.files[r] = struct{}{}
 }
 
+// AddExtension records the given extension, which is used to ensure that no two files
+// attempt to extend the same message using the same tag. The given pkg should be the
+// package that defines extendee.
 func (s *Symbols) AddExtension(pkg, extendee protoreflect.FullName, tag protoreflect.FieldNumber, span ast.SourceSpan, handler *reporter.Handler) error {
 	if pkg != "" {
 		if !strings.HasPrefix(string(extendee), string(pkg)+".") {
@@ -558,17 +579,35 @@ func (s *packageSymbols) addExtension(extendee protoreflect.FullName, tag protor
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	extNum := extNumber{extendee: extendee, tag: tag}
+	if existing, ok := s.exts[extNum]; ok {
+		return handler.HandleErrorf(span, "extension with tag %d for message %s already defined at %v", tag, extendee, existing)
+	}
+
 	if s.exts == nil {
 		s.exts = map[extNumber]ast.SourcePos{}
 	}
+	s.exts[extNum] = span.Start()
+	return nil
+}
 
-	extNum := extNumber{extendee: extendee, tag: tag}
-	if existing, ok := s.exts[extNum]; ok {
-		if err := handler.HandleErrorf(span, "extension with tag %d for message %s already defined at %v", tag, extendee, existing); err != nil {
-			return err
+// AddExtensionDeclaration records the given extension declaration, which is used to
+// ensure that no two declarations refer to the same extension.
+func (s *Symbols) AddExtensionDeclaration(extension, extendee protoreflect.FullName, tag protoreflect.FieldNumber, span ast.SourceSpan, handler *reporter.Handler) error {
+	s.extDeclsMu.Lock()
+	defer s.extDeclsMu.Unlock()
+	existing, ok := s.extDecls[extension]
+	if ok {
+		if existing.extendee == extendee && existing.tag == tag {
+			// This is a declaration that has already been added. Ignore.
+			return nil
 		}
-	} else {
-		s.exts[extNum] = span.Start()
+		return handler.HandleErrorf(span, "extension %s already declared as extending %s with tag %d at %v", extension, extendee, tag, existing.pos)
+	}
+	s.extDecls[extension] = extDecl{
+		pos:      span.Start(),
+		extendee: extendee,
+		tag:      tag,
 	}
 	return nil
 }

--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -602,7 +602,10 @@ func (s *Symbols) AddExtensionDeclaration(extension, extendee protoreflect.FullN
 			// This is a declaration that has already been added. Ignore.
 			return nil
 		}
-		return handler.HandleErrorf(span, "extension %s already declared as extending %s with tag %d at %v", extension, extendee, tag, existing.pos)
+		return handler.HandleErrorf(span, "extension %s already declared as extending %s with tag %d at %v", extension, existing.extendee, existing.tag, existing.pos)
+	}
+	if s.extDecls == nil {
+		s.extDecls = map[protoreflect.FullName]extDecl{}
 	}
 	s.extDecls[extension] = extDecl{
 		pos:      span.Start(),

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -638,7 +638,7 @@ func findExtensionRangeOptionSpan(
 		// Find the location using the AST, which will generally be higher fidelity
 		// than what we might find in a file descriptor's source code info.
 		exts := r.ExtensionsNode(extRange)
-		return findOptionSpan(r.FileNode(), exts, ast.AsNodeWithOptions(exts), extRange.Options.ProtoReflect().Descriptor(), path)
+		return findOptionSpan(r.FileNode(), exts, extRange.Options.ProtoReflect().Descriptor(), path)
 	}
 
 	srcLocs := file.SourceLocations()
@@ -689,15 +689,14 @@ func findExtensionRangeOptionSpan(
 
 func findOptionSpan(
 	file ast.FileDeclNode,
-	root ast.Node,
-	rootWithOpts ast.NodeWithOptions,
+	root ast.NodeWithOptions,
 	md protoreflect.MessageDescriptor,
 	path protoreflect.SourcePath,
 ) (ast.SourceSpan, bool) {
-	bestMatch := root
+	bestMatch := ast.Node(root)
 	var bestMatchLen int
 	var repeatedIndices []int
-	rootWithOpts.RangeOptions(func(n *ast.OptionNode) bool {
+	root.RangeOptions(func(n *ast.OptionNode) bool {
 		desc := md
 		limit := len(n.Name.Parts)
 		if limit > len(path) {

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -23,14 +23,16 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 
+	"github.com/bufbuild/protocompile/ast"
 	"github.com/bufbuild/protocompile/internal"
+	"github.com/bufbuild/protocompile/protoutil"
 	"github.com/bufbuild/protocompile/reporter"
 	"github.com/bufbuild/protocompile/walk"
 )
 
 // ValidateOptions runs some validation checks on the result that can only
 // be done after options are interpreted.
-func (r *result) ValidateOptions(handler *reporter.Handler) error {
+func (r *result) ValidateOptions(handler *reporter.Handler, symbols *Symbols) error {
 	return walk.Descriptors(r, func(d protoreflect.Descriptor) error {
 		switch d := d.(type) {
 		case protoreflect.FieldDescriptor:
@@ -38,7 +40,10 @@ func (r *result) ValidateOptions(handler *reporter.Handler) error {
 				return err
 			}
 		case protoreflect.MessageDescriptor:
-			if err := r.validateMessage(d, handler); err != nil {
+			if symbols == nil {
+				symbols = &Symbols{}
+			}
+			if err := r.validateMessage(d, handler, symbols); err != nil {
 				return err
 			}
 		case protoreflect.EnumDescriptor:
@@ -90,18 +95,25 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 	// NB: It's a little gross that we don't enforce these in validateBasic().
 	// But it requires linking to resolve the extendee, so we can interrogate
 	// its descriptor.
-	if fd.ContainingMessage().Options().(*descriptorpb.MessageOptions).GetMessageSetWireFormat() {
+	msg := fd.ContainingMessage()
+	if msg.Options().(*descriptorpb.MessageOptions).GetMessageSetWireFormat() {
 		// Message set wire format requires that all extensions be messages
 		// themselves (no scalar extensions)
 		if fd.Kind() != protoreflect.MessageKind {
 			file := r.FileNode()
 			info := file.NodeInfo(r.FieldNode(fd.proto).FieldType())
-			return handler.HandleErrorf(info, "messages with message-set wire format cannot contain scalar extensions, only messages")
+			err := handler.HandleErrorf(info, "messages with message-set wire format cannot contain scalar extensions, only messages")
+			if err != nil {
+				return err
+			}
 		}
 		if fd.Cardinality() == protoreflect.Repeated {
 			file := r.FileNode()
 			info := file.NodeInfo(r.FieldNode(fd.proto).FieldLabel())
-			return handler.HandleErrorf(info, "messages with message-set wire format cannot contain repeated extensions, only optional")
+			err := handler.HandleErrorf(info, "messages with message-set wire format cannot contain repeated extensions, only optional")
+			if err != nil {
+				return err
+			}
 		}
 	} else if fd.Number() > internal.MaxNormalTag {
 		// In validateBasic() we just made sure these were within bounds for any message. But
@@ -109,7 +121,88 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 		// and, if not, enforce tighter limit.
 		file := r.FileNode()
 		info := file.NodeInfo(r.FieldNode(fd.proto).FieldTag())
-		return handler.HandleErrorf(info, "tag number %d is higher than max allowed tag number (%d)", fd.Number(), internal.MaxNormalTag)
+		err := handler.HandleErrorf(info, "tag number %d is higher than max allowed tag number (%d)", fd.Number(), internal.MaxNormalTag)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If the extendee uses extension declarations, make sure this extension matches.
+	md := protoutil.ProtoFromMessageDescriptor(msg)
+	for i, extRange := range md.ExtensionRange {
+		if int32(fd.Number()) < extRange.GetStart() || int32(fd.Number()) >= extRange.GetEnd() {
+			continue
+		}
+		extRangeOpts := extRange.GetOptions()
+		if extRangeOpts == nil {
+			break
+		}
+		if extRangeOpts.GetVerification() == descriptorpb.ExtensionRangeOptions_UNVERIFIED {
+			break
+		}
+		var found bool
+		for j, extDecl := range extRangeOpts.Declaration {
+			if extDecl.GetNumber() != int32(fd.Number()) {
+				continue
+			}
+			found = true
+			if extDecl.GetReserved() {
+				file := r.FileNode()
+				info := file.NodeInfo(r.FieldNode(fd.proto))
+				span, _ := findExtensionRangeOptionSpan(r, msg, i, extRange,
+					internal.ExtensionRangeOptionsDeclarationTag, int32(j), internal.ExtensionRangeOptionsDeclarationReservedTag)
+				err := handler.HandleErrorf(info, "cannot use field number %d for an extension because it is reserved in declaration at %v",
+					fd.Number(), span)
+				if err != nil {
+					return err
+				}
+			} else if extDecl.GetFullName() != string(fd.FullName()) {
+				file := r.FileNode()
+				info := file.NodeInfo(r.FieldNode(fd.proto))
+				span, _ := findExtensionRangeOptionSpan(r, msg, i, extRange,
+					internal.ExtensionRangeOptionsDeclarationTag, int32(j), internal.ExtensionRangeOptionsDeclarationFullNameTag)
+				err := handler.HandleErrorf(info, "expected extension with number %d to be named %s, not %s, per declaration at %v",
+					fd.Number(), extDecl.GetFullName(), fd.FullName(), span)
+				if err != nil {
+					return err
+				}
+			} else if extDecl.GetType() != getTypeName(fd) {
+				file := r.FileNode()
+				info := file.NodeInfo(r.FieldNode(fd.proto))
+				span, _ := findExtensionRangeOptionSpan(r, msg, i, extRange,
+					internal.ExtensionRangeOptionsDeclarationTag, int32(j), internal.ExtensionRangeOptionsDeclarationTypeTag)
+				err := handler.HandleErrorf(info, "expected extension with number %d to have type %s, not %s, per declaration at %v",
+					fd.Number(), extDecl.GetType(), getTypeName(fd), span)
+				if err != nil {
+					return err
+				}
+			} else if extDecl.GetRepeated() != (fd.Cardinality() == protoreflect.Repeated) {
+				expected, actual := "repeated", "optional"
+				if !extDecl.GetRepeated() {
+					expected, actual = actual, expected
+				}
+				file := r.FileNode()
+				info := file.NodeInfo(r.FieldNode(fd.proto))
+				span, _ := findExtensionRangeOptionSpan(r, msg, i, extRange,
+					internal.ExtensionRangeOptionsDeclarationTag, int32(j), internal.ExtensionRangeOptionsDeclarationRepeatedTag)
+				err := handler.HandleErrorf(info, "expected extension with number %d to be %s, not %s, per declaration at %v",
+					fd.Number(), expected, actual, span)
+				if err != nil {
+					return err
+				}
+			}
+			break
+		}
+		if !found {
+			file := r.FileNode()
+			info := file.NodeInfo(r.FieldNode(fd.proto))
+			span, _ := findExtensionRangeOptionSpan(r, msg, i, extRange, internal.ExtensionRangeOptionsVerificationTag)
+			err := handler.HandleErrorf(info, "expected extension with number %d to be declared in type %s, but no declaration found at %v",
+				fd.Number(), fd.ContainingMessage().FullName(), span)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -138,7 +231,7 @@ func (r *result) validatePacked(fd *fldDescriptor, handler *reporter.Handler) er
 	return nil
 }
 
-func (r *result) validateMessage(d protoreflect.MessageDescriptor, handler *reporter.Handler) error {
+func (r *result) validateMessage(d protoreflect.MessageDescriptor, handler *reporter.Handler, symbols *Symbols) error {
 	md, ok := d.(*msgDescriptor)
 	if !ok {
 		// should not be possible
@@ -149,7 +242,7 @@ func (r *result) validateMessage(d protoreflect.MessageDescriptor, handler *repo
 		return err
 	}
 
-	return nil
+	return r.validateExtensionDeclarations(md, handler, symbols)
 }
 
 func (r *result) validateJSONNamesInMessage(md *msgDescriptor, handler *reporter.Handler) error {
@@ -273,6 +366,102 @@ func (r *result) validateFieldJSONNames(md *msgDescriptor, useCustom bool, handl
 	return nil
 }
 
+func (r *result) validateExtensionDeclarations(md *msgDescriptor, handler *reporter.Handler, symbols *Symbols) error {
+	for i, extRange := range md.proto.ExtensionRange {
+		opts := extRange.GetOptions()
+		if len(opts.GetDeclaration()) > 0 && opts.GetVerification() == descriptorpb.ExtensionRangeOptions_UNVERIFIED {
+			span, ok := findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsVerificationTag)
+			if !ok {
+				span, _ = findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsDeclarationTag, 0)
+			}
+			if err := handler.HandleErrorf(span, "extension range cannot have declarations and have verification of UNVERIFIED"); err != nil {
+				return err
+			}
+		}
+		for i, extDecl := range extRange.GetOptions().GetDeclaration() {
+			if extDecl.Number == nil {
+				span, _ := findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsDeclarationTag, int32(i))
+				if err := handler.HandleErrorf(span, "extension declaration is missing required field number"); err != nil {
+					return err
+				}
+			}
+			if extDecl.GetNumber() < extRange.GetStart() || extDecl.GetNumber() >= extRange.GetEnd() {
+				span, _ := findExtensionRangeOptionSpan(r, md, i, extRange,
+					internal.ExtensionRangeOptionsDeclarationTag, int32(i), internal.ExtensionRangeOptionsDeclarationNumberTag)
+				err := handler.HandleErrorf(span, "extension declaration has number outside the range: %d not in [%d,%d]",
+					extDecl.GetNumber(), extRange.GetStart(), extRange.GetEnd()-1)
+				if err != nil {
+					return err
+				}
+			}
+
+			if extDecl.GetReserved() {
+				if extDecl.FullName != nil {
+					span, _ := findExtensionRangeOptionSpan(r, md, i, extRange,
+						internal.ExtensionRangeOptionsDeclarationTag, int32(i), internal.ExtensionRangeOptionsDeclarationFullNameTag)
+					if err := handler.HandleErrorf(span, "extension declaration is marked reserved so full_name should not be present"); err != nil {
+						return err
+					}
+				}
+				if extDecl.Type != nil {
+					span, _ := findExtensionRangeOptionSpan(r, md, i, extRange,
+						internal.ExtensionRangeOptionsDeclarationTag, int32(i), internal.ExtensionRangeOptionsDeclarationTypeTag)
+					if err := handler.HandleErrorf(span, "extension declaration is marked reserved so type should not be present"); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			if extDecl.FullName == nil {
+				span, _ := findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsDeclarationTag, int32(i))
+				if err := handler.HandleErrorf(span, "extension declaration that is not marked reserved must have a full_name"); err != nil {
+					return err
+				}
+			}
+			extensionNameSpan, _ := findExtensionRangeOptionSpan(r, md, i, extRange,
+				internal.ExtensionRangeOptionsDeclarationTag, int32(i), internal.ExtensionRangeOptionsDeclarationFullNameTag)
+			if !strings.HasPrefix(extDecl.GetFullName(), ".") {
+				if err := handler.HandleErrorf(extensionNameSpan, "extension declaration full name should start with a leading dot (.)"); err != nil {
+					return err
+				}
+			}
+			extensionFullName := protoreflect.FullName(extDecl.GetFullName()[1:])
+			if extensionFullName.IsValid() {
+				if err := handler.HandleErrorf(extensionNameSpan, "extension declaration full name is not a valid qualified name"); err != nil {
+					return err
+				}
+			}
+			if err := symbols.AddExtensionDeclaration(extensionFullName, md.FullName(), protoreflect.FieldNumber(extDecl.GetNumber()), extensionNameSpan, handler); err != nil {
+				return err
+			}
+
+			if extDecl.Type == nil {
+				span, _ := findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsDeclarationTag, int32(i))
+				if err := handler.HandleErrorf(span, "extension declaration that is not marked reserved must have a type"); err != nil {
+					return err
+				}
+			}
+			if strings.HasPrefix(extDecl.GetType(), ".") {
+				if protoreflect.FullName(extDecl.GetType()[1:]).IsValid() {
+					span, _ := findExtensionRangeOptionSpan(r, md, i, extRange,
+						internal.ExtensionRangeOptionsDeclarationTag, int32(i), internal.ExtensionRangeOptionsDeclarationTypeTag)
+					if err := handler.HandleErrorf(span, "extension declaration type is not a valid qualified name"); err != nil {
+						return err
+					}
+				}
+			} else if !isBuiltinTypeName(extDecl.GetType()) {
+				span, _ := findExtensionRangeOptionSpan(r, md, i, extRange,
+					internal.ExtensionRangeOptionsDeclarationTag, int32(i), internal.ExtensionRangeOptionsDeclarationTypeTag)
+				if err := handler.HandleErrorf(span, "extension declaration type must be a builtin type or start with a leading dot (.)"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (r *result) hasCustomJSONName(fdProto *descriptorpb.FieldDescriptorProto) bool {
 	// if we have the AST, we can more precisely determine if there was a custom
 	// JSON named defined, even if it is explicitly configured to tbe the same
@@ -358,4 +547,276 @@ func enumValCamelCase(name string) string {
 		}
 	}
 	return string(js)
+}
+
+func isBuiltinTypeName(typeName string) bool {
+	switch typeName {
+	case "int32", "int64", "uint32", "uint64", "sint32", "sint64",
+		"fixed32", "fixed64", "sfixed32", "sfixed64",
+		"bool", "double", "float", "string", "bytes":
+		return true
+	default:
+		return false
+	}
+}
+
+func getTypeName(fd protoreflect.FieldDescriptor) string {
+	switch fd.Kind() {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return "." + string(fd.Message().FullName())
+	case protoreflect.EnumKind:
+		return "." + string(fd.Enum().FullName())
+	default:
+		return fd.Kind().String()
+	}
+}
+
+func findExtensionRangeOptionSpan(
+	file protoreflect.FileDescriptor,
+	extended protoreflect.MessageDescriptor,
+	extRangeIndex int,
+	extRange *descriptorpb.DescriptorProto_ExtensionRange,
+	path ...int32,
+) (ast.SourceSpan, bool) {
+	// NB: Typically, we have an AST for a file and NOT source code info, because the
+	// compiler validates options before computing source code info. However, we might
+	// be validating an extension (whose source/AST we have), but whose extendee (and
+	// thus extension range options for declarations) could be in some other file, which
+	// could be provided to the compiler as an already-compiled descriptor. So this
+	// function can fallback to using source code info if an AST is not available.
+
+	if r, ok := file.(Result); ok && r.AST() != nil {
+		// Find the location using the AST, which will generally be higher fidelity
+		// than what we might find in a file descriptor's source code info.
+		exts := r.ExtensionsNode(extRange)
+		return findOptionSpan(r.FileNode(), exts, ast.AsNodeWithOptions(exts), extRange.Options.ProtoReflect().Descriptor(), path)
+	}
+
+	srcLocs := file.SourceLocations()
+	if srcLocs.Len() == 0 {
+		// no source code info, can't do any better than the filename. We
+		// return true as the boolean so the caller doesn't try again with
+		// an alternate path, since we won't be able to do any better.
+		return ast.UnknownSpan(file.Path()), true
+	}
+	msgPath, ok := internal.ComputePath(extended)
+	if !ok {
+		// Same as above: return true since no subsequent query can do better.
+		return ast.UnknownSpan(file.Path()), true
+	}
+
+	extRangePath := append(msgPath, internal.MessageExtensionRangesTag, int32(extRangeIndex))
+	optsPath := append(extRangePath, internal.ExtensionRangeOptionsTag)
+	fullPath := append(optsPath, path...)
+	srcLoc := srcLocs.ByPath(fullPath)
+	if srcLoc.Path != nil {
+		// found it
+		return asSpan(file.Path(), srcLoc), true
+	}
+
+	// Slow path to find closest match :/
+	// We look for longest matching path that is at least len(extRangePath)
+	// long. If we find a path that is longer (meaning a path that points INSIDE
+	// the request element), accept the first such location.
+	var bestMatch protoreflect.SourceLocation
+	var bestMatchPathLen int
+	for i, length := 0, srcLocs.Len(); i < length; i++ {
+		srcLoc := srcLocs.Get(i)
+		if len(srcLoc.Path) >= len(extRangePath) &&
+			isDescendantPath(fullPath, srcLoc.Path) &&
+			len(srcLoc.Path) > bestMatchPathLen {
+			bestMatch = srcLoc
+			bestMatchPathLen = len(srcLoc.Path)
+		} else if isDescendantPath(srcLoc.Path, path) {
+			return asSpan(file.Path(), srcLoc), false
+		}
+	}
+	if bestMatchPathLen > 0 {
+		return asSpan(file.Path(), bestMatch), false
+	}
+	return ast.UnknownSpan(file.Path()), false
+}
+
+func findOptionSpan(
+	file ast.FileDeclNode,
+	root ast.Node,
+	rootWithOpts ast.NodeWithOptions,
+	md protoreflect.MessageDescriptor,
+	path protoreflect.SourcePath,
+) (ast.SourceSpan, bool) {
+	bestMatch := root
+	var bestMatchLen int
+	var repeatedIndices []int
+	rootWithOpts.RangeOptions(func(n *ast.OptionNode) bool {
+		desc := md
+		limit := len(n.Name.Parts)
+		if limit > len(path) {
+			limit = len(path)
+		}
+		var nextIsIndex bool
+		for i := 0; i < limit; i++ {
+			if desc == nil || nextIsIndex {
+				// Can't match anymore. Try next option.
+				return true
+			}
+			wantField := desc.Fields().ByNumber(protoreflect.FieldNumber(path[i]))
+			if wantField == nil {
+				// Should not be possible... next option won't fare any better since
+				// it's a disagreement between given path and given descriptor so bail.
+				return false
+			}
+			if n.Name.Parts[i].Open != nil ||
+				string(n.Name.Parts[i].Name.AsIdentifier()) != string(wantField.Name()) {
+				// This is an extension/custom option or indicates the wrong name.
+				// Try the next one.
+				return true
+			}
+			desc = wantField.Message()
+			nextIsIndex = wantField.Cardinality() == protoreflect.Repeated
+		}
+		// If we made it this far, we've matched everything so far.
+		if len(n.Name.Parts) >= len(path) {
+			// Either an exact match (if equal) or this option points *inside* the
+			// item we care about (if greater). Either way, the first such result
+			// is a keeper.
+			bestMatch = n
+			bestMatchLen = len(n.Name.Parts)
+			return false
+		}
+		// We've got more path elements to try to match with the value.
+		match, matchLen := findMatchingValueNode(desc, path[len(n.Name.Parts):], nextIsIndex, 0, &repeatedIndices, n.Val)
+		if match != nil {
+			bestMatch, bestMatchLen = match, matchLen+len(n.Name.Parts)
+		}
+		return bestMatchLen != len(path) // no exact match, so keep looking
+	})
+	return file.NodeInfo(bestMatch), bestMatchLen == len(path)
+}
+
+func findMatchingValueNode(
+	md protoreflect.MessageDescriptor,
+	path protoreflect.SourcePath,
+	currIsRepeated bool,
+	repeatedCount int,
+	repeatedIndices *[]int,
+	val ast.ValueNode,
+) (ast.Node, int) {
+	var matchLen int
+	var index int
+	if currIsRepeated {
+		// Compute the index of the current value (or, if an array literal, the
+		// index of the first value in the array).
+		if len(*repeatedIndices) > repeatedCount {
+			(*repeatedIndices)[repeatedCount]++
+			index = (*repeatedIndices)[repeatedCount]
+		} else {
+			*repeatedIndices = append(*repeatedIndices, 0)
+			index = 0
+		}
+		repeatedCount++
+	}
+
+	if arrayVal, ok := val.(*ast.ArrayLiteralNode); ok {
+		if !currIsRepeated {
+			// This should not happen.
+			return nil, 0
+		}
+		offset := int(path[0]) - index
+		if offset >= len(arrayVal.Elements) {
+			// The index we are looking for is not in this array.
+			return nil, 0
+		}
+		elem := arrayVal.Elements[offset]
+		// We've matched the index!
+		matchLen++
+		path = path[1:]
+		// Recurse into array element.
+		nextMatch, nextMatchLen := findMatchingValueNode(md, path, false, repeatedCount, repeatedIndices, elem)
+		return nextMatch, nextMatchLen + matchLen
+	}
+
+	if currIsRepeated {
+		if index != int(path[0]) {
+			// Not a match!
+			return nil, 0
+		}
+		// We've matched the index!
+		matchLen++
+		path = path[1:]
+		if len(path) == 0 {
+			// We're done matching!
+			return val, matchLen
+		}
+		currIsRepeated = false
+	}
+
+	msgValue, ok := val.(*ast.MessageLiteralNode)
+	if !ok {
+		// We can't go any further
+		return val, matchLen
+	}
+
+	var wantField protoreflect.FieldDescriptor
+	if md != nil {
+		wantField = md.Fields().ByNumber(protoreflect.FieldNumber(path[0]))
+	}
+	if wantField == nil {
+		// Should not be possible... next option won't fare any better since
+		// it's a disagreement between given path and given descriptor so bail.
+		return nil, 0
+	}
+	for _, field := range msgValue.Elements {
+		if field.Name.Open != nil ||
+			string(field.Name.Name.AsIdentifier()) != string(wantField.Name()) {
+			// This is an extension/custom option or indicates the wrong name.
+			// Try the next one.
+			continue
+		}
+		// We've matched this field.
+		matchLen++
+		path = path[1:]
+		if len(path) == 0 {
+			// Perfect match!
+			return field.Val, matchLen
+		}
+		nextMatch, nextMatchLen := findMatchingValueNode(
+			wantField.Message(),
+			path,
+			wantField.Cardinality() == protoreflect.Repeated,
+			repeatedCount,
+			repeatedIndices,
+			field.Val,
+		)
+		return nextMatch, nextMatchLen + matchLen
+	}
+
+	// If we didn't find the right field, just return what we have so far.
+	return val, matchLen
+}
+
+func isDescendantPath(descendant, ancestor protoreflect.SourcePath) bool {
+	if len(descendant) < len(ancestor) {
+		return false
+	}
+	for i := range ancestor {
+		if descendant[i] != ancestor[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func asSpan(file string, srcLoc protoreflect.SourceLocation) ast.SourceSpan {
+	return ast.NewSourceSpan(
+		ast.SourcePos{
+			Filename: file,
+			Line:     srcLoc.StartLine + 1,
+			Col:      srcLoc.StartColumn + 1,
+		},
+		ast.SourcePos{
+			Filename: file,
+			Line:     srcLoc.EndLine + 1,
+			Col:      srcLoc.EndColumn + 1,
+		},
+	)
 }

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -157,7 +157,9 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 				if err != nil {
 					return err
 				}
-			} else if extDecl.GetFullName() != "."+string(fd.FullName()) {
+				break
+			}
+			if extDecl.GetFullName() != "."+string(fd.FullName()) {
 				file := r.FileNode()
 				info := file.NodeInfo(r.FieldNode(fd.proto).FieldName())
 				span, _ := findExtensionRangeOptionSpan(msg.ParentFile(), msg, i, extRange,
@@ -167,7 +169,8 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 				if err != nil {
 					return err
 				}
-			} else if extDecl.GetType() != getTypeName(fd) {
+			}
+			if extDecl.GetType() != getTypeName(fd) {
 				file := r.FileNode()
 				info := file.NodeInfo(r.FieldNode(fd.proto).FieldType())
 				span, _ := findExtensionRangeOptionSpan(msg.ParentFile(), msg, i, extRange,
@@ -177,7 +180,8 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 				if err != nil {
 					return err
 				}
-			} else if extDecl.GetRepeated() != (fd.Cardinality() == protoreflect.Repeated) {
+			}
+			if extDecl.GetRepeated() != (fd.Cardinality() == protoreflect.Repeated) {
 				expected, actual := "repeated", "optional"
 				if !extDecl.GetRepeated() {
 					expected, actual = actual, expected
@@ -650,9 +654,10 @@ func findExtensionRangeOptionSpan(
 		return ast.UnknownSpan(file.Path()), true
 	}
 
+	//nolint:gocritic // intentionally assigning to different slice variables
 	extRangePath := append(msgPath, internal.MessageExtensionRangesTag, int32(extRangeIndex))
-	optsPath := append(extRangePath, internal.ExtensionRangeOptionsTag)
-	fullPath := append(optsPath, path...)
+	optsPath := append(extRangePath, internal.ExtensionRangeOptionsTag) //nolint:gocritic
+	fullPath := append(optsPath, path...)                               //nolint:gocritic
 	srcLoc := srcLocs.ByPath(fullPath)
 	if srcLoc.Path != nil {
 		// found it
@@ -795,7 +800,6 @@ func findMatchingValueNode(
 			// We're done matching!
 			return val, matchLen
 		}
-		currIsRepeated = false
 	}
 
 	msgValue, ok := val.(*ast.MessageLiteralNode)

--- a/parser/clone.go
+++ b/parser/clone.go
@@ -106,6 +106,7 @@ func recreateNodeIndexForMessage(orig, clone *result, origProto, cloneProto *des
 	}
 	for i, origExtr := range origProto.ExtensionRange {
 		cloneExtr := cloneProto.ExtensionRange[i]
+		updateNodeIndex(orig, clone, asExtsNode(origExtr), asExtsNode(cloneExtr))
 		updateNodeIndexWithOptions[*descriptorpb.ExtensionRangeOptions](orig, clone, origExtr, cloneExtr)
 	}
 	for i, origRr := range origProto.ReservedRange {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -155,12 +155,19 @@ type Result interface {
 	// return nil, such as if the given oneof is not part of the
 	// FileDescriptorProto hierarchy. If this result has no AST, this returns a
 	// placeholder node.
-	OneofNode(*descriptorpb.OneofDescriptorProto) ast.Node
+	OneofNode(*descriptorpb.OneofDescriptorProto) ast.OneofDeclNode
 	// ExtensionRangeNode returns the AST node corresponding to the given
 	// extension range. This can return nil, such as if the given range is not
 	// part of the FileDescriptorProto hierarchy. If this result has no AST,
 	// this returns a placeholder node.
 	ExtensionRangeNode(*descriptorpb.DescriptorProto_ExtensionRange) ast.RangeDeclNode
+
+	// ExtensionsNode returns the AST node corresponding to the "extensions"
+	// statement in a message that corresponds to the given range. This will be
+	// the parent of the node returned by ExtensionRangeNode, which contains the
+	// options that apply to all child ranges.
+	ExtensionsNode(*descriptorpb.DescriptorProto_ExtensionRange) ast.NodeWithCompactOptions
+
 	// MessageReservedRangeNode returns the AST node corresponding to the given
 	// reserved range. This can return nil, such as if the given range is not
 	// part of the FileDescriptorProto hierarchy. If this result has no AST,
@@ -170,7 +177,7 @@ type Result interface {
 	// return nil, such as if the given enum is not part of the
 	// FileDescriptorProto hierarchy. If this result has no AST, this returns a
 	// placeholder node.
-	EnumNode(*descriptorpb.EnumDescriptorProto) ast.Node
+	EnumNode(*descriptorpb.EnumDescriptorProto) ast.NodeWithOptions
 	// EnumValueNode returns the AST node corresponding to the given enum. This
 	// can return nil, such as if the given enum value is not part of the
 	// FileDescriptorProto hierarchy. If this result has no AST, this returns a
@@ -185,7 +192,7 @@ type Result interface {
 	// can return nil, such as if the given service is not part of the
 	// FileDescriptorProto hierarchy. If this result has no AST, this returns a
 	// placeholder node.
-	ServiceNode(*descriptorpb.ServiceDescriptorProto) ast.Node
+	ServiceNode(*descriptorpb.ServiceDescriptorProto) ast.NodeWithOptions
 	// MethodNode returns the AST node corresponding to the given method. This
 	// can return nil, such as if the given method is not part of the
 	// FileDescriptorProto hierarchy. If this result has no AST, this returns a

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -166,7 +166,7 @@ type Result interface {
 	// statement in a message that corresponds to the given range. This will be
 	// the parent of the node returned by ExtensionRangeNode, which contains the
 	// options that apply to all child ranges.
-	ExtensionsNode(*descriptorpb.DescriptorProto_ExtensionRange) ast.NodeWithCompactOptions
+	ExtensionsNode(*descriptorpb.DescriptorProto_ExtensionRange) ast.NodeWithOptions
 
 	// MessageReservedRangeNode returns the AST node corresponding to the given
 	// reserved range. This can return nil, such as if the given range is not

--- a/parser/result.go
+++ b/parser/result.go
@@ -1008,7 +1008,7 @@ func asExtsNode(er *descriptorpb.DescriptorProto_ExtensionRange) proto.Message {
 
 // a simple marker type that allows us to have two distinct keys in a map for
 // the same ExtensionRange proto -- one for the range itself and another to
-// associate with the enclosing/parent AST node
+// associate with the enclosing/parent AST node.
 type extsParent struct {
 	*descriptorpb.DescriptorProto_ExtensionRange
 }

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -287,7 +287,7 @@ func findMessageReservedNameNode(msgNode ast.MessageDeclNode, name string) ast.N
 	switch msgNode := msgNode.(type) {
 	case *ast.MessageNode:
 		decls = msgNode.Decls
-	case *ast.GroupNode:
+	case *ast.SyntheticGroupMessageNode:
 		decls = msgNode.Decls
 	default:
 		// leave decls empty

--- a/sourceinfo/source_code_info.go
+++ b/sourceinfo/source_code_info.go
@@ -310,10 +310,10 @@ func generateSourceCodeInfoForMessage(opts OptionIndex, sci *sourceCodeInfo, n a
 	case *ast.MessageNode:
 		openBrace = n.OpenBrace
 		decls = n.Decls
-	case *ast.GroupNode:
+	case *ast.SyntheticGroupMessageNode:
 		openBrace = n.OpenBrace
 		decls = n.Decls
-	case *ast.MapFieldNode:
+	case *ast.SyntheticMapEntryNode:
 		sci.newLoc(n, path)
 		// map entry so nothing else to do
 		return
@@ -342,7 +342,7 @@ func generateSourceCodeInfoForMessage(opts OptionIndex, sci *sourceCodeInfo, n a
 			fieldIndex++
 			// we clone the path here so that append can't mutate fldPath, since they may share storage
 			msgPath := append(internal.ClonePath(path), internal.MessageNestedMessagesTag, nestedMsgIndex)
-			generateSourceCodeInfoForMessage(opts, sci, child, fldPath, msgPath)
+			generateSourceCodeInfoForMessage(opts, sci, child.AsMessage(), fldPath, msgPath)
 			nestedMsgIndex++
 		case *ast.MapFieldNode:
 			generateSourceCodeInfoForField(opts, sci, child, append(path, internal.MessageFieldsTag, fieldIndex))
@@ -469,7 +469,7 @@ func generateSourceCodeInfoForExtensions(opts OptionIndex, sci *sourceCodeInfo, 
 			fldPath = append(fldPath, *extendIndex)
 			generateSourceCodeInfoForField(opts, sci, decl, fldPath)
 			*extendIndex++
-			generateSourceCodeInfoForMessage(opts, sci, decl, fldPath, append(msgPath, *msgIndex))
+			generateSourceCodeInfoForMessage(opts, sci, decl.AsMessage(), fldPath, append(msgPath, *msgIndex))
 			*msgIndex++
 		}
 	}
@@ -492,7 +492,7 @@ func generateSourceCodeInfoForOneof(opts OptionIndex, sci *sourceCodeInfo, n *as
 			fldPath = append(fldPath, *fieldIndex)
 			generateSourceCodeInfoForField(opts, sci, child, fldPath)
 			*fieldIndex++
-			generateSourceCodeInfoForMessage(opts, sci, child, fldPath, append(nestedMsgPath, *nestedMsgIndex))
+			generateSourceCodeInfoForMessage(opts, sci, child.AsMessage(), fldPath, append(nestedMsgPath, *nestedMsgIndex))
 			*nestedMsgIndex++
 		}
 	}


### PR DESCRIPTION
This adds validation of the extension declaration configuration and then also adds enforcement for extension ranges that have declarations.

The validation and checks are all based on the same logic in `protoc` ([here](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L8031-L8035) and [here](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L7092-L7095)).

The one area where we go above and beyond `protoc` is that `protocompile` will check that an extension is only used once by a declaration _globally_ (as best it can anyways); `protoc` on the other hand only checks that an extension is only used once by a declaration within a single message. So it allows the same fully-qualified extension to be referenced in declarations from different messages. This doesn't make sense because a single extension can only extend one message -- so if it's a valid extension for one message, it _can't_ be a valid extension for a different one.