### PR TITLE
Fix a typo in code that adapts/re-parses features to match a descriptor

### DIFF
--- a/internal/editions/editions.go
+++ b/internal/editions/editions.go
@@ -264,7 +264,7 @@ func adaptFeatureSet(msg *descriptorpb.FeatureSet, field protoreflect.FieldDescr
 		// let's try to parse the unrecognized bytes, just in case they contain
 		// this extension.
 		temp := &descriptorpb.FeatureSet{}
-		unmarshaler := prototext.UnmarshalOptions{
+		unmarshaler := proto.UnmarshalOptions{
 			AllowPartial: true,
 			Resolver:     resolverForExtension{field},
 		}


### PR DESCRIPTION
I'm still trying to figure out how to formulate a test that can catch this (since this code path was clearly not covered by existing tests 🤦).