### PR TITLE
Validate usage of features in editions

### DIFF
--- a/internal/tags.go
+++ b/internal/tags.go
@@ -186,6 +186,15 @@ const (
 	// FieldOptionsPackedTag is the number of the packed field in the
 	// FieldOptions proto.
 	FieldOptionsPackedTag = 2
+	// FieldOptionsLazyTag is the number of the lazy field in the
+	// FieldOptions proto.
+	FieldOptionsLazyTag = 5
+	// FieldOptionsJSTypeTag is the number of the jstype field in the
+	// FieldOptions proto.
+	FieldOptionsJSTypeTag = 6
+	// FieldOptionsUnverifiedLazyTag is the number of the unverified_lazy
+	// field in the FieldOptions proto.
+	FieldOptionsUnverifiedLazyTag = 15
 	// FieldOptionsFeaturesTag is the tag number of the features field in the
 	// FieldOptions proto.
 	FieldOptionsFeaturesTag = 21

--- a/internal/tags.go
+++ b/internal/tags.go
@@ -61,6 +61,9 @@ const (
 	// FileOptionsTag is the tag number of the options element in a file
 	// descriptor proto.
 	FileOptionsTag = 8
+	// FileOptionsJavaStringCheckUTF8Tag is the tag number of the java_string_check_utf8
+	// field in the FileOptions proto.
+	FileOptionsJavaStringCheckUTF8Tag = 27
 	// FileOptionsFeaturesTag is the tag number of the features field in the
 	// FileOptions proto.
 	FileOptionsFeaturesTag = 50
@@ -177,6 +180,12 @@ const (
 	// FieldOptionsTag is the tag number of the options element in a field
 	// descriptor proto.
 	FieldOptionsTag = 8
+	// FieldOptionsCTypeTag is the number of the ctype field in the
+	// FieldOptions proto.
+	FieldOptionsCTypeTag = 1
+	// FieldOptionsPackedTag is the number of the packed field in the
+	// FieldOptions proto.
+	FieldOptionsPackedTag = 2
 	// FieldOptionsFeaturesTag is the tag number of the features field in the
 	// FieldOptions proto.
 	FieldOptionsFeaturesTag = 21
@@ -296,4 +305,23 @@ const (
 	AnyTypeURLTag = 1
 	// AnyValueTag is the tag number of the value field of the Any proto.
 	AnyValueTag = 2
+
+	// FeatureSetFieldPresenceTag is the tag number of the field_presence field
+	// in the FeatureSet proto.
+	FeatureSetFieldPresenceTag = 1
+	// FeatureSetEnumTypeTag is the tag number of the enum_type field in the
+	// FeatureSet proto.
+	FeatureSetEnumTypeTag = 2
+	// FeatureSetRepeatedFieldEncodingTag is the tag number of the repeated_field_encoding
+	// field in the FeatureSet proto.
+	FeatureSetRepeatedFieldEncodingTag = 3
+	// FeatureSetUTF8ValidationTag is the tag number of the utf8_validation field
+	// in the FeatureSet proto.
+	FeatureSetUTF8ValidationTag = 4
+	// FeatureSetMessageEncodingTag is the tag number of the message_encoding
+	// field in the FeatureSet proto.
+	FeatureSetMessageEncodingTag = 5
+	// FeatureSetJSONFormatTag is the tag number of the json_format field in
+	// the FeatureSet proto.
+	FeatureSetJSONFormatTag = 6
 )

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -2232,7 +2232,13 @@ func TestLinkerValidation(t *testing.T) {
 			input: map[string]string{
 				"test.proto": `syntax = "proto3"; enum Foo { FIRST = 1; }`,
 			},
-			expectedErr: `test.proto:1:39: first value of open enum Foo must be zero`,
+			expectedErr: `test.proto:1:39: enum Foo: proto3 requires that first value of enum have numeric value zero`,
+		},
+		"failure_editions_open_enum_zero_value": {
+			input: map[string]string{
+				"test.proto": `edition = "2023"; enum Foo { FIRST = 1; }`,
+			},
+			expectedErr: `test.proto:1:38: first value of open enum Foo must have numeric value zero`,
 		},
 		"success_extension_declarations": {
 			input: map[string]string{

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -147,6 +147,14 @@ func TestLinkerValidation(t *testing.T) {
 			expectedErr: `foo.proto:1:8: cycle found in imports: "foo.proto" -> "foo2.proto" -> "foo.proto"` +
 				` || foo2.proto:1:8: cycle found in imports: "foo2.proto" -> "foo.proto" -> "foo2.proto"`,
 		},
+		"failure_import_lite_from_nonlite": {
+			input: map[string]string{
+				"foo.proto":  `option optimize_for=LITE_RUNTIME;`,
+				"foo2.proto": `import "foo.proto"; message baz{}`,
+			},
+			// since files are compiled concurrently, there are two possible outcomes
+			expectedErr: `foo2.proto:1:8: a file that does not use optimize_for=LITE_RUNTIME may not import file "foo.proto" that does`,
+		},
 		"failure_enum_cpp_scope": {
 			input: map[string]string{
 				"foo.proto": "enum foo { bar = 1; baz = 2; } enum fu { bar = 1; baz = 2; }",
@@ -289,6 +297,12 @@ func TestLinkerValidation(t *testing.T) {
 				"foo.proto": "package fu.baz; message foobar{ optional string a = 1 [default = 1.234]; }",
 			},
 			expectedErr: "foo.proto:1:66: field fu.baz.foobar.a: option default: expecting string, got double",
+		},
+		"failure_editions_default_with_implicit_presence": {
+			input: map[string]string{
+				"foo.proto": `edition = "2023"; message Foo { string s = 1 [default="abc", features.field_presence=IMPLICIT]; }`,
+			},
+			expectedErr: "foo.proto:1:47: default value is not allowed on fields with implicit presence",
 		},
 		"failure_enum_default_not_found": {
 			input: map[string]string{
@@ -2204,6 +2218,18 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			expectedErr: `test.proto:3:3: packed option is only allowed on repeated fields`,
 		},
+		"failure_editions_packed_option_not_allowed": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						repeated uint32 ids = 1 [packed=true];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:34: field foo.A.ids: packed option is not allowed in editions; use option features.repeated_field_encoding instead`,
+		},
 		"failure_editions_feature_on_wrong_target_type": {
 			input: map[string]string{
 				"test.proto": `
@@ -2329,7 +2355,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:4:30: extension range cannot have declarations and have verification of UNVERIFIED`,
+			expectedErr: `test.proto:4:17: extension range cannot have declarations and have verification of UNVERIFIED`,
 		},
 		"failure_extension_declaration_without_number": {
 			input: map[string]string{
@@ -2811,7 +2837,302 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:14:31: expected extension with number 3 to be declared in type foo.A, but no declaration found at test.proto:5:30`,
+			expectedErr: `test.proto:14:31: expected extension with number 3 to be declared in type foo.A, but no declaration found at test.proto:5:17`,
+		},
+		"success_field_presence": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					option features.field_presence = IMPLICIT;
+					message A {
+						B b = 1 [features.field_presence = LEGACY_REQUIRED];
+						message B {
+							string s = 1 [features.field_presence = EXPLICIT];
+						}
+						A a = 2 [features.field_presence = EXPLICIT];
+						uint64 u = 3 [features.field_presence = IMPLICIT];
+					}
+				`,
+			},
+		},
+		"failure_field_presence_on_oneof_field": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						oneof b {
+							string s = 1 [features.field_presence = EXPLICIT];
+							int64 n = 2;
+						}
+					}
+				`,
+			},
+			expectedErr: `test.proto:5:40: oneof fields may not specify field presence`,
+		},
+		"failure_field_presence_on_repeated_field": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						repeated string s = 1 [features.field_presence = IMPLICIT];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:41: repeated fields may not specify field presence`,
+		},
+		"failure_field_presence_on_map_field": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						map<string,string> s = 1 [features.field_presence = IMPLICIT];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:44: repeated fields may not specify field presence`,
+		},
+		"failure_field_presence_on_message_field": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						A a = 1 [features.field_presence = IMPLICIT];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:27: message fields may not specify implicit presence`,
+		},
+		"failure_field_presence_on_extension_field": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						extensions 1 to 100;
+					}
+					extend A {
+						string s = 1 [features = {
+							field_presence:LEGACY_REQUIRED
+						}];
+					}
+				`,
+			},
+			expectedErr: `test.proto:8:17: extension fields may not specify field presence`,
+		},
+		"failure_field_presence_on_file": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					option features={
+						field_presence : LEGACY_REQUIRED;
+					};
+					message A {
+						string s = 1;
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:9: LEGACY_REQUIRED field presence cannot be set as the default for a file`,
+		},
+		"success_repeated_field_encoding": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					option features.repeated_field_encoding=EXPANDED;
+					message A {
+						repeated string s = 1 [features.repeated_field_encoding=EXPANDED];
+						map<string,string> m = 2 [features.repeated_field_encoding=EXPANDED];
+						repeated A a = 3 [features.repeated_field_encoding=EXPANDED];
+						repeated bool b = 4 [features.repeated_field_encoding=PACKED];
+						repeated double d = 5 [features.repeated_field_encoding=PACKED];
+						repeated E e = 6 [features.repeated_field_encoding=PACKED];
+						enum E { ZERO=0; }
+					}
+				`,
+			},
+		},
+		"failure_repeated_field_encoding_not_repeated": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						string s = 1 [features.repeated_field_encoding=EXPANDED];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:32: only repeated fields may specify repeated field encoding`,
+		},
+		"failure_repeated_field_encoding_not_packable": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						repeated string s = 1 [features.repeated_field_encoding=PACKED];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:41: only repeated primitive fields may specify packed encoding`,
+		},
+		"failure_repeated_field_encoding_not_packable_map": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						map<string,string> s = 1 [features.repeated_field_encoding=PACKED];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:44: only repeated primitive fields may specify packed encoding`,
+		},
+		"success_utf8_validation": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					option features = {
+						utf8_validation:NONE;
+					};
+					message A {
+						string s = 1 [features.utf8_validation=VERIFY];
+						map<string,A> ma = 2 [features.utf8_validation=VERIFY];
+						map<uint32,string> mu = 3 [features.utf8_validation=VERIFY];
+						map<string,string> ms = 4 [features.utf8_validation=VERIFY];
+					}
+				`,
+			},
+		},
+		"failure_utf8_validation_not_string": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						bytes s = 1 [features.utf8_validation=VERIFY];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:31: only string fields may specify UTF8 validation`,
+		},
+		"failure_utf8_validation_not_string_map": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						map<uint32,bytes> m = 1 [features.utf8_validation=VERIFY];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:43: only string fields may specify UTF8 validation`,
+		},
+		"failure_utf8_validation_java_option": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					option java_string_check_utf8 = true;
+					message A {
+						map<uint32,bytes> m = 1;
+					}
+				`,
+			},
+			expectedErr: `test.proto:3:8: file option java_string_check_utf8 is not allowed with editions; import "google/protobuf/java_features.proto" and use (pb.java).utf8_validation instead`,
+		},
+		"success_message_encoding": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					option features.message_encoding = DELIMITED;
+					message A {
+						A a = 1 [features={
+							message_encoding : LENGTH_PREFIXED,
+						}];
+						repeated A as = 2 [features.message_encoding=DELIMITED];
+					}
+				`,
+			},
+		},
+		"failure_message_encoding_not_message": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						repeated string s = 1 [features={
+							message_encoding : LENGTH_PREFIXED,
+						}];
+					}
+				`,
+			},
+			expectedErr: `test.proto:5:17: only message fields may specify message encoding`,
+		},
+		"failure_message_encoding_map": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						map<string,string> m = 1 [features={
+							message_encoding : LENGTH_PREFIXED,
+						}];
+					}
+				`,
+			},
+			expectedErr: `test.proto:5:17: only message fields may specify message encoding`,
+		},
+		"success_editions_ctype": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						string s = 1 [ctype=CORD];
+						bytes b = 2 [ctype=STRING_PIECE];
+						repeated string r = 3 [ctype=STRING];
+						extensions 10 to 100;
+					}
+					extend A {
+						string ext = 10 [ctype=STRING_PIECE];
+					}
+				`,
+			},
+		},
+		"failure_editions_ctype_not_string_or_bytes": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						uint32 s = 1 [ctype=STRING_PIECE];
+					}
+				`,
+			},
+			expectedErr: `test.proto:4:23: ctype option can only be used on string and bytes fields`,
+		},
+		"failure_editions_ctype_ext_cannot_be_cord": {
+			input: map[string]string{
+				"test.proto": `
+					edition = "2023";
+					package foo;
+					message A {
+						extensions 10 to 100;
+					}
+					extend A {
+						string ext = 10 [ctype=CORD];
+					}
+				`,
+			},
+			expectedErr: `test.proto:7:26: ctype option cannot be CORD for extension fields`,
 		},
 	}
 

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -281,7 +281,7 @@ func (r *result) validateEnum(d protoreflect.EnumDescriptor, handler *reporter.H
 			return fmt.Errorf("enum value descriptor is wrong type: expecting %T, got %T", (*enValDescriptor)(nil), firstValue)
 		}
 		info := file.NodeInfo(r.EnumValueNode(evd.proto).GetNumber())
-		if err := handler.HandleErrorf(info, "first value of open enum %s must be zero", ed.FullName()); err != nil {
+		if err := handler.HandleErrorf(info, "first value of open enum %s must have numeric value zero", ed.FullName()); err != nil {
 			return err
 		}
 	}

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -89,7 +89,7 @@ func (r *result) validateFile(handler *reporter.Handler) error {
 		}
 		if opts != nil && opts.JavaStringCheckUtf8 != nil {
 			span := r.findOptionSpan(r, internal.FileOptionsJavaStringCheckUTF8Tag)
-			err := handler.HandleErrorf(span, `file option java_string_check_utf8 is not allowed with editions; import "google/protobuf/java_features.proto" and use the (pb.java).utf8_validation instead`)
+			err := handler.HandleErrorf(span, `file option java_string_check_utf8 is not allowed with editions; import "google/protobuf/java_features.proto" and use (pb.java).utf8_validation instead`)
 			if err != nil {
 				return err
 			}
@@ -917,7 +917,7 @@ func findOptionSpan(
 			// Either an exact match (if equal) or this option points *inside* the
 			// item we care about (if greater). Either way, the first such result
 			// is a keeper.
-			bestMatch = n.Val
+			bestMatch = n.Name.Parts[len(path)-1]
 			bestMatchLen = len(n.Name.Parts)
 			return false
 		}

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -353,6 +353,14 @@ func validateEnum(res *result, syntax protoreflect.Syntax, name protoreflect.Ful
 		}
 	}
 
+	if syntax == protoreflect.Proto3 && len(ed.Value) > 0 && ed.Value[0].GetNumber() != 0 {
+		evNode := res.EnumValueNode(ed.Value[0])
+		evNodeInfo := res.file.NodeInfo(evNode.GetNumber())
+		if err := handler.HandleErrorf(evNodeInfo, "%s: proto3 requires that first value of enum have numeric value zero", scope); err != nil {
+			return err
+		}
+	}
+
 	// check for aliases
 	vals := map[int32]string{}
 	hasAlias := false

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -248,6 +248,10 @@ func TestBasicValidation(t *testing.T) {
 			contents:    `enum Foo { V0 = 0; reserved 1 to 20; reserved 20 to 40; reserved "V2"; }`,
 			expectedErr: `test.proto:1:47: enum Foo: reserved ranges overlap: 1 to 20 and 20 to 40`,
 		},
+		"failure_proto3_enum_zero_value": {
+			contents:    `syntax = "proto3"; enum Foo { FIRST = 1; }`,
+			expectedErr: `test.proto:1:39: enum Foo: proto3 requires that first value of enum have numeric value zero`,
+		},
 		"failure_message_number_conflict": {
 			contents:    `syntax = "proto3"; message Foo { string s = 1; int32 i = 1; }`,
 			expectedErr: `test.proto:1:58: message Foo: fields s and i both have the same tag 1`,

--- a/reporting_test.go
+++ b/reporting_test.go
@@ -105,6 +105,7 @@ func TestErrorReporting(t *testing.T) {
 			expectedErrs: [][]string{
 				{
 					"test.proto:4:62: tag number 0 must be greater than zero",
+					"test.proto:8:55: enum Bar: proto3 requires that first value of enum have numeric value zero",
 					"test.proto:9:56: enum Bar: values BAZ and BUZZ both have the same numeric value 1; use allow_alias option if intentional",
 				},
 			},


### PR DESCRIPTION
This adds lots of validation of feature values, to mirror the logic performed in `protoc`.

This also adds some other validation checks that are implemented in `protoc` but were not previously implemented here in protocompile.

This would have been the last change needed to support editions in protocompile, except it looks like we'll also need to support extra validation of which features are allowed in which editions (see this protoc commit that just landed this week: https://github.com/protocolbuffers/protobuf/commit/b09b3e46fe2a111d412251f6d043649334e9cbee).

Since that change includes new stuff in `descriptor.proto` which isn't likely to make it into protobuf-go's `descriptorpb` package until v27 is released (or at least until the first release candidate is made available), we'll need to provide a stop-gap here to opt into editions support. I was _hoping_ to just enable editions support in this repo once the work was complete; but now it won't be complete until after the above happens, yet we need to start working with the support that has been implemented so far in order to update logic in the buf CLI. So we'll have to expose the current internal flag to allow importing code (like the buf CLI) to opt into working with editions so we can implement and test editions-related things there.