### PR TITLE
Fix more CI flakiness issues due to test duration

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -994,9 +994,9 @@ func TestPathological(t *testing.T) {
 		t.Run(fileName, func(t *testing.T) {
 			t.Parallel()
 			// Fuzz testing complains if this loop, with 100 iterations, takes longer
-			// than 60 seconds. To prevent this test from being too slow, we limit to
-			// 3 iterations and no longer than 1 second (which is a stricter deadline).
-			allowedDuration := time.Second
+			// than 60 seconds. We're only running 3 iterations, so this test isn't
+			// too slow. So we can use a much tighter deadline.
+			allowedDuration := 2 * time.Second
 			if internal.IsRace {
 				// We increase that threshold to 20 seconds when the race detector is enabled.
 				// The race detector has been observed to make it take ~8x as long. If coverage


### PR DESCRIPTION
I just saw a couple of other failures, even after #288, in the non-race/non-coverage run of the tests :(

So this hopefully addresses that.