### PR TITLE
Fix bug in extension declarations: presence of a declaration implies the range is verified

### DIFF
--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -2954,7 +2954,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:14:25: expected extension with number 1 to be named .foo.bar, not foo.s, per declaration at test.proto:8:25`,
+			expectedErr: `test.proto:14:25: expected extension with number 1 to be named foo.bar, not foo.s, per declaration at test.proto:8:25`,
 		},
 		"failure_extension_name_does_not_match_declaration2": {
 			input: map[string]string{
@@ -2975,7 +2975,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:13:25: expected extension with number 1 to be named .foo.bar, not foo.s, per declaration at test.proto:7:25`,
+			expectedErr: `test.proto:13:25: expected extension with number 1 to be named foo.bar, not foo.s, per declaration at test.proto:7:25`,
 		},
 		"failure_extension_type_does_not_match_declaration": {
 			input: map[string]string{
@@ -3009,7 +3009,7 @@ func TestLinkerValidation(t *testing.T) {
 							declaration={
 								number: 1
 								full_name: ".foo.bar"
-								type: "string"
+								type: ".foo.A"
 							}
 						];
 					}
@@ -3018,7 +3018,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 				`,
 			},
-			expectedErr: `test.proto:13:18: expected extension with number 1 to have type string, not uint32, per declaration at test.proto:8:25`,
+			expectedErr: `test.proto:13:18: expected extension with number 1 to have type foo.A, not uint32, per declaration at test.proto:8:25`,
 		},
 		"failure_extension_label_does_not_match_declaration": {
 			input: map[string]string{

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -2956,6 +2956,27 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			expectedErr: `test.proto:14:25: expected extension with number 1 to be named .foo.bar, not foo.s, per declaration at test.proto:8:25`,
 		},
+		"failure_extension_name_does_not_match_declaration2": {
+			input: map[string]string{
+				"test.proto": `
+					syntax = "proto2";
+					package foo;
+					message A {
+						extensions 1 [
+							declaration={
+								number: 1
+								full_name: ".foo.bar"
+								type: "string"
+							}
+						];
+					}
+					extend A {
+						optional string s = 1;
+					}
+				`,
+			},
+			expectedErr: `test.proto:13:25: expected extension with number 1 to be named .foo.bar, not foo.s, per declaration at test.proto:7:25`,
+		},
 		"failure_extension_type_does_not_match_declaration": {
 			input: map[string]string{
 				"test.proto": `
@@ -2977,6 +2998,27 @@ func TestLinkerValidation(t *testing.T) {
 				`,
 			},
 			expectedErr: `test.proto:14:18: expected extension with number 1 to have type string, not uint32, per declaration at test.proto:9:25`,
+		},
+		"failure_extension_type_does_not_match_declaration2": {
+			input: map[string]string{
+				"test.proto": `
+					syntax = "proto2";
+					package foo;
+					message A {
+						extensions 1 [
+							declaration={
+								number: 1
+								full_name: ".foo.bar"
+								type: "string"
+							}
+						];
+					}
+					extend A {
+						optional uint32 bar = 1;
+					}
+				`,
+			},
+			expectedErr: `test.proto:13:18: expected extension with number 1 to have type string, not uint32, per declaration at test.proto:8:25`,
 		},
 		"failure_extension_label_does_not_match_declaration": {
 			input: map[string]string{
@@ -3023,6 +3065,27 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			expectedErr: `test.proto:14:9: expected extension with number 1 to be optional, not repeated, per declaration at test.proto:6:17`,
 		},
+		"failure_extension_label_does_not_match_declaration3": {
+			input: map[string]string{
+				"test.proto": `
+					syntax = "proto2";
+					package foo;
+					message A {
+						extensions 1 [
+							declaration={
+								number: 1
+								full_name: ".foo.bar"
+								type: "string"
+							}
+						];
+					}
+					extend A {
+						repeated string bar = 1;
+					}
+				`,
+			},
+			expectedErr: `test.proto:13:9: expected extension with number 1 to be optional, not repeated, per declaration at test.proto:5:17`,
+		},
 		"failure_extension_matches_no_declaration": {
 			input: map[string]string{
 				"test.proto": `
@@ -3044,6 +3107,27 @@ func TestLinkerValidation(t *testing.T) {
 				`,
 			},
 			expectedErr: `test.proto:14:31: expected extension with number 3 to be declared in type foo.A, but no declaration found at test.proto:5:17`,
+		},
+		"failure_extension_matches_no_declaration2": {
+			input: map[string]string{
+				"test.proto": `
+					syntax = "proto2";
+					package foo;
+					message A {
+						extensions 1 to 3 [
+							declaration={
+								number: 1
+								full_name: ".foo.bar"
+								type: "string"
+							}
+						];
+					}
+					extend A {
+						repeated string bar = 3;
+					}
+				`,
+			},
+			expectedErr: `test.proto:13:31: expected extension with number 3 to be declared in type foo.A, but no declaration found at test.proto:4:9`,
 		},
 		"success_field_presence": {
 			input: map[string]string{

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -294,7 +294,7 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 				span, _ := findExtensionRangeOptionSpan(msg.ParentFile(), msg, i, extRange,
 					internal.ExtensionRangeOptionsDeclarationTag, int32(j), internal.ExtensionRangeOptionsDeclarationFullNameTag)
 				err := handler.HandleErrorf(info, "expected extension with number %d to be named %s, not %s, per declaration at %v",
-					fd.Number(), extDecl.GetFullName(), fd.FullName(), span.Start())
+					fd.Number(), strings.TrimPrefix(extDecl.GetFullName(), "."), fd.FullName(), span.Start())
 				if err != nil {
 					return err
 				}
@@ -305,7 +305,7 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 				span, _ := findExtensionRangeOptionSpan(msg.ParentFile(), msg, i, extRange,
 					internal.ExtensionRangeOptionsDeclarationTag, int32(j), internal.ExtensionRangeOptionsDeclarationTypeTag)
 				err := handler.HandleErrorf(info, "expected extension with number %d to have type %s, not %s, per declaration at %v",
-					fd.Number(), extDecl.GetType(), getTypeName(fd), span.Start())
+					fd.Number(), strings.TrimPrefix(extDecl.GetType(), "."), getTypeName(fd), span.Start())
 				if err != nil {
 					return err
 				}

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -267,7 +267,7 @@ func (r *result) validateExtension(fd *fldDescriptor, handler *reporter.Handler)
 		if extRangeOpts == nil {
 			break
 		}
-		if extRangeOpts.GetVerification() == descriptorpb.ExtensionRangeOptions_UNVERIFIED {
+		if len(extRangeOpts.Declaration) == 0 && extRangeOpts.GetVerification() != descriptorpb.ExtensionRangeOptions_DECLARATION {
 			break
 		}
 		var found bool
@@ -590,17 +590,15 @@ func (r *result) validateExtensionDeclarations(md *msgDescriptor, handler *repor
 			// nothing to check
 			continue
 		}
-		// Strange that the "has_verification" check is here, but this
-		// mimics protoc:
-		//   https://github.com/protocolbuffers/protobuf/blob/v26.1/src/google/protobuf/descriptor.cc#L8187-L8188
-		// The effect is that you can add declarations even when the range
-		// is in default unverified state, and they just have no effect. ¯\_(ツ)_/¯
-		if opts.Verification != nil && opts.GetVerification() == descriptorpb.ExtensionRangeOptions_UNVERIFIED {
+		// If any declarations are present, verification is assumed to be
+		// DECLARATION. It's an error for declarations to be present but the
+		// verification field explicitly set to something other than that.
+		if opts.Verification != nil && opts.GetVerification() != descriptorpb.ExtensionRangeOptions_DECLARATION {
 			span, ok := findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsVerificationTag)
 			if !ok {
 				span, _ = findExtensionRangeOptionSpan(r, md, i, extRange, internal.ExtensionRangeOptionsDeclarationTag, 0)
 			}
-			if err := handler.HandleErrorf(span, "extension range cannot have declarations and have verification of UNVERIFIED"); err != nil {
+			if err := handler.HandleErrorf(span, "extension range cannot have declarations and have verification of %s", opts.GetVerification()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
I didn't quite implement this correctly, where "correct" means matching the behavior of `protoc`. For `protoc`, the presence of a declaration _implies_ that `verification = DECLARATION`.
https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L8003-L8023

I previously had implemented it where validation only occurred when `verification` was _explicitly_ set to `DECLARATION`. Oops.