### PR TITLE
Add lookup methods to linker.Symbols; improve performance/reduce allocations

### DIFF
--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -616,36 +616,20 @@ func (s *Symbols) AddExtensionDeclaration(extension, extendee protoreflect.FullN
 // Lookup finds the registered location of the given name. If the given name has
 // not been seen/registered, nil is returned.
 func (s *Symbols) Lookup(name protoreflect.FullName) ast.SourceSpan {
-	pkg := name.Parent()
-	for {
-		pkgSyms := s.getPackage(pkg, false)
-		if pkgSyms != nil {
-			if entry, ok := pkgSyms.symbols[name]; ok {
-				return entry.span
-			}
-			return nil
-		}
-		if pkg == "" {
-			return nil
-		}
-		pkg = pkg.Parent()
+	// note: getPackage never returns nil when exact=false
+	pkgSyms := s.getPackage(name, false)
+	if entry, ok := pkgSyms.symbols[name]; ok {
+		return entry.span
 	}
+	return nil
 }
 
 // LookupExtension finds the registered location of the given extension. If the given
 // extension has not been seen/registered, nil is returned.
 func (s *Symbols) LookupExtension(messageName protoreflect.FullName, extensionNumber protoreflect.FieldNumber) ast.SourceSpan {
-	pkg := messageName.Parent()
-	for {
-		pkgSyms := s.getPackage(pkg, false)
-		if pkgSyms != nil {
-			return pkgSyms.exts[extNumber{messageName, extensionNumber}]
-		}
-		if pkg == "" {
-			return nil
-		}
-		pkg = pkg.Parent()
-	}
+	// note: getPackage never returns nil when exact=false
+	pkgSyms := s.getPackage(messageName, false)
+	return pkgSyms.exts[extNumber{messageName, extensionNumber}]
 }
 
 type nameEnumerator struct {

--- a/linker/symbols_benchmark_test.go
+++ b/linker/symbols_benchmark_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkSymbols(b *testing.B) {
+	s := &Symbols{}
+	_, err := s.importPackages(nil, "foo.bar.baz.fizz.buzz.frob.nitz", nil)
+	require.NoError(b, err)
+	for i := 0; i < b.N; i++ {
+		pkg := s.getPackage("foo.bar.baz.fizz.buzz.frob.nitz", true)
+		require.NotNil(b, pkg)
+	}
+}

--- a/linker/symbols_test.go
+++ b/linker/symbols_test.go
@@ -34,7 +34,7 @@ func TestSymbolsPackages(t *testing.T) {
 
 	var s Symbols
 	// default/nameless package is the root
-	assert.Equal(t, &s.pkgTrie, s.getPackage(""))
+	assert.Equal(t, &s.pkgTrie, s.getPackage("", true))
 
 	h := reporter.NewHandler(nil)
 	span := ast.UnknownSpan("foo.proto")
@@ -46,7 +46,7 @@ func TestSymbolsPackages(t *testing.T) {
 	assert.Empty(t, pkg.symbols)
 	assert.Empty(t, pkg.exts)
 
-	assert.Equal(t, pkg, s.getPackage("build.buf.foo.bar.baz"))
+	assert.Equal(t, pkg, s.getPackage("build.buf.foo.bar.baz", true))
 
 	// verify that trie was created correctly:
 	//   each package has just one entry, which is its immediate sub-package
@@ -115,7 +115,7 @@ func TestSymbolsImport(t *testing.T) {
 
 			// verify contents of s
 
-			pkg := s.getPackage("foo.bar")
+			pkg := s.getPackage("foo.bar", true)
 			syms := pkg.symbols
 			assert.Len(t, syms, 6)
 			assert.Contains(t, syms, protoreflect.FullName("foo.bar.Foo"))
@@ -129,7 +129,7 @@ func TestSymbolsImport(t *testing.T) {
 			assert.Contains(t, exts, extNumber{"foo.bar.Foo", 10})
 			assert.Contains(t, exts, extNumber{"foo.bar.Foo", 11})
 
-			pkg = s.getPackage("google.protobuf")
+			pkg = s.getPackage("google.protobuf", true)
 			exts = pkg.exts
 			assert.Len(t, exts, 1)
 			assert.Contains(t, exts, extNumber{"google.protobuf.FieldOptions", 20000})
@@ -179,13 +179,13 @@ func TestSymbolExtensions(t *testing.T) {
 
 	// verify contents of s
 
-	pkg := s.getPackage("foo.bar")
+	pkg := s.getPackage("foo.bar", true)
 	exts := pkg.exts
 	assert.Len(t, exts, 2)
 	assert.Contains(t, exts, extNumber{"foo.bar.Foo", 11})
 	assert.Contains(t, exts, extNumber{"foo.bar.Foo", 12})
 
-	pkg = s.getPackage("google.protobuf")
+	pkg = s.getPackage("google.protobuf", true)
 	exts = pkg.exts
 	assert.Len(t, exts, 3)
 	assert.Contains(t, exts, extNumber{"google.protobuf.FileOptions", 10101})


### PR DESCRIPTION
This adds a lookup methods, which can be used to improve the efficiency of a resolver that is based on a `linker.Files`: instead of O(n) to query each file for an item, we can look the item up from the symbol table and directly determine the file it is in.

To further aid efficiency, this adds some benchmarks and then optimizes the `Symbols.getPackage` function so both symbol table construction and lookup are more efficient. In particular, instead of `strings.Split`, which must allocate a slice, we now use a new `nameEnumerator` type, which can be used to iterate through name components without allocation.

Benchmark improvements below.

**before**
```
BenchmarkSymbols-10    	 2,073,348	       568.7 ns/op	     240 B/op	       7 allocs/op
```

**after**
```
BenchmarkSymbols-10    	 3,570,336	       324.1 ns/op	       0 B/op	       0 allocs/op
```