### PR TITLE
Update linker tests to use protodesc to create descriptors from compilation results

### DIFF
--- a/internal/messageset/messageset.go
+++ b/internal/messageset/messageset.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package options
+package messageset
 
 import (
 	"math"
@@ -28,7 +28,9 @@ var (
 	messageSetSupportInit sync.Once
 )
 
-func canSerializeMessageSets() bool {
+// CanSupportMessageSets returns true if the protobuf-go runtime supports
+// serializing messages with the message set wire format.
+func CanSupportMessageSets() bool {
 	messageSetSupportInit.Do(func() {
 		// We check using the protodesc package, instead of just relying
 		// on protolegacy build tag, in case someone links in a fork of

--- a/internal/messageset/messageset_protolegacy_test.go
+++ b/internal/messageset/messageset_protolegacy_test.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !protolegacy
-// +build !protolegacy
+//go:build protolegacy
+// +build protolegacy
 
-package options
+package messageset
 
 import (
 	"testing"
@@ -25,5 +25,5 @@ import (
 
 func TestCanSerializeMessageSets(t *testing.T) {
 	t.Parallel()
-	assert.False(t, canSerializeMessageSets())
+	assert.True(t, CanSupportMessageSets())
 }

--- a/internal/messageset/messageset_test.go
+++ b/internal/messageset/messageset_test.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build protolegacy
-// +build protolegacy
+//go:build !protolegacy
+// +build !protolegacy
 
-package options
+package messageset
 
 import (
 	"testing"
@@ -25,5 +25,5 @@ import (
 
 func TestCanSerializeMessageSets(t *testing.T) {
 	t.Parallel()
-	assert.True(t, canSerializeMessageSets())
+	assert.False(t, CanSupportMessageSets())
 }

--- a/options/options.go
+++ b/options/options.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/bufbuild/protocompile/ast"
 	"github.com/bufbuild/protocompile/internal"
+	"github.com/bufbuild/protocompile/internal/messageset"
 	"github.com/bufbuild/protocompile/linker"
 	"github.com/bufbuild/protocompile/parser"
 	"github.com/bufbuild/protocompile/reporter"
@@ -659,7 +660,7 @@ func (interp *interpreter) checkFieldUsage(
 	node ast.Node,
 ) error {
 	msgOpts, _ := fld.ContainingMessage().Options().(*descriptorpb.MessageOptions)
-	if msgOpts.GetMessageSetWireFormat() && !canSerializeMessageSets() {
+	if msgOpts.GetMessageSetWireFormat() && !messageset.CanSupportMessageSets() {
 		err := interp.reporter.HandleErrorf(interp.nodeInfo(node), "field %q may not be used in an option: it uses 'message set wire format' legacy proto1 feature which is not supported", fld.FullName())
 		if err != nil {
 			return err


### PR DESCRIPTION
This verifies that the results of compilation are processable by `protodesc.NewFile`. There's an opt-out for cases where we know the protobuf-go runtime can't correctly handle it.
