### PR TITLE
Use functions instead of a var for internal editions flag

### DIFF
--- a/internal/editions.go
+++ b/internal/editions.go
@@ -16,10 +16,20 @@ package internal
 
 import "google.golang.org/protobuf/types/descriptorpb"
 
-// AllowEditions is set to true in tests to enable editions syntax for testing.
-// This will be removed and editions will be allowed by non-test code once the
+var allowEditions = false
+
+// AllowEditionsForTest is called to enable editions syntax for testing. This
+// will be removed and editions will be allowed by non-test code once the
 // implementation is complete.
-var AllowEditions = false
+func AllowEditionsForTest() {
+	allowEditions = true
+}
+
+// IsEditionsAllowed returns true if editions syntax is allowed by the compiler.
+// This is currently only enabled from tests.
+func IsEditionsAllowed() bool {
+	return allowEditions
+}
 
 // SupportedEditions is the exhaustive set of editions that protocompile
 // can support. We don't allow it to compile future/unknown editions, to

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -41,7 +41,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// Enable just for tests.
-	internal.AllowEditions = true
+	internal.AllowEditionsForTest()
 	status := m.Run()
 	os.Exit(status)
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -45,7 +45,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// Enable just for tests.
-	internal.AllowEditions = true
+	internal.AllowEditionsForTest()
 	status := m.Run()
 	os.Exit(status)
 }

--- a/parser/result.go
+++ b/parser/result.go
@@ -107,7 +107,7 @@ func (r *result) createFileDescriptor(filename string, file *ast.FileNode, handl
 			fd.Syntax = proto.String(file.Syntax.Syntax.AsString())
 		}
 	case file.Edition != nil:
-		if !internal.AllowEditions {
+		if !internal.IsEditionsAllowed() {
 			nodeInfo := file.NodeInfo(file.Edition.Edition)
 			if handler.HandleErrorf(nodeInfo, `editions are not yet supported; use syntax proto2 or proto3 instead`) != nil {
 				return

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// Enable just for tests.
-	internal.AllowEditions = true
+	internal.AllowEditionsForTest()
 	status := m.Run()
 	os.Exit(status)
 }


### PR DESCRIPTION
This should allow a sneaky user of this repo to override `internal.IsEditionsAllowed` to return true (via `go:linkname`), if one really wanted to enable editions even though the implementation is not technically complete. We should be able to use this trick to start implementing and testing stuff in the Buf CLI related to editions without actually enabling support for editions for users yet.