### PR TITLE
Use fewer allocations when building descriptors in the linker package

### DIFF
--- a/linker/descriptors.go
+++ b/linker/descriptors.go
@@ -400,13 +400,13 @@ func (s *srcLocs) ByDescriptor(d protoreflect.Descriptor) protoreflect.SourceLoc
 
 type msgDescriptors struct {
 	protoreflect.MessageDescriptors
-	msgs []*msgDescriptor
+	msgs []msgDescriptor
 }
 
-func (r *result) createMessages(prefix string, parent protoreflect.Descriptor, msgProtos []*descriptorpb.DescriptorProto) msgDescriptors {
-	msgs := make([]*msgDescriptor, len(msgProtos))
+func (r *result) createMessages(prefix string, parent protoreflect.Descriptor, msgProtos []*descriptorpb.DescriptorProto, pool *allocPool) msgDescriptors {
+	msgs := pool.getMessages(len(msgProtos))
 	for i, msgProto := range msgProtos {
-		msgs[i] = r.createMessageDescriptor(msgProto, parent, i, prefix+msgProto.GetName())
+		r.createMessageDescriptor(&msgs[i], msgProto, parent, i, prefix+msgProto.GetName(), pool)
 	}
 	return msgDescriptors{msgs: msgs}
 }
@@ -416,11 +416,12 @@ func (m *msgDescriptors) Len() int {
 }
 
 func (m *msgDescriptors) Get(i int) protoreflect.MessageDescriptor {
-	return m.msgs[i]
+	return &m.msgs[i]
 }
 
 func (m *msgDescriptors) ByName(s protoreflect.Name) protoreflect.MessageDescriptor {
-	for _, msg := range m.msgs {
+	for i := range m.msgs {
+		msg := &m.msgs[i]
 		if msg.Name() == s {
 			return msg
 		}
@@ -450,23 +451,27 @@ type msgDescriptor struct {
 var _ protoreflect.MessageDescriptor = (*msgDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*msgDescriptor)(nil)
 
-func (r *result) createMessageDescriptor(md *descriptorpb.DescriptorProto, parent protoreflect.Descriptor, index int, fqn string) *msgDescriptor {
-	ret := &msgDescriptor{MessageDescriptor: noOpMessage, file: r, parent: parent, index: index, proto: md, fqn: fqn}
+func (r *result) createMessageDescriptor(ret *msgDescriptor, md *descriptorpb.DescriptorProto, parent protoreflect.Descriptor, index int, fqn string, pool *allocPool) {
 	r.descriptors[fqn] = ret
+
+	ret.MessageDescriptor = noOpMessage
+	ret.file = r
+	ret.parent = parent
+	ret.index = index
+	ret.proto = md
+	ret.fqn = fqn
 
 	prefix := fqn + "."
 	// NB: We MUST create fields before oneofs so that we can populate the
 	//  set of fields that belong to the oneof
-	ret.fields = r.createFields(prefix, ret, md.Field)
-	ret.oneofs = r.createOneofs(prefix, ret, md.OneofDecl)
-	ret.nestedMessages = r.createMessages(prefix, ret, md.NestedType)
-	ret.nestedEnums = r.createEnums(prefix, ret, md.EnumType)
-	ret.nestedExtensions = r.createExtensions(prefix, ret, md.Extension)
+	ret.fields = r.createFields(prefix, ret, md.Field, pool)
+	ret.oneofs = r.createOneofs(prefix, ret, md.OneofDecl, pool)
+	ret.nestedMessages = r.createMessages(prefix, ret, md.NestedType, pool)
+	ret.nestedEnums = r.createEnums(prefix, ret, md.EnumType, pool)
+	ret.nestedExtensions = r.createExtensions(prefix, ret, md.Extension, pool)
 	ret.extRanges = createFieldRanges(md.ExtensionRange)
 	ret.rsvdRanges = createFieldRanges(md.ReservedRange)
 	ret.rsvdNames = names{s: md.ReservedName}
-
-	return ret
 }
 
 func (m *msgDescriptor) MessageDescriptorProto() *descriptorpb.DescriptorProto {
@@ -643,13 +648,13 @@ func (f fieldRanges) Has(n protoreflect.FieldNumber) bool {
 
 type enumDescriptors struct {
 	protoreflect.EnumDescriptors
-	enums []*enumDescriptor
+	enums []enumDescriptor
 }
 
-func (r *result) createEnums(prefix string, parent protoreflect.Descriptor, enumProtos []*descriptorpb.EnumDescriptorProto) enumDescriptors {
-	enums := make([]*enumDescriptor, len(enumProtos))
+func (r *result) createEnums(prefix string, parent protoreflect.Descriptor, enumProtos []*descriptorpb.EnumDescriptorProto, pool *allocPool) enumDescriptors {
+	enums := pool.getEnums(len(enumProtos))
 	for i, enumProto := range enumProtos {
-		enums[i] = r.createEnumDescriptor(enumProto, parent, i, prefix+enumProto.GetName())
+		r.createEnumDescriptor(&enums[i], enumProto, parent, i, prefix+enumProto.GetName(), pool)
 	}
 	return enumDescriptors{enums: enums}
 }
@@ -659,13 +664,14 @@ func (e *enumDescriptors) Len() int {
 }
 
 func (e *enumDescriptors) Get(i int) protoreflect.EnumDescriptor {
-	return e.enums[i]
+	return &e.enums[i]
 }
 
 func (e *enumDescriptors) ByName(s protoreflect.Name) protoreflect.EnumDescriptor {
-	for _, en := range e.enums {
-		if en.Name() == s {
-			return en
+	for i := range e.enums {
+		enum := &e.enums[i]
+		if enum.Name() == s {
+			return enum
 		}
 	}
 	return nil
@@ -688,19 +694,24 @@ type enumDescriptor struct {
 var _ protoreflect.EnumDescriptor = (*enumDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*enumDescriptor)(nil)
 
-func (r *result) createEnumDescriptor(ed *descriptorpb.EnumDescriptorProto, parent protoreflect.Descriptor, index int, fqn string) *enumDescriptor {
-	ret := &enumDescriptor{EnumDescriptor: noOpEnum, file: r, parent: parent, index: index, proto: ed, fqn: fqn}
+func (r *result) createEnumDescriptor(ret *enumDescriptor, ed *descriptorpb.EnumDescriptorProto, parent protoreflect.Descriptor, index int, fqn string, pool *allocPool) {
 	r.descriptors[fqn] = ret
 
-	// Unlike all other elements, the fully-qualified name of enum values
-	// is NOT scoped to their parent element (the enum), but rather to
+	ret.EnumDescriptor = noOpEnum
+	ret.file = r
+	ret.parent = parent
+	ret.index = index
+	ret.proto = ed
+	ret.fqn = fqn
+
+	// Unlike all other elements, the fully-qualified names of enum values
+	// are NOT scoped to their parent element (the enum), but rather to
 	// the enum's parent element. This follows C++ scoping rules for
 	// enum values.
 	prefix := strings.TrimSuffix(fqn, ed.GetName())
-	ret.values = r.createEnumValues(prefix, ret, ed.Value)
+	ret.values = r.createEnumValues(prefix, ret, ed.Value, pool)
 	ret.rsvdRanges = createEnumRanges(ed.ReservedRange)
 	ret.rsvdNames = names{s: ed.ReservedName}
-	return ret
 }
 
 func (e *enumDescriptor) EnumDescriptorProto() *descriptorpb.EnumDescriptorProto {
@@ -795,13 +806,13 @@ func (e enumRanges) Has(n protoreflect.EnumNumber) bool {
 
 type enValDescriptors struct {
 	protoreflect.EnumValueDescriptors
-	vals []*enValDescriptor
+	vals []enValDescriptor
 }
 
-func (r *result) createEnumValues(prefix string, parent *enumDescriptor, enValProtos []*descriptorpb.EnumValueDescriptorProto) enValDescriptors {
-	vals := make([]*enValDescriptor, len(enValProtos))
+func (r *result) createEnumValues(prefix string, parent *enumDescriptor, enValProtos []*descriptorpb.EnumValueDescriptorProto, pool *allocPool) enValDescriptors {
+	vals := pool.getEnumValues(len(enValProtos))
 	for i, enValProto := range enValProtos {
-		vals[i] = r.createEnumValueDescriptor(enValProto, parent, i, prefix+enValProto.GetName())
+		r.createEnumValueDescriptor(&vals[i], enValProto, parent, i, prefix+enValProto.GetName())
 	}
 	return enValDescriptors{vals: vals}
 }
@@ -811,11 +822,12 @@ func (e *enValDescriptors) Len() int {
 }
 
 func (e *enValDescriptors) Get(i int) protoreflect.EnumValueDescriptor {
-	return e.vals[i]
+	return &e.vals[i]
 }
 
 func (e *enValDescriptors) ByName(s protoreflect.Name) protoreflect.EnumValueDescriptor {
-	for _, val := range e.vals {
+	for i := range e.vals {
+		val := &e.vals[i]
 		if val.Name() == s {
 			return val
 		}
@@ -824,7 +836,8 @@ func (e *enValDescriptors) ByName(s protoreflect.Name) protoreflect.EnumValueDes
 }
 
 func (e *enValDescriptors) ByNumber(n protoreflect.EnumNumber) protoreflect.EnumValueDescriptor {
-	for _, val := range e.vals {
+	for i := range e.vals {
+		val := &e.vals[i]
 		if val.Number() == n {
 			return val
 		}
@@ -844,10 +857,14 @@ type enValDescriptor struct {
 var _ protoreflect.EnumValueDescriptor = (*enValDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*enValDescriptor)(nil)
 
-func (r *result) createEnumValueDescriptor(ed *descriptorpb.EnumValueDescriptorProto, parent *enumDescriptor, index int, fqn string) *enValDescriptor {
-	ret := &enValDescriptor{EnumValueDescriptor: noOpEnumValue, file: r, parent: parent, index: index, proto: ed, fqn: fqn}
+func (r *result) createEnumValueDescriptor(ret *enValDescriptor, ed *descriptorpb.EnumValueDescriptorProto, parent *enumDescriptor, index int, fqn string) {
 	r.descriptors[fqn] = ret
-	return ret
+	ret.EnumValueDescriptor = noOpEnumValue
+	ret.file = r
+	ret.parent = parent
+	ret.index = index
+	ret.proto = ed
+	ret.fqn = fqn
 }
 
 func (e *enValDescriptor) EnumValueDescriptorProto() *descriptorpb.EnumValueDescriptorProto {
@@ -896,13 +913,13 @@ func (e *enValDescriptor) Number() protoreflect.EnumNumber {
 
 type extDescriptors struct {
 	protoreflect.ExtensionDescriptors
-	exts []*extTypeDescriptor
+	exts []extTypeDescriptor
 }
 
-func (r *result) createExtensions(prefix string, parent protoreflect.Descriptor, extProtos []*descriptorpb.FieldDescriptorProto) extDescriptors {
-	exts := make([]*extTypeDescriptor, len(extProtos))
+func (r *result) createExtensions(prefix string, parent protoreflect.Descriptor, extProtos []*descriptorpb.FieldDescriptorProto, pool *allocPool) extDescriptors {
+	exts := pool.getExtensions(len(extProtos))
 	for i, extProto := range extProtos {
-		exts[i] = r.createExtTypeDescriptor(extProto, parent, i, prefix+extProto.GetName())
+		r.createExtTypeDescriptor(&exts[i], extProto, parent, i, prefix+extProto.GetName())
 	}
 	return extDescriptors{exts: exts}
 }
@@ -912,11 +929,12 @@ func (e *extDescriptors) Len() int {
 }
 
 func (e *extDescriptors) Get(i int) protoreflect.ExtensionDescriptor {
-	return e.exts[i]
+	return &e.exts[i]
 }
 
 func (e *extDescriptors) ByName(s protoreflect.Name) protoreflect.ExtensionDescriptor {
-	for _, ext := range e.exts {
+	for i := range e.exts {
+		ext := &e.exts[i]
 		if ext.Name() == s {
 			return ext
 		}
@@ -926,15 +944,15 @@ func (e *extDescriptors) ByName(s protoreflect.Name) protoreflect.ExtensionDescr
 
 type extTypeDescriptor struct {
 	protoreflect.ExtensionTypeDescriptor
-	field *fldDescriptor
+	field fldDescriptor
 }
 
 var _ protoutil.DescriptorProtoWrapper = &extTypeDescriptor{}
 
-func (r *result) createExtTypeDescriptor(fd *descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, index int, fqn string) *extTypeDescriptor {
-	ret := &fldDescriptor{FieldDescriptor: noOpExtension, file: r, parent: parent, index: index, proto: fd, fqn: fqn}
+func (r *result) createExtTypeDescriptor(ret *extTypeDescriptor, fd *descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, index int, fqn string) {
 	r.descriptors[fqn] = ret
-	return &extTypeDescriptor{ExtensionTypeDescriptor: dynamicpb.NewExtensionType(ret).TypeDescriptor(), field: ret}
+	ret.field = fldDescriptor{FieldDescriptor: noOpExtension, file: r, parent: parent, index: index, proto: fd, fqn: fqn}
+	ret.ExtensionTypeDescriptor = dynamicpb.NewExtensionType(&ret.field).TypeDescriptor()
 }
 
 func (e *extTypeDescriptor) FieldDescriptorProto() *descriptorpb.FieldDescriptorProto {
@@ -947,15 +965,23 @@ func (e *extTypeDescriptor) AsProto() proto.Message {
 
 type fldDescriptors struct {
 	protoreflect.FieldDescriptors
+	// We use pointers here, instead of flattened slice, because oneofs
+	// also have fields, but need to point to values in the parent
+	// message's fields. Even though they are pointers, in the containing
+	// message, we always allocate a flattened slice and then point into
+	// that, so we're still doing fewer allocations (2 per set of fields
+	// instead of 1 per each field).
 	fields []*fldDescriptor
 }
 
-func (r *result) createFields(prefix string, parent *msgDescriptor, fldProtos []*descriptorpb.FieldDescriptorProto) fldDescriptors {
-	fields := make([]*fldDescriptor, len(fldProtos))
+func (r *result) createFields(prefix string, parent *msgDescriptor, fldProtos []*descriptorpb.FieldDescriptorProto, pool *allocPool) fldDescriptors {
+	fields := pool.getFields(len(fldProtos))
+	fieldPtrs := make([]*fldDescriptor, len(fldProtos))
 	for i, fldProto := range fldProtos {
-		fields[i] = r.createFieldDescriptor(fldProto, parent, i, prefix+fldProto.GetName())
+		r.createFieldDescriptor(&fields[i], fldProto, parent, i, prefix+fldProto.GetName())
+		fieldPtrs[i] = &fields[i]
 	}
-	return fldDescriptors{fields: fields}
+	return fldDescriptors{fields: fieldPtrs}
 }
 
 func (f *fldDescriptors) Len() int {
@@ -985,7 +1011,18 @@ func (f *fldDescriptors) ByJSONName(s string) protoreflect.FieldDescriptor {
 }
 
 func (f *fldDescriptors) ByTextName(s string) protoreflect.FieldDescriptor {
-	return f.ByName(protoreflect.Name(s))
+	fld := f.ByName(protoreflect.Name(s))
+	if fld != nil {
+		return fld
+	}
+	// Groups use type name instead
+	for _, fld := range f.fields {
+		if fld.proto.GetType() == descriptorpb.FieldDescriptorProto_TYPE_GROUP &&
+			string(fld.Message().Name()) == s {
+			return fld
+		}
+	}
+	return nil
 }
 
 func (f *fldDescriptors) ByNumber(n protoreflect.FieldNumber) protoreflect.FieldDescriptor {
@@ -1014,10 +1051,14 @@ type fldDescriptor struct {
 var _ protoreflect.FieldDescriptor = (*fldDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*fldDescriptor)(nil)
 
-func (r *result) createFieldDescriptor(fd *descriptorpb.FieldDescriptorProto, parent *msgDescriptor, index int, fqn string) *fldDescriptor {
-	ret := &fldDescriptor{FieldDescriptor: noOpField, file: r, parent: parent, index: index, proto: fd, fqn: fqn}
+func (r *result) createFieldDescriptor(ret *fldDescriptor, fd *descriptorpb.FieldDescriptorProto, parent *msgDescriptor, index int, fqn string) {
 	r.descriptors[fqn] = ret
-	return ret
+	ret.FieldDescriptor = noOpField
+	ret.file = r
+	ret.parent = parent
+	ret.index = index
+	ret.proto = fd
+	ret.fqn = fqn
 }
 
 func (f *fldDescriptor) FieldDescriptorProto() *descriptorpb.FieldDescriptorProto {
@@ -1454,13 +1495,13 @@ func (f *fldDescriptor) Message() protoreflect.MessageDescriptor {
 
 type oneofDescriptors struct {
 	protoreflect.OneofDescriptors
-	oneofs []*oneofDescriptor
+	oneofs []oneofDescriptor
 }
 
-func (r *result) createOneofs(prefix string, parent *msgDescriptor, ooProtos []*descriptorpb.OneofDescriptorProto) oneofDescriptors {
-	oos := make([]*oneofDescriptor, len(ooProtos))
+func (r *result) createOneofs(prefix string, parent *msgDescriptor, ooProtos []*descriptorpb.OneofDescriptorProto, pool *allocPool) oneofDescriptors {
+	oos := pool.getOneofs(len(ooProtos))
 	for i, fldProto := range ooProtos {
-		oos[i] = r.createOneofDescriptor(fldProto, parent, i, prefix+fldProto.GetName())
+		r.createOneofDescriptor(&oos[i], fldProto, parent, i, prefix+fldProto.GetName())
 	}
 	return oneofDescriptors{oneofs: oos}
 }
@@ -1470,11 +1511,12 @@ func (o *oneofDescriptors) Len() int {
 }
 
 func (o *oneofDescriptors) Get(i int) protoreflect.OneofDescriptor {
-	return o.oneofs[i]
+	return &o.oneofs[i]
 }
 
 func (o *oneofDescriptors) ByName(s protoreflect.Name) protoreflect.OneofDescriptor {
-	for _, oo := range o.oneofs {
+	for i := range o.oneofs {
+		oo := &o.oneofs[i]
 		if oo.Name() == s {
 			return oo
 		}
@@ -1496,9 +1538,14 @@ type oneofDescriptor struct {
 var _ protoreflect.OneofDescriptor = (*oneofDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*oneofDescriptor)(nil)
 
-func (r *result) createOneofDescriptor(ood *descriptorpb.OneofDescriptorProto, parent *msgDescriptor, index int, fqn string) *oneofDescriptor {
-	ret := &oneofDescriptor{OneofDescriptor: noOpOneof, file: r, parent: parent, index: index, proto: ood, fqn: fqn}
+func (r *result) createOneofDescriptor(ret *oneofDescriptor, ood *descriptorpb.OneofDescriptorProto, parent *msgDescriptor, index int, fqn string) {
 	r.descriptors[fqn] = ret
+	ret.OneofDescriptor = noOpOneof
+	ret.file = r
+	ret.parent = parent
+	ret.index = index
+	ret.proto = ood
+	ret.fqn = fqn
 
 	var fields []*fldDescriptor
 	for _, fld := range parent.fields.fields {
@@ -1507,8 +1554,6 @@ func (r *result) createOneofDescriptor(ood *descriptorpb.OneofDescriptorProto, p
 		}
 	}
 	ret.fields = fldDescriptors{fields: fields}
-
-	return ret
 }
 
 func (o *oneofDescriptor) OneofDescriptorProto() *descriptorpb.OneofDescriptorProto {
@@ -1566,13 +1611,13 @@ func (o *oneofDescriptor) Fields() protoreflect.FieldDescriptors {
 
 type svcDescriptors struct {
 	protoreflect.ServiceDescriptors
-	svcs []*svcDescriptor
+	svcs []svcDescriptor
 }
 
-func (r *result) createServices(prefix string, svcProtos []*descriptorpb.ServiceDescriptorProto) svcDescriptors {
-	svcs := make([]*svcDescriptor, len(svcProtos))
+func (r *result) createServices(prefix string, svcProtos []*descriptorpb.ServiceDescriptorProto, pool *allocPool) svcDescriptors {
+	svcs := pool.getServices(len(svcProtos))
 	for i, svcProto := range svcProtos {
-		svcs[i] = r.createServiceDescriptor(svcProto, i, prefix+svcProto.GetName())
+		r.createServiceDescriptor(&svcs[i], svcProto, i, prefix+svcProto.GetName(), pool)
 	}
 	return svcDescriptors{svcs: svcs}
 }
@@ -1582,11 +1627,12 @@ func (s *svcDescriptors) Len() int {
 }
 
 func (s *svcDescriptors) Get(i int) protoreflect.ServiceDescriptor {
-	return s.svcs[i]
+	return &s.svcs[i]
 }
 
 func (s *svcDescriptors) ByName(n protoreflect.Name) protoreflect.ServiceDescriptor {
-	for _, svc := range s.svcs {
+	for i := range s.svcs {
+		svc := &s.svcs[i]
 		if svc.Name() == n {
 			return svc
 		}
@@ -1607,14 +1653,16 @@ type svcDescriptor struct {
 var _ protoreflect.ServiceDescriptor = (*svcDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*svcDescriptor)(nil)
 
-func (r *result) createServiceDescriptor(sd *descriptorpb.ServiceDescriptorProto, index int, fqn string) *svcDescriptor {
-	ret := &svcDescriptor{ServiceDescriptor: noOpService, file: r, index: index, proto: sd, fqn: fqn}
+func (r *result) createServiceDescriptor(ret *svcDescriptor, sd *descriptorpb.ServiceDescriptorProto, index int, fqn string, pool *allocPool) {
 	r.descriptors[fqn] = ret
+	ret.ServiceDescriptor = noOpService
+	ret.file = r
+	ret.index = index
+	ret.proto = sd
+	ret.fqn = fqn
 
 	prefix := fqn + "."
-	ret.methods = r.createMethods(prefix, ret, sd.Method)
-
-	return ret
+	ret.methods = r.createMethods(prefix, ret, sd.Method, pool)
 }
 
 func (s *svcDescriptor) ServiceDescriptorProto() *descriptorpb.ServiceDescriptorProto {
@@ -1663,13 +1711,13 @@ func (s *svcDescriptor) Methods() protoreflect.MethodDescriptors {
 
 type mtdDescriptors struct {
 	protoreflect.MethodDescriptors
-	mtds []*mtdDescriptor
+	mtds []mtdDescriptor
 }
 
-func (r *result) createMethods(prefix string, parent *svcDescriptor, mtdProtos []*descriptorpb.MethodDescriptorProto) mtdDescriptors {
-	mtds := make([]*mtdDescriptor, len(mtdProtos))
+func (r *result) createMethods(prefix string, parent *svcDescriptor, mtdProtos []*descriptorpb.MethodDescriptorProto, pool *allocPool) mtdDescriptors {
+	mtds := pool.getMethods(len(mtdProtos))
 	for i, mtdProto := range mtdProtos {
-		mtds[i] = r.createMethodDescriptor(mtdProto, parent, i, prefix+mtdProto.GetName())
+		r.createMethodDescriptor(&mtds[i], mtdProto, parent, i, prefix+mtdProto.GetName())
 	}
 	return mtdDescriptors{mtds: mtds}
 }
@@ -1679,11 +1727,12 @@ func (m *mtdDescriptors) Len() int {
 }
 
 func (m *mtdDescriptors) Get(i int) protoreflect.MethodDescriptor {
-	return m.mtds[i]
+	return &m.mtds[i]
 }
 
 func (m *mtdDescriptors) ByName(n protoreflect.Name) protoreflect.MethodDescriptor {
-	for _, mtd := range m.mtds {
+	for i := range m.mtds {
+		mtd := &m.mtds[i]
 		if mtd.Name() == n {
 			return mtd
 		}
@@ -1705,10 +1754,14 @@ type mtdDescriptor struct {
 var _ protoreflect.MethodDescriptor = (*mtdDescriptor)(nil)
 var _ protoutil.DescriptorProtoWrapper = (*mtdDescriptor)(nil)
 
-func (r *result) createMethodDescriptor(mtd *descriptorpb.MethodDescriptorProto, parent *svcDescriptor, index int, fqn string) *mtdDescriptor {
-	ret := &mtdDescriptor{MethodDescriptor: noOpMethod, file: r, parent: parent, index: index, proto: mtd, fqn: fqn}
+func (r *result) createMethodDescriptor(ret *mtdDescriptor, mtd *descriptorpb.MethodDescriptorProto, parent *svcDescriptor, index int, fqn string) {
 	r.descriptors[fqn] = ret
-	return ret
+	ret.MethodDescriptor = noOpMethod
+	ret.file = r
+	ret.parent = parent
+	ret.index = index
+	ret.proto = mtd
+	ret.fqn = fqn
 }
 
 func (m *mtdDescriptor) MethodDescriptorProto() *descriptorpb.MethodDescriptorProto {

--- a/linker/linker.go
+++ b/linker/linker.go
@@ -67,8 +67,10 @@ func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *r
 		prefix:               prefix,
 		optionQualifiedNames: map[ast.IdentValueNode]string{},
 	}
+	// First, we create the hierarchy of descendant descriptors.
+	r.createDescendants()
 
-	// First, we put all symbols into a single pool, which lets us ensure there
+	// Then we can put all symbols into a single pool, which lets us ensure there
 	// are no duplicate symbols and will also let us resolve and revise all type
 	// references in next step.
 	if err := symbols.importResult(r, handler); err != nil {

--- a/linker/pool.go
+++ b/linker/pool.go
@@ -1,0 +1,141 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linker
+
+import "google.golang.org/protobuf/types/descriptorpb"
+
+// allocPool helps allocate descriptor instances. Instead of allocating
+// them one at a time, we allocate a pool -- a large, flat slice to hold
+// all descriptors of a particular kind for a file. We then use capacity
+// in the pool when we need space for individual descriptors.
+type allocPool struct {
+	numMessages   int
+	numFields     int
+	numOneofs     int
+	numEnums      int
+	numEnumValues int
+	numExtensions int
+	numServices   int
+	numMethods    int
+
+	messages   []msgDescriptor
+	fields     []fldDescriptor
+	oneofs     []oneofDescriptor
+	enums      []enumDescriptor
+	enumVals   []enValDescriptor
+	extensions []extTypeDescriptor
+	services   []svcDescriptor
+	methods    []mtdDescriptor
+}
+
+func (p *allocPool) getMessages(count int) []msgDescriptor {
+	if p.messages == nil {
+		p.messages = make([]msgDescriptor, p.numMessages)
+	}
+	allocated := p.messages[:count]
+	p.messages = p.messages[count:]
+	return allocated
+}
+
+func (p *allocPool) getFields(count int) []fldDescriptor {
+	if p.fields == nil {
+		p.fields = make([]fldDescriptor, p.numFields)
+	}
+	allocated := p.fields[:count]
+	p.fields = p.fields[count:]
+	return allocated
+}
+
+func (p *allocPool) getOneofs(count int) []oneofDescriptor {
+	if p.oneofs == nil {
+		p.oneofs = make([]oneofDescriptor, p.numOneofs)
+	}
+	allocated := p.oneofs[:count]
+	p.oneofs = p.oneofs[count:]
+	return allocated
+}
+
+func (p *allocPool) getEnums(count int) []enumDescriptor {
+	if p.enums == nil {
+		p.enums = make([]enumDescriptor, p.numEnums)
+	}
+	allocated := p.enums[:count]
+	p.enums = p.enums[count:]
+	return allocated
+}
+
+func (p *allocPool) getEnumValues(count int) []enValDescriptor {
+	if p.enumVals == nil {
+		p.enumVals = make([]enValDescriptor, p.numEnumValues)
+	}
+	allocated := p.enumVals[:count]
+	p.enumVals = p.enumVals[count:]
+	return allocated
+}
+
+func (p *allocPool) getExtensions(count int) []extTypeDescriptor {
+	if p.extensions == nil {
+		p.extensions = make([]extTypeDescriptor, p.numExtensions)
+	}
+	allocated := p.extensions[:count]
+	p.extensions = p.extensions[count:]
+	return allocated
+}
+
+func (p *allocPool) getServices(count int) []svcDescriptor {
+	if p.services == nil {
+		p.services = make([]svcDescriptor, p.numServices)
+	}
+	allocated := p.services[:count]
+	p.services = p.services[count:]
+	return allocated
+}
+
+func (p *allocPool) getMethods(count int) []mtdDescriptor {
+	if p.methods == nil {
+		p.methods = make([]mtdDescriptor, p.numMethods)
+	}
+	allocated := p.methods[:count]
+	p.methods = p.methods[count:]
+	return allocated
+}
+
+func (p *allocPool) countElements(file *descriptorpb.FileDescriptorProto) {
+	p.countElementsInMessages(file.MessageType)
+	p.countElementsInEnums(file.EnumType)
+	p.numExtensions += len(file.Extension)
+	p.numServices += len(file.Service)
+	for _, svc := range file.Service {
+		p.numMethods += len(svc.Method)
+	}
+}
+
+func (p *allocPool) countElementsInMessages(msgs []*descriptorpb.DescriptorProto) {
+	p.numMessages += len(msgs)
+	for _, msg := range msgs {
+		p.numFields += len(msg.Field)
+		p.numOneofs += len(msg.OneofDecl)
+		p.countElementsInMessages(msg.NestedType)
+		p.countElementsInEnums(msg.EnumType)
+		p.numExtensions += len(msg.Extension)
+	}
+}
+
+func (p *allocPool) countElementsInEnums(enums []*descriptorpb.EnumDescriptorProto) {
+	p.numEnums += len(enums)
+	for _, enum := range enums {
+		p.numEnumValues += len(enum.Value)
+	}
+}

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -152,20 +152,24 @@ func descriptorTypeWithArticle(d protoreflect.Descriptor) string {
 	}
 }
 
-func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error {
-	// first create the full descriptor hierarchy
+func (r *result) createDescendants() {
 	fd := r.FileDescriptorProto()
+	pool := &allocPool{}
+	pool.countElements(fd)
 	prefix := ""
 	if fd.GetPackage() != "" {
 		prefix = fd.GetPackage() + "."
 	}
 	r.imports = r.createImports()
-	r.messages = r.createMessages(prefix, r, fd.MessageType)
-	r.enums = r.createEnums(prefix, r, fd.EnumType)
-	r.extensions = r.createExtensions(prefix, r, fd.Extension)
-	r.services = r.createServices(prefix, fd.Service)
+	r.messages = r.createMessages(prefix, r, fd.MessageType, pool)
+	r.enums = r.createEnums(prefix, r, fd.EnumType, pool)
+	r.extensions = r.createExtensions(prefix, r, fd.Extension, pool)
+	r.services = r.createServices(prefix, fd.Service, pool)
+}
 
-	// then resolve symbol references
+func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error {
+	fd := r.FileDescriptorProto()
+
 	scopes := []scope{fileScope(r)}
 	if fd.Options != nil {
 		if err := r.resolveOptions(handler, "file", protoreflect.FullName(fd.GetName()), fd.Options.UninterpretedOption, scopes); err != nil {
@@ -211,7 +215,7 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 				if extendeeNodes == nil && r.AST() != nil {
 					extendeeNodes = map[ast.Node]struct{}{}
 				}
-				if err := resolveFieldTypes(d.field, handler, extendeeNodes, s, scopes); err != nil {
+				if err := resolveFieldTypes(&d.field, handler, extendeeNodes, s, scopes); err != nil {
 					return err
 				}
 				if r.Syntax() == protoreflect.Proto3 && !allowedProto3Extendee(d.field.proto.GetExtendee()) {


### PR DESCRIPTION
The idea here is to use fewer, larger allocations. This is also able to eliminate many allocations related to computing fully-qualified-names.

Previously, when adding the file's elements to the symbol table, we had to traverse the hierarchy of descriptor _protos_, because the wrapper descriptor implementations hadn't yet been created. But this incurred redundantly computing the full name for every element an extra two times -- once for the first pass which checked for collisions and again in the second pass which commits the items to the symbol table.

The new flow instead instantiates the descriptor wrappers first. So we compute the fully-qualified names for that, but no more. Adding the names to the symbol table can then traverse those descriptor wrappers, which does not incur the cost of allocating/computing full names again.

Also, when we create the descriptor wrappers, we allocate them in bulk using larger, flattened slices. This means many fewer calls to the allocator.

I don't have benchmark results just for this change. I was working on benchmarks in the `bufbuild/buf` repo, and this was an optimization I happened to spot. While it did provide noticeable improvements, they were small (both in terms of total number of allocations and in terms of throughput). I was hoping for a more dramatic improvement, but despite only modest gains this still seems like a keeper to me.