### PR TITLE
Flatten slices

### DIFF
--- a/linker/linker.go
+++ b/linker/linker.go
@@ -71,7 +71,8 @@ func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *r
 	// First, we put all symbols into a single pool, which lets us ensure there
 	// are no duplicate symbols and will also let us resolve and revise all type
 	// references in next step.
-	if err := symbols.importResult(r, handler); err != nil {
+	pool := &allocPool{}
+	if err := symbols.importResult(r, handler, pool); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +82,7 @@ func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *r
 	// message references since we don't actually know message or enum until
 	// link time), and references will be re-written to be fully-qualified
 	// references (e.g. start with a dot ".").
-	if err := r.resolveReferences(handler, symbols); err != nil {
+	if err := r.resolveReferences(handler, symbols, pool); err != nil {
 		return nil, err
 	}
 

--- a/linker/linker.go
+++ b/linker/linker.go
@@ -67,12 +67,13 @@ func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *r
 		prefix:               prefix,
 		optionQualifiedNames: map[ast.IdentValueNode]string{},
 	}
+	// First, we create the hierarchy of descendant descriptors.
+	r.createDescendants()
 
-	// First, we put all symbols into a single pool, which lets us ensure there
+	// Then we can put all symbols into a single pool, which lets us ensure there
 	// are no duplicate symbols and will also let us resolve and revise all type
 	// references in next step.
-	pool := &allocPool{}
-	if err := symbols.importResult(r, handler, pool); err != nil {
+	if err := symbols.importResult(r, handler); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +83,7 @@ func Link(parsed parser.Result, dependencies Files, symbols *Symbols, handler *r
 	// message references since we don't actually know message or enum until
 	// link time), and references will be re-written to be fully-qualified
 	// references (e.g. start with a dot ".").
-	if err := r.resolveReferences(handler, symbols, pool); err != nil {
+	if err := r.resolveReferences(handler, symbols); err != nil {
 		return nil, err
 	}
 

--- a/linker/pool.go
+++ b/linker/pool.go
@@ -1,0 +1,97 @@
+package linker
+
+// allocPool helps allocate descriptor instances. Instead of allocating
+// them one at a time, we allocate a pool -- a large, flat slice to hold
+// all descriptors of a particular kind for a file. We then use capacity
+// in the pool when we need space for individual descriptors.
+type allocPool struct {
+	numMessages   int
+	numFields     int
+	numOneofs     int
+	numEnums      int
+	numEnumValues int
+	numExtensions int
+	numServices   int
+	numMethods    int
+
+	messages   []msgDescriptor
+	fields     []fldDescriptor
+	oneofs     []oneofDescriptor
+	enums      []enumDescriptor
+	enumVals   []enValDescriptor
+	extensions []extTypeDescriptor
+	services   []svcDescriptor
+	methods    []mtdDescriptor
+}
+
+func (p *allocPool) getMessages(count int) []msgDescriptor {
+	if p.messages == nil {
+		p.messages = make([]msgDescriptor, p.numMessages)
+	}
+	allocated := p.messages[:count]
+	p.messages = p.messages[count:]
+	return allocated
+}
+
+func (p *allocPool) getFields(count int) []fldDescriptor {
+	if p.fields == nil {
+		p.fields = make([]fldDescriptor, p.numFields)
+	}
+	allocated := p.fields[:count]
+	p.fields = p.fields[count:]
+	return allocated
+}
+
+func (p *allocPool) getOneofs(count int) []oneofDescriptor {
+	if p.oneofs == nil {
+		p.oneofs = make([]oneofDescriptor, p.numOneofs)
+	}
+	allocated := p.oneofs[:count]
+	p.oneofs = p.oneofs[count:]
+	return allocated
+}
+
+func (p *allocPool) getEnums(count int) []enumDescriptor {
+	if p.enums == nil {
+		p.enums = make([]enumDescriptor, p.numEnums)
+	}
+	allocated := p.enums[:count]
+	p.enums = p.enums[count:]
+	return allocated
+}
+
+func (p *allocPool) getEnumValues(count int) []enValDescriptor {
+	if p.enumVals == nil {
+		p.enumVals = make([]enValDescriptor, p.numEnumValues)
+	}
+	allocated := p.enumVals[:count]
+	p.enumVals = p.enumVals[count:]
+	return allocated
+}
+
+func (p *allocPool) getExtensions(count int) []extTypeDescriptor {
+	if p.extensions == nil {
+		p.extensions = make([]extTypeDescriptor, p.numExtensions)
+	}
+	allocated := p.extensions[:count]
+	p.extensions = p.extensions[count:]
+	return allocated
+}
+
+func (p *allocPool) getServices(count int) []svcDescriptor {
+	if p.services == nil {
+		p.services = make([]svcDescriptor, p.numServices)
+	}
+	allocated := p.services[:count]
+	p.services = p.services[count:]
+	return allocated
+}
+
+func (p *allocPool) getMethods(count int) []mtdDescriptor {
+	if p.methods == nil {
+		p.methods = make([]mtdDescriptor, p.numMethods)
+	}
+	allocated := p.methods[:count]
+	p.methods = p.methods[count:]
+	return allocated
+}

--- a/linker/pool.go
+++ b/linker/pool.go
@@ -1,4 +1,20 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package linker
+
+import "google.golang.org/protobuf/types/descriptorpb"
 
 // allocPool helps allocate descriptor instances. Instead of allocating
 // them one at a time, we allocate a pool -- a large, flat slice to hold
@@ -94,4 +110,32 @@ func (p *allocPool) getMethods(count int) []mtdDescriptor {
 	allocated := p.methods[:count]
 	p.methods = p.methods[count:]
 	return allocated
+}
+
+func (p *allocPool) countElements(file *descriptorpb.FileDescriptorProto) {
+	p.countElementsInMessages(file.MessageType)
+	p.countElementsInEnums(file.EnumType)
+	p.numExtensions += len(file.Extension)
+	p.numServices += len(file.Service)
+	for _, svc := range file.Service {
+		p.numMethods += len(svc.Method)
+	}
+}
+
+func (p *allocPool) countElementsInMessages(msgs []*descriptorpb.DescriptorProto) {
+	p.numMessages += len(msgs)
+	for _, msg := range msgs {
+		p.numFields += len(msg.Field)
+		p.numOneofs += len(msg.OneofDecl)
+		p.countElementsInMessages(msg.NestedType)
+		p.countElementsInEnums(msg.EnumType)
+		p.numExtensions += len(msg.Extension)
+	}
+}
+
+func (p *allocPool) countElementsInEnums(enums []*descriptorpb.EnumDescriptorProto) {
+	p.numEnums += len(enums)
+	for _, enum := range enums {
+		p.numEnumValues += len(enum.Value)
+	}
 }

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -152,7 +152,7 @@ func descriptorTypeWithArticle(d protoreflect.Descriptor) string {
 	}
 }
 
-func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error {
+func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols, pool *allocPool) error {
 	// first create the full descriptor hierarchy
 	fd := r.FileDescriptorProto()
 	prefix := ""
@@ -160,10 +160,10 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 		prefix = fd.GetPackage() + "."
 	}
 	r.imports = r.createImports()
-	r.messages = r.createMessages(prefix, r, fd.MessageType)
-	r.enums = r.createEnums(prefix, r, fd.EnumType)
-	r.extensions = r.createExtensions(prefix, r, fd.Extension)
-	r.services = r.createServices(prefix, fd.Service)
+	r.messages = r.createMessages(prefix, r, fd.MessageType, pool)
+	r.enums = r.createEnums(prefix, r, fd.EnumType, pool)
+	r.extensions = r.createExtensions(prefix, r, fd.Extension, pool)
+	r.services = r.createServices(prefix, fd.Service, pool)
 
 	// then resolve symbol references
 	scopes := []scope{fileScope(r)}

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -211,7 +211,7 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error 
 				if extendeeNodes == nil && r.AST() != nil {
 					extendeeNodes = map[ast.Node]struct{}{}
 				}
-				if err := resolveFieldTypes(d.field, handler, extendeeNodes, s, scopes); err != nil {
+				if err := resolveFieldTypes(&d.field, handler, extendeeNodes, s, scopes); err != nil {
 					return err
 				}
 				if r.Syntax() == protoreflect.Proto3 && !allowedProto3Extendee(d.field.proto.GetExtendee()) {

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -152,9 +152,10 @@ func descriptorTypeWithArticle(d protoreflect.Descriptor) string {
 	}
 }
 
-func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols, pool *allocPool) error {
-	// first create the full descriptor hierarchy
+func (r *result) createDescendants() {
 	fd := r.FileDescriptorProto()
+	pool := &allocPool{}
+	pool.countElements(fd)
 	prefix := ""
 	if fd.GetPackage() != "" {
 		prefix = fd.GetPackage() + "."
@@ -164,8 +165,11 @@ func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols, pool *
 	r.enums = r.createEnums(prefix, r, fd.EnumType, pool)
 	r.extensions = r.createExtensions(prefix, r, fd.Extension, pool)
 	r.services = r.createServices(prefix, fd.Service, pool)
+}
 
-	// then resolve symbol references
+func (r *result) resolveReferences(handler *reporter.Handler, s *Symbols) error {
+	fd := r.FileDescriptorProto()
+
 	scopes := []scope{fileScope(r)}
 	if fd.Options != nil {
 		if err := r.resolveOptions(handler, "file", protoreflect.FullName(fd.GetName()), fd.Options.UninterpretedOption, scopes); err != nil {


### PR DESCRIPTION
History shows individual steps w/ incremental improvement (vs. PR #290 which has these all as a single commit).

Benchmarks below. As already mentioned, the actual impact was quite small: a total of only 4% reduction in runtime, 16% reduction in number of allocations, and 11% reduction in bytes allocated.

**baseline (main)**:
```
BenchmarkNewResolver-10    	      43	 271596716 ns/op	286317449 B/op	 4059360 allocs/op
```

**after commit 1 (use flattened slices at each level of the hierarchy)**:
```
BenchmarkNewResolver-10    	      44	 267228843 ns/op	285727338 B/op	 3893423 allocs/op
```

**after commit 2 (use pool to completely flatten slices, single allocation per descriptor type)**:
```
BenchmarkNewResolver-10    	      44	 262225374 ns/op	285721262 B/op	 3857492 allocs/op
```

***after commit 3 (create descriptors first so we don't need to recompute full names when importing symbols)**:
```
BenchmarkNewResolver-10    	      45	 259486931 ns/op	254811876 B/op	 3399879 allocs/op
```

The actual benchmark comes from a work-in-progress in the `bufbuild/buf` repo.