### PR TITLE
Validate target type for all option fields, not just features

### DIFF
--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -1378,7 +1378,8 @@ func TestLinkerValidation(t *testing.T) {
 					  };
 					}`,
 			},
-			expectedErr: `foo.proto:9:6: message foo.bar.Baz: option (foo.bar.any): any type references cannot be repeated or mixed with other fields`,
+			expectedErr: `foo.proto:9:6: message foo.bar.Baz: option (foo.bar.any): any type references cannot be repeated or mixed with other fields` +
+				` && foo.proto:13:6: message foo.bar.Baz: option (foo.bar.any): any type references cannot be repeated or mixed with other fields`,
 		},
 		"failure_scope_type_name": {
 			input: map[string]string{
@@ -2443,7 +2444,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:3:27: feature "enum_type" is allowed on [enum,file], not on field`,
+			expectedErr: `test.proto:3:27: field "google.protobuf.FeatureSet.enum_type" is allowed on [enum,file], not on field`,
 		},
 		"failure_editions_feature_on_wrong_target_type_msg_literal": {
 			input: map[string]string{
@@ -2456,7 +2457,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:4:5: feature "enum_type" is allowed on [enum,file], not on field`,
+			expectedErr: `test.proto:4:5: field "google.protobuf.FeatureSet.enum_type" is allowed on [enum,file], not on field`,
 		},
 		"failure_proto3_enum_zero_value": {
 			input: map[string]string{

--- a/options/options.go
+++ b/options/options.go
@@ -47,16 +47,6 @@ import (
 	"github.com/bufbuild/protocompile/sourceinfo"
 )
 
-const (
-	// featuresFieldName is the name of a field in every options message.
-	featuresFieldName = "features"
-)
-
-var (
-	featureSetType = (*descriptorpb.FeatureSet)(nil).ProtoReflect().Type()
-	featureSetName = featureSetType.Descriptor().FullName()
-)
-
 type interpreter struct {
 	file                    file
 	resolver                linker.Resolver
@@ -587,7 +577,6 @@ func (interp *interpreter) interpretOptions(
 	}
 	var remain []*descriptorpb.UninterpretedOption
 	var optNodes []*ast.OptionNode
-	var features []*ast.OptionNode
 	for _, uo := range uninterpreted {
 		isCustom := uo.Name[0].GetIsExtension()
 		if isCustom != customOpts {
@@ -614,7 +603,7 @@ func (interp *interpreter) interpretOptions(
 			}
 		}
 		mc.Option = uo
-		srcInfo, err := interp.interpretField(mc, msg, uo, 0, interp.pathBuffer)
+		srcInfo, err := interp.interpretField(targetType, mc, msg, uo, 0, interp.pathBuffer)
 		if err != nil {
 			if interp.lenient {
 				remain = append(remain, uo)
@@ -624,17 +613,10 @@ func (interp *interpreter) interpretOptions(
 		}
 		if optn, ok := node.(*ast.OptionNode); ok {
 			optNodes = append(optNodes, optn)
-			if !isCustom && uo.Name[0].GetNamePart() == featuresFieldName {
-				features = append(features, optn)
-			}
 			if srcInfo != nil {
 				interp.index[optn] = srcInfo
 			}
 		}
-	}
-
-	if err := interp.validateFeatures(targetType, msg, features); err != nil && !interp.lenient {
-		return nil, err
 	}
 
 	if interp.lenient {
@@ -668,103 +650,32 @@ func (interp *interpreter) interpretOptions(
 	return remain, nil
 }
 
-func (interp *interpreter) validateFeatures(
+func (interp *interpreter) checkFieldUsage(
 	targetType descriptorpb.FieldOptions_OptionTargetType,
-	opts protoreflect.Message,
-	features []*ast.OptionNode,
+	fld protoreflect.FieldDescriptor,
+	node ast.Node,
 ) error {
-	fld := opts.Descriptor().Fields().ByName(featuresFieldName)
-	if fld == nil {
-		// no features to resolve
-		return nil
-	}
-	if fld.IsList() || fld.Message() == nil || fld.Message().FullName() != featureSetName {
-		// features field doesn't look right... abort
-		// TODO: should this return an error?
-		return nil
-	}
-	featureSet := opts.Get(fld).Message()
-	var err error
-	featureSet.Range(func(featureField protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
-		opts, ok := featureField.Options().(*descriptorpb.FieldOptions)
-		if !ok {
-			return true
-		}
-		targetTypes := opts.GetTargets()
-		var allowed bool
-		for _, allowedType := range targetTypes {
-			if allowedType == targetType {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
-			allowedTypes := make([]string, len(targetTypes))
-			for i, t := range opts.Targets {
-				allowedTypes[i] = targetTypeString(t)
-			}
-			pos := interp.positionOfFeature(features, featuresFieldName, featureField.Name())
-			if len(opts.Targets) == 1 && opts.Targets[0] == descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN {
-				err = interp.reporter.HandleErrorf(pos, "feature field %q may not be used explicitly", featureField.Name())
-			} else {
-				err = interp.reporter.HandleErrorf(pos, "feature %q is allowed on [%s], not on %s", featureField.Name(), strings.Join(allowedTypes, ","), targetTypeString(targetType))
-			}
-		}
-		return err == nil
-	})
-	return err
-}
-
-func (interp *interpreter) positionOfFeature(features []*ast.OptionNode, fieldNames ...protoreflect.Name) ast.SourceSpan {
-	if interp.file.AST() == nil {
-		return ast.UnknownSpan(interp.file.FileDescriptorProto().GetName())
-	}
-	for _, feature := range features {
-		matched, remainingNames, nodePos, nodeValue := matchInterpretedOption(feature, fieldNames)
-		if !matched {
-			continue
-		}
-		if len(remainingNames) > 0 {
-			nodePos = findInterpretedFieldForFeature(nodePos, nodeValue, remainingNames)
-		}
-		if nodePos != nil {
-			return interp.file.FileNode().NodeInfo(nodePos)
-		}
-	}
-	return ast.UnknownSpan(interp.file.FileDescriptorProto().GetName())
-}
-
-func matchInterpretedOption(node *ast.OptionNode, path []protoreflect.Name) (bool, []protoreflect.Name, ast.Node, ast.ValueNode) {
-	for i := 0; i < len(path) && i < len(node.Name.Parts); i++ {
-		part := node.Name.Parts[i]
-		if !part.IsExtension() && protoreflect.Name(part.Name.AsIdentifier()) != path[i] {
-			return false, nil, nil, nil
-		}
-	}
-	if len(path) <= len(node.Name.Parts) {
-		// No more path elements to match. Report location
-		// of the final element of path inside option name.
-		return true, nil, node.Name.Parts[len(path)-1], node.Val
-	}
-	return true, path[len(node.Name.Parts):], node.Name.Parts[len(node.Name.Parts)-1], node.Val
-}
-
-func findInterpretedFieldForFeature(nodePos ast.Node, nodeValue ast.ValueNode, path []protoreflect.Name) ast.Node {
-	if len(path) == 0 {
-		return nodePos
-	}
-	msgNode, ok := nodeValue.(*ast.MessageLiteralNode)
+	opts, ok := fld.Options().(*descriptorpb.FieldOptions)
 	if !ok {
 		return nil
 	}
-	for _, fldNode := range msgNode.Elements {
-		if fldNode.Name.Open == nil && protoreflect.Name(fldNode.Name.Name.AsIdentifier()) == path[0] {
-			if res := findInterpretedFieldForFeature(fldNode.Name, fldNode.Val, path[1:]); res != nil {
-				return res
-			}
+	targetTypes := opts.GetTargets()
+	if len(targetTypes) == 0 {
+		return nil
+	}
+	for _, allowedType := range targetTypes {
+		if allowedType == targetType {
+			return nil
 		}
 	}
-	return nil
+	allowedTypes := make([]string, len(targetTypes))
+	for i, t := range targetTypes {
+		allowedTypes[i] = targetTypeString(t)
+	}
+	if len(targetTypes) == 1 && targetTypes[0] == descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN {
+		return interp.reporter.HandleErrorf(interp.nodeInfo(node), "field %q may not be used in an option (it declares no allowed target types)", fld.FullName())
+	}
+	return interp.reporter.HandleErrorf(interp.nodeInfo(node), "field %q is allowed on [%s], not on %s", fld.FullName(), strings.Join(allowedTypes, ","), targetTypeString(targetType))
 }
 
 func targetTypeString(t descriptorpb.FieldOptions_OptionTargetType) string {
@@ -1001,7 +912,12 @@ func findOptionValueNode(
 // msg must be an options message. For nameIndex > 0, msg is a nested message inside of the
 // options message. The given pathPrefix is the path (sequence of field numbers and indices
 // with a FileDescriptorProto as the start) up to but not including the given nameIndex.
+//
+// Any errors encountered will be handled, so the returned error will only be non-nil if
+// the handler returned non-nil. Callers must check that the source info is non-nil before
+// using it since it can be nil (in the event of a problem) even if the error is nil.
 func (interp *interpreter) interpretField(
+	targetType descriptorpb.FieldOptions_OptionTargetType,
 	mc *internal.MessageContext,
 	msg protoreflect.Message,
 	opt *descriptorpb.UninterpretedOption,
@@ -1040,6 +956,10 @@ func (interp *interpreter) interpretField(
 	}
 	pathPrefix = append(pathPrefix, int32(fld.Number()))
 
+	if err := interp.checkFieldUsage(targetType, fld, node); err != nil {
+		return nil, err
+	}
+
 	if len(opt.GetName()) > nameIndex+1 {
 		nextnm := opt.GetName()[nameIndex+1]
 		nextnode := interp.file.OptionNamePartNode(nextnm)
@@ -1072,7 +992,7 @@ func (interp *interpreter) interpretField(
 			msg.Set(fld, fldVal)
 		}
 		// recurse to set next part of name
-		return interp.interpretField(mc, fdm, opt, nameIndex+1, pathPrefix)
+		return interp.interpretField(targetType, mc, fdm, opt, nameIndex+1, pathPrefix)
 	}
 
 	optNode := interp.file.OptionNode(opt)
@@ -1080,14 +1000,14 @@ func (interp *interpreter) interpretField(
 	var srcInfo *sourceinfo.OptionSourceInfo
 	var err error
 	if optValNode.Value() == nil {
-		err = interp.setOptionFieldFromProto(mc, msg, fld, node, opt, optValNode)
+		err = interp.setOptionFieldFromProto(targetType, mc, msg, fld, node, opt, optValNode)
 		srcInfoVal := newSrcInfo(pathPrefix, nil)
 		srcInfo = &srcInfoVal
 	} else {
-		srcInfo, err = interp.setOptionField(mc, msg, fld, node, optValNode, false, pathPrefix)
+		srcInfo, err = interp.setOptionField(targetType, mc, msg, fld, node, optValNode, false, pathPrefix)
 	}
 	if err != nil {
-		return nil, interp.reporter.HandleError(err)
+		return nil, err
 	}
 
 	return srcInfo, nil
@@ -1097,6 +1017,7 @@ func (interp *interpreter) interpretField(
 // by AST node val. The given name is the AST node that corresponds to the name of fld. On success,
 // it returns additional metadata about the field that was set.
 func (interp *interpreter) setOptionField(
+	targetType descriptorpb.FieldOptions_OptionTargetType,
 	mc *internal.MessageContext,
 	msg protoreflect.Message,
 	fld protoreflect.FieldDescriptor,
@@ -1109,7 +1030,7 @@ func (interp *interpreter) setOptionField(
 	if sl, ok := v.([]ast.ValueNode); ok {
 		// handle slices a little differently than the others
 		if fld.Cardinality() != protoreflect.Repeated {
-			return nil, reporter.Errorf(interp.nodeInfo(val), "%vvalue is an array but field is not repeated", mc)
+			return nil, interp.reporter.HandleErrorf(interp.nodeInfo(val), "%vvalue is an array but field is not repeated", mc)
 		}
 		origPath := mc.OptAggPath
 		defer func() {
@@ -1124,8 +1045,8 @@ func (interp *interpreter) setOptionField(
 		}
 		for index, item := range sl {
 			mc.OptAggPath = fmt.Sprintf("%s[%d]", origPath, index)
-			value, srcInfo, err := interp.fieldValue(mc, msg, fld, item, insideMsgLiteral, append(pathPrefix, int32(firstIndex+index)))
-			if err != nil {
+			value, srcInfo, err := interp.fieldValue(targetType, mc, msg, fld, item, insideMsgLiteral, append(pathPrefix, int32(firstIndex+index)))
+			if err != nil || !value.IsValid() {
 				return nil, err
 			}
 			if fld.IsMap() {
@@ -1147,15 +1068,15 @@ func (interp *interpreter) setOptionField(
 		pathPrefix = append(pathPrefix, int32(msg.Get(fld).List().Len()))
 	}
 
-	value, srcInfo, err := interp.fieldValue(mc, msg, fld, val, insideMsgLiteral, pathPrefix)
-	if err != nil {
+	value, srcInfo, err := interp.fieldValue(targetType, mc, msg, fld, val, insideMsgLiteral, pathPrefix)
+	if err != nil || !value.IsValid() {
 		return nil, err
 	}
 
 	if ood := fld.ContainingOneof(); ood != nil {
 		existingFld := msg.WhichOneof(ood)
 		if existingFld != nil && existingFld.Number() != fld.Number() {
-			return nil, reporter.Errorf(interp.nodeInfo(name), "%voneof %q already has field %q set", mc, ood.Name(), fieldName(existingFld))
+			return nil, interp.reporter.HandleErrorf(interp.nodeInfo(name), "%voneof %q already has field %q set", mc, ood.Name(), fieldName(existingFld))
 		}
 	}
 
@@ -1168,7 +1089,7 @@ func (interp *interpreter) setOptionField(
 		lv.Append(value)
 	default:
 		if msg.Has(fld) {
-			return nil, reporter.Errorf(interp.nodeInfo(name), "%vnon-repeated option field %s already set", mc, fieldName(fld))
+			return nil, interp.reporter.HandleErrorf(interp.nodeInfo(name), "%vnon-repeated option field %s already set", mc, fieldName(fld))
 		}
 		msg.Set(fld, value)
 	}
@@ -1180,6 +1101,7 @@ func (interp *interpreter) setOptionField(
 // to report source positions in error messages. On success, it returns additional metadata
 // about the field that was set.
 func (interp *interpreter) setOptionFieldFromProto(
+	targetType descriptorpb.FieldOptions_OptionTargetType,
 	mc *internal.MessageContext,
 	msg protoreflect.Message,
 	fld protoreflect.FieldDescriptor,
@@ -1193,13 +1115,13 @@ func (interp *interpreter) setOptionFieldFromProto(
 	case protoreflect.EnumKind:
 		num, _, err := interp.enumFieldValueFromProto(mc, fld.Enum(), opt, node)
 		if err != nil {
-			return err
+			return interp.reporter.HandleError(err)
 		}
 		value = protoreflect.ValueOfEnum(num)
 
 	case protoreflect.MessageKind, protoreflect.GroupKind:
 		if opt.AggregateValue == nil {
-			return reporter.Errorf(interp.nodeInfo(node), "%vexpecting message, got %s", mc, optionValueKind(opt))
+			return interp.reporter.HandleErrorf(interp.nodeInfo(node), "%vexpecting message, got %s", mc, optionValueKind(opt))
 		}
 		// We must parse the text format from the aggregate value string
 		var elem protoreflect.Message
@@ -1216,14 +1138,17 @@ func (interp *interpreter) setOptionFieldFromProto(
 			AllowPartial: true,
 		}.Unmarshal([]byte(opt.GetAggregateValue()), elem.Interface())
 		if err != nil {
-			return reporter.Errorf(interp.nodeInfo(node), "%vfailed to parse message literal %w", mc, err)
+			return interp.reporter.HandleErrorf(interp.nodeInfo(node), "%vfailed to parse message literal %w", mc, err)
+		}
+		if err := interp.checkFieldUsages(targetType, elem, node); err != nil {
+			return err
 		}
 		value = protoreflect.ValueOfMessage(elem)
 
 	default:
 		v, err := interp.scalarFieldValueFromProto(mc, descriptorpb.FieldDescriptorProto_Type(k), opt, node)
 		if err != nil {
-			return err
+			return interp.reporter.HandleError(err)
 		}
 		value = protoreflect.ValueOf(v)
 	}
@@ -1231,7 +1156,7 @@ func (interp *interpreter) setOptionFieldFromProto(
 	if ood := fld.ContainingOneof(); ood != nil {
 		existingFld := msg.WhichOneof(ood)
 		if existingFld != nil && existingFld.Number() != fld.Number() {
-			return reporter.Errorf(interp.nodeInfo(name), "%voneof %q already has field %q set", mc, ood.Name(), fieldName(existingFld))
+			return interp.reporter.HandleErrorf(interp.nodeInfo(name), "%voneof %q already has field %q set", mc, ood.Name(), fieldName(existingFld))
 		}
 	}
 
@@ -1243,11 +1168,45 @@ func (interp *interpreter) setOptionFieldFromProto(
 		msg.Mutable(fld).List().Append(value)
 	default:
 		if msg.Has(fld) {
-			return reporter.Errorf(interp.nodeInfo(name), "%vnon-repeated option field %s already set", mc, fieldName(fld))
+			return interp.reporter.HandleErrorf(interp.nodeInfo(name), "%vnon-repeated option field %s already set", mc, fieldName(fld))
 		}
 		msg.Set(fld, value)
 	}
 	return nil
+}
+
+func (interp *interpreter) checkFieldUsages(
+	targetType descriptorpb.FieldOptions_OptionTargetType,
+	msg protoreflect.Message,
+	node ast.Node,
+) error {
+	var err error
+	msg.Range(func(fld protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+		err = interp.checkFieldUsage(targetType, fld, node)
+		if err != nil {
+			return false
+		}
+		switch {
+		case fld.IsList() && fld.Message() != nil:
+			listVal := val.List()
+			for i, length := 0, listVal.Len(); i < length; i++ {
+				err = interp.checkFieldUsages(targetType, listVal.Get(i).Message(), node)
+				if err != nil {
+					return false
+				}
+			}
+		case fld.IsMap() && fld.MapValue().Message() != nil:
+			mapVal := val.Map()
+			mapVal.Range(func(_ protoreflect.MapKey, val protoreflect.Value) bool {
+				err = interp.checkFieldUsages(targetType, val.Message(), node)
+				return err == nil
+			})
+		case !fld.IsMap() && fld.Message() != nil:
+			err = interp.checkFieldUsages(targetType, val.Message(), node)
+		}
+		return err == nil
+	})
+	return err
 }
 
 func setMapEntry(
@@ -1387,7 +1346,12 @@ func optionValueKind(opt *descriptorpb.UninterpretedOption) string {
 
 // fieldValue computes a compile-time value (constant or list or message literal) for the given
 // AST node val. The value in val must be assignable to the field fld.
+//
+// If the returned value is not valid, then an error occurred during processing.
+// The returned err may be nil, however, as any errors will already have been
+// handled (so the resulting error could be nil if the handler returned nil).
 func (interp *interpreter) fieldValue(
+	targetType descriptorpb.FieldOptions_OptionTargetType,
 	mc *internal.MessageContext,
 	msg protoreflect.Message,
 	fld protoreflect.FieldDescriptor,
@@ -1400,7 +1364,7 @@ func (interp *interpreter) fieldValue(
 	case protoreflect.EnumKind:
 		num, _, err := interp.enumFieldValue(mc, fld.Enum(), val, insideMsgLiteral)
 		if err != nil {
-			return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+			return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, interp.reporter.HandleError(err)
 		}
 		return protoreflect.ValueOfEnum(num), newSrcInfo(pathPrefix, nil), nil
 
@@ -1420,15 +1384,15 @@ func (interp *interpreter) fieldValue(
 				// Normal message field
 				childMsg = msg.NewField(fld).Message()
 			}
-			return interp.messageLiteralValue(mc, aggs, childMsg, pathPrefix)
+			return interp.messageLiteralValue(targetType, mc, aggs, childMsg, pathPrefix)
 		}
 		return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-			reporter.Errorf(interp.nodeInfo(val), "%vexpecting message, got %s", mc, valueKind(v))
+			interp.reporter.HandleErrorf(interp.nodeInfo(val), "%vexpecting message, got %s", mc, valueKind(v))
 
 	default:
 		v, err := interp.scalarFieldValue(mc, descriptorpb.FieldDescriptorProto_Type(k), val, insideMsgLiteral)
 		if err != nil {
-			return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+			return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, interp.reporter.HandleError(err)
 		}
 		return protoreflect.ValueOf(v), newSrcInfo(pathPrefix, nil), nil
 	}
@@ -1800,7 +1764,13 @@ func descriptorType(m proto.Message) string {
 	}
 }
 
+// messageLiteralValue processes a message literal value.
+//
+// If the returned value is not valid, then an error occurred during processing.
+// The returned err may be nil, however, as any errors will already have been
+// handled (so the resulting error could be nil if the handler returned nil).
 func (interp *interpreter) messageLiteralValue(
+	targetType descriptorpb.FieldOptions_OptionTargetType,
 	mc *internal.MessageContext,
 	fieldNodes []*ast.MessageFieldNode,
 	msg protoreflect.Message,
@@ -1812,6 +1782,7 @@ func (interp *interpreter) messageLiteralValue(
 		mc.OptAggPath = origPath
 	}()
 	flds := make(map[*ast.MessageFieldNode]*sourceinfo.OptionSourceInfo, len(fieldNodes))
+	var hadError bool
 	for _, fieldNode := range fieldNodes {
 		if origPath == "" {
 			mc.OptAggPath = fieldNode.Name.Value()
@@ -1820,13 +1791,57 @@ func (interp *interpreter) messageLiteralValue(
 		}
 		if fieldNode.Name.IsAnyTypeReference() {
 			if len(fieldNodes) > 1 {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vany type references cannot be repeated or mixed with other fields", mc)
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vany type references cannot be repeated or mixed with other fields", mc)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
 			}
+
 			if fmd.FullName() != "google.protobuf.Any" {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vtype references are only allowed for google.protobuf.Any, but this type is %s", mc, fmd.FullName())
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vtype references are only allowed for google.protobuf.Any, but this type is %s", mc, fmd.FullName())
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
 			}
+			typeURLDescriptor := fmd.Fields().ByNumber(internal.AnyTypeURLTag)
+			var err error
+			switch {
+			case typeURLDescriptor == nil:
+				err = fmt.Errorf("message schema is missing type_url field (number %d)", internal.AnyTypeURLTag)
+			case typeURLDescriptor.IsList():
+				err = fmt.Errorf("message schema has type_url field (number %d) that is a list but should be singular", internal.AnyTypeURLTag)
+			case typeURLDescriptor.Kind() != protoreflect.StringKind:
+				err = fmt.Errorf("message schema has type_url field (number %d) that is %s but should be string", internal.AnyTypeURLTag, typeURLDescriptor.Kind())
+			}
+			if err != nil {
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name), "%v%w", mc, err)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
+			}
+			valueDescriptor := fmd.Fields().ByNumber(internal.AnyValueTag)
+			switch {
+			case valueDescriptor == nil:
+				err = fmt.Errorf("message schema is missing value field (number %d)", internal.AnyValueTag)
+			case valueDescriptor.IsList():
+				err = fmt.Errorf("message schema has value field (number %d) that is a list but should be singular", internal.AnyValueTag)
+			case valueDescriptor.Kind() != protoreflect.BytesKind:
+				err = fmt.Errorf("message schema has value field (number %d) that is %s but should be bytes", internal.AnyValueTag, valueDescriptor.Kind())
+			}
+			if err != nil {
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name), "%v%w", mc, err)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
+			}
+
 			urlPrefix := fieldNode.Name.URLPrefix.AsIdentifier()
 			msgName := fieldNode.Name.Name.AsIdentifier()
 			fullURL := fmt.Sprintf("%s/%s", urlPrefix, msgName)
@@ -1838,104 +1853,137 @@ func (interp *interpreter) messageLiteralValue(
 			// file's transitive closure to find the named message, since that
 			// is what protoc does.
 			if urlPrefix != "type.googleapis.com" && urlPrefix != "type.googleprod.com" {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vcould not resolve type reference %s", mc, fullURL)
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vcould not resolve type reference %s", mc, fullURL)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
 			}
 			anyFields, ok := fieldNode.Val.Value().([]*ast.MessageFieldNode)
 			if !ok {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Val), "%vtype references for google.protobuf.Any must have message literal value", mc)
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Val), "%vtype references for google.protobuf.Any must have message literal value", mc)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
 			}
 			anyMd := resolveDescriptor[protoreflect.MessageDescriptor](interp.resolver, string(msgName))
 			if anyMd == nil {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vcould not resolve type reference %s", mc, fullURL)
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name.URLPrefix), "%vcould not resolve type reference %s", mc, fullURL)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
 			}
 			// parse the message value
-			msgVal, valueSrcInfo, err := interp.messageLiteralValue(mc, anyFields, dynamicpb.NewMessage(anyMd), append(pathPrefix, internal.AnyValueTag))
+			msgVal, valueSrcInfo, err := interp.messageLiteralValue(targetType, mc, anyFields, dynamicpb.NewMessage(anyMd), append(pathPrefix, internal.AnyValueTag))
 			if err != nil {
 				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
-			}
-
-			typeURLDescriptor := fmd.Fields().ByNumber(internal.AnyTypeURLTag)
-			if typeURLDescriptor == nil || typeURLDescriptor.Kind() != protoreflect.StringKind {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name), "%vfailed to set type_url string field on Any: %w", mc, err)
-			}
-			typeURLVal := protoreflect.ValueOfString(fullURL)
-			msg.Set(typeURLDescriptor, typeURLVal)
-			valueDescriptor := fmd.Fields().ByNumber(internal.AnyValueTag)
-			if valueDescriptor == nil || valueDescriptor.Kind() != protoreflect.BytesKind {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name), "%vfailed to set value bytes field on Any: %w", mc, err)
+			} else if !msgVal.IsValid() {
+				hadError = true
+				continue
 			}
 
 			b, err := (proto.MarshalOptions{Deterministic: true}).Marshal(msgVal.Message().Interface())
 			if err != nil {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Val), "%vfailed to serialize message value: %w", mc, err)
+				err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Val), "%vfailed to serialize message value: %w", mc, err)
+				if err != nil {
+					return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+				}
+				hadError = true
+				continue
 			}
-			msg.Set(valueDescriptor, protoreflect.ValueOfBytes(b))
-			flds[fieldNode] = &valueSrcInfo
-		} else {
-			var ffld protoreflect.FieldDescriptor
-			var err error
-			if fieldNode.Name.IsExtension() {
-				n := interp.file.ResolveMessageLiteralExtensionName(fieldNode.Name.Name)
-				if n == "" {
-					// this should not be possible!
-					n = string(fieldNode.Name.Name.AsIdentifier())
-				}
-				ffld, err = interp.resolveExtensionType(n)
-				if errors.Is(err, protoregistry.NotFound) {
-					// may need to qualify with package name
-					// (this should not be necessary!)
-					pkg := mc.File.FileDescriptorProto().GetPackage()
-					if pkg != "" {
-						ffld, err = interp.resolveExtensionType(pkg + "." + n)
-					}
-				}
-			} else {
-				ffld = fmd.Fields().ByName(protoreflect.Name(fieldNode.Name.Value()))
-				if ffld == nil {
-					err = protoregistry.NotFound
-					// It could be a proto2 group, where the text format refers to the group type
-					// name, and the field name is the lower-cased form of that.
-					ffld = fmd.Fields().ByName(protoreflect.Name(strings.ToLower(fieldNode.Name.Value())))
-					if ffld != nil {
-						// In editions, we support using the group type name only for fields that
-						// "look like" proto2 groups.
-						if protoreflect.Name(fieldNode.Name.Value()) == ffld.Message().Name() && // text format uses type name
-							ffld.Message().FullName().Parent() == ffld.FullName().Parent() && // message and field declared in same scope
-							ffld.Kind() == protoreflect.GroupKind /* uses delimited encoding */ {
-							// This one looks like a proto2 group, so it's a keeper.
-							err = nil
-						} else {
-							// It doesn't look like a proto2 group, so this is not a match.
-							ffld = nil
-						}
-					}
-				}
+
+			// Success!
+			if !hadError {
+				msg.Set(typeURLDescriptor, protoreflect.ValueOfString(fullURL))
+				msg.Set(valueDescriptor, protoreflect.ValueOfBytes(b))
+				flds[fieldNode] = &valueSrcInfo
 			}
+			continue
+		}
+
+		// Not expanded Any syntax; handle normal field.
+		var ffld protoreflect.FieldDescriptor
+		var err error
+		if fieldNode.Name.IsExtension() {
+			n := interp.file.ResolveMessageLiteralExtensionName(fieldNode.Name.Name)
+			if n == "" {
+				// this should not be possible!
+				n = string(fieldNode.Name.Name.AsIdentifier())
+			}
+			ffld, err = interp.resolveExtensionType(n)
 			if errors.Is(err, protoregistry.NotFound) {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Name), "%vfield %s not found", mc, string(fieldNode.Name.Name.AsIdentifier()))
-			} else if err != nil {
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Error(interp.nodeInfo(fieldNode.Name), err)
+				// may need to qualify with package name
+				// (this should not be necessary!)
+				pkg := mc.File.FileDescriptorProto().GetPackage()
+				if pkg != "" {
+					ffld, err = interp.resolveExtensionType(pkg + "." + n)
+				}
 			}
-			if fieldNode.Sep == nil && ffld.Message() == nil {
-				// If there is no separator, the field type should be a message.
-				// Otherwise, it is an error in the text format.
-				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{},
-					reporter.Errorf(interp.nodeInfo(fieldNode.Val), "syntax error: unexpected value, expecting ':'")
+		} else {
+			ffld = fmd.Fields().ByName(protoreflect.Name(fieldNode.Name.Value()))
+			if ffld == nil {
+				err = protoregistry.NotFound
+				// It could be a proto2 group, where the text format refers to the group type
+				// name, and the field name is the lower-cased form of that.
+				ffld = fmd.Fields().ByName(protoreflect.Name(strings.ToLower(fieldNode.Name.Value())))
+				if ffld != nil {
+					// In editions, we support using the group type name only for fields that
+					// "look like" proto2 groups.
+					if protoreflect.Name(fieldNode.Name.Value()) == ffld.Message().Name() && // text format uses type name
+						ffld.Message().FullName().Parent() == ffld.FullName().Parent() && // message and field declared in same scope
+						ffld.Kind() == protoreflect.GroupKind /* uses delimited encoding */ {
+						// This one looks like a proto2 group, so it's a keeper.
+						err = nil
+					} else {
+						// It doesn't look like a proto2 group, so this is not a match.
+						ffld = nil
+					}
+				}
 			}
-			srcInfo, err := interp.setOptionField(mc, msg, ffld, fieldNode.Name, fieldNode.Val, true, append(pathPrefix, int32(ffld.Number())))
+		}
+		if errors.Is(err, protoregistry.NotFound) {
+			err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Name), "%vfield %s not found", mc, string(fieldNode.Name.Name.AsIdentifier()))
 			if err != nil {
 				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
 			}
+			hadError = true
+			continue
+		} else if err != nil {
+			err := interp.reporter.HandleErrorWithPos(interp.nodeInfo(fieldNode.Name), err)
+			if err != nil {
+				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+			}
+			hadError = true
+			continue
+		}
+		if err := interp.checkFieldUsage(targetType, ffld, fieldNode.Name); err != nil {
+			return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+		}
+		if fieldNode.Sep == nil && ffld.Message() == nil {
+			// If there is no separator, the field type should be a message.
+			// Otherwise, it is an error in the text format.
+			err := interp.reporter.HandleErrorf(interp.nodeInfo(fieldNode.Val), "syntax error: unexpected value, expecting ':'")
+			if err != nil {
+				return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+			}
+			hadError = true
+			continue
+		}
+		srcInfo, err := interp.setOptionField(targetType, mc, msg, ffld, fieldNode.Name, fieldNode.Val, true, append(pathPrefix, int32(ffld.Number())))
+		if err != nil {
+			return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, err
+		}
+		if srcInfo != nil {
 			flds[fieldNode] = srcInfo
 		}
+	}
+	if hadError {
+		return protoreflect.Value{}, sourceinfo.OptionSourceInfo{}, nil
 	}
 	return protoreflect.ValueOfMessage(msg),
 		newSrcInfo(pathPrefix, &sourceinfo.MessageLiteralSourceInfo{Fields: flds}),


### PR DESCRIPTION
The code to verify that a feature field was only used on particular kind of element was features-specific. However, in `protoc`, it is not features-specific and applies to _all_ option fields that have a `targets` option defined.

This PR is a bit complicated because I had to change the error handling of the `*interpreter.fieldValue` method (and the `setOptionField` method that called it, as well as numerous methods that it used). It previously either returned a value or an error. If it returned an error, it would be reported by the caller. Even in the previous iteration of the code, this was not optimal because it meant that we had to abort processing an option value after the first error, instead of being able to potentially report multiple errors in the same option. But now, since the `targets` usage really doesn't impact the rest of the processing of an option value, it seems weird to abort that processing just because of a target type usage issue.

_So now_, the `*interpreter.fieldValue` method _handles_ the errors that come up and only returns a non-nil error if the handler returns a non-nil error. That means calling code can no longer rely on `err == nil` but must separately check that the other returned value is valid/non-nil.

This change is the cause for most of the change/churn in the code.

The actual change to target type validation is a net simplification, which is nice.