### PR TITLE
Linker tests allow compiler to report multiple errors; fix ensuing issues with redundant/inaccurate errors reported

### DIFF
--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -173,6 +173,11 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 		}
 	}
 
+	// This is to de-dupe extendee-releated error messages when the same
+	// extendee is referenced from multiple extension field definitions.
+	// We leave it nil if there's no AST.
+	var extendeeNodes map[ast.Node]struct{}
+
 	return walk.DescriptorsEnterAndExit(r,
 		func(d protoreflect.Descriptor) error {
 			fqn := d.FullName()
@@ -203,7 +208,10 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 						return err
 					}
 				}
-				if err := resolveFieldTypes(d.field, handler, s, scopes); err != nil {
+				if extendeeNodes == nil && r.AST() != nil {
+					extendeeNodes = map[ast.Node]struct{}{}
+				}
+				if err := resolveFieldTypes(d.field, handler, extendeeNodes, s, scopes); err != nil {
 					return err
 				}
 				if r.Syntax() == protoreflect.Proto3 && !allowedProto3Extendee(d.field.proto.GetExtendee()) {
@@ -219,7 +227,7 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 						return err
 					}
 				}
-				if err := resolveFieldTypes(d, handler, s, scopes); err != nil {
+				if err := resolveFieldTypes(d, handler, nil, s, scopes); err != nil {
 					return err
 				}
 			case *oneofDescriptor:
@@ -291,7 +299,7 @@ func allowedProto3Extendee(n string) bool {
 	return ok
 }
 
-func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, scopes []scope) error {
+func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, extendees map[ast.Node]struct{}, s *Symbols, scopes []scope) error {
 	r := f.file
 	fld := f.proto
 	file := r.FileNode()
@@ -299,17 +307,37 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, s *Symbols, 
 	scope := fmt.Sprintf("field %s", f.fqn)
 	if fld.GetExtendee() != "" {
 		scope := fmt.Sprintf("extension %s", f.fqn)
+		var alreadyReported bool
+		var extendeePrefix string
+		if extendees == nil {
+			extendeePrefix = scope + ": "
+		} else {
+			_, alreadyReported = extendees[node.FieldExtendee()]
+			if !alreadyReported {
+				extendees[node.FieldExtendee()] = struct{}{}
+			}
+		}
 		dsc := r.resolve(fld.GetExtendee(), false, scopes)
 		if dsc == nil {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "unknown extendee type %s", fld.GetExtendee())
+			if alreadyReported {
+				return nil
+			}
+			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "%sunknown extendee type %s", extendeePrefix, fld.GetExtendee())
 		}
 		if isSentinelDescriptor(dsc) {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "unknown extendee type %s; resolved to %s which is not defined; consider using a leading dot", fld.GetExtendee(), dsc.FullName())
+			if alreadyReported {
+				return nil
+			}
+			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "%sunknown extendee type %s; resolved to %s which is not defined; consider using a leading dot", extendeePrefix, fld.GetExtendee(), dsc.FullName())
 		}
 		extd, ok := dsc.(protoreflect.MessageDescriptor)
 		if !ok {
-			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "extendee is invalid: %s is %s, not a message", dsc.FullName(), descriptorTypeWithArticle(dsc))
+			if alreadyReported {
+				return nil
+			}
+			return handler.HandleErrorf(file.NodeInfo(node.FieldExtendee()), "%sextendee is invalid: %s is %s, not a message", extendeePrefix, dsc.FullName(), descriptorTypeWithArticle(dsc))
 		}
+
 		f.extendee = extd
 		extendeeName := "." + string(dsc.FullName())
 		if fld.GetExtendee() != extendeeName {

--- a/sourceinfo/source_code_info.go
+++ b/sourceinfo/source_code_info.go
@@ -45,6 +45,10 @@ type OptionSourceInfo struct {
 	// The source info path to this element. If this element represents a
 	// declaration with an array-literal value, the last element of the
 	// path is the index of the first item in the array.
+	//
+	// This path is relative to the options message. So the first element
+	// is a field number of the options message.
+	//
 	// If the first element is negative, it indicates the number of path
 	// components to remove from the path to the relevant options. This is
 	// used for field pseudo-options, so that the path indicates a field on
@@ -53,8 +57,8 @@ type OptionSourceInfo struct {
 	Path []int32
 	// Children can be an *ArrayLiteralSourceInfo, a *MessageLiteralSourceInfo,
 	// or nil, depending on whether the option's value is an
-	// *ast.ArrayLiteralNode, an *ast.MessageLiteralNode, or neither.
-	// For *ast.ArrayLiteralNode values, this is only populated if the
+	// [*ast.ArrayLiteralNode], an [*ast.MessageLiteralNode], or neither.
+	// For [*ast.ArrayLiteralNode] values, this is only populated if the
 	// value is a non-empty array of messages. (Empty arrays and arrays
 	// of scalar values do not need any additional info.)
 	Children OptionChildrenSourceInfo
@@ -67,7 +71,7 @@ type OptionChildrenSourceInfo interface {
 }
 
 // ArrayLiteralSourceInfo represents source info paths for the child
-// elements of an *ast.ArrayLiteralNode. This value is only useful for
+// elements of an [*ast.ArrayLiteralNode]. This value is only useful for
 // non-empty array literals that contain messages.
 type ArrayLiteralSourceInfo struct {
 	Elements []OptionSourceInfo
@@ -76,7 +80,7 @@ type ArrayLiteralSourceInfo struct {
 func (*ArrayLiteralSourceInfo) isChildSourceInfo() {}
 
 // MessageLiteralSourceInfo represents source info paths for the child
-// elements of an *ast.MessageLiteralNode.
+// elements of an [*ast.MessageLiteralNode].
 type MessageLiteralSourceInfo struct {
 	Fields map[*ast.MessageFieldNode]*OptionSourceInfo
 }


### PR DESCRIPTION
This is another pre-factoring step. Currently, when interpreting an option value, the value is a "leaf" in the error checking. That means it returns either a value or an error. If it returns an error, the caller will report it. If the configured error handler returns nil, the operation keeps going, to allow collecting multiple errors in a single pass instead of failing fast. But I want to change this so that we can report multiple errors even about a single option value. The main use for this is to report all relevant errors inside a message literal, which is a complex composite value that could contain more than one problem.

When I changed the linker test to report and compare _all_ errors, I actually discovered numerous problems. In some cases (when there was a problem with the `default` or `json_name` for a field, or if an extension declaration had no name or type), it would follow up with inaccurate/confusing error messages. And in some other cases, it would report duplicate/redundant errors.

So this fixes those issues so that the only errors reported are useful. This also _improves_ the error reporting for if a message in an option had missing required fields. Previously, this would always report line 1, column 1 (the starting position of the whole file), because it wasn't obvious how to report the position of a value that is **not** present (and looking up _any_ value is a bit of a hassle, TBH). I've changed it to find the best match for the containing message (in which the field is absent). If the options used de-structured options for the message (i.e. each field in a separate option statement), it will report the location of the first such option. But if the options used a message literal, it will use the location of that value.