### PR TITLE
Fix panic that can occur when interpreting options in lenient mode

### DIFF
--- a/internal/options.go
+++ b/internal/options.go
@@ -25,15 +25,17 @@ type hasOptionNode interface {
 	FileNode() ast.FileDeclNode // needed in order to query for NodeInfo
 }
 
-func FindFirstOption(res hasOptionNode, handler ErrorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string) (int, error) {
+type errorHandler func(span ast.SourceSpan, format string, args ...interface{}) error
+
+func FindFirstOption(res hasOptionNode, handler errorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string) (int, error) {
 	return findOption(res, handler, scope, opts, name, false, true)
 }
 
-func FindOption(res hasOptionNode, handler ErrorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string) (int, error) {
+func FindOption(res hasOptionNode, handler errorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string) (int, error) {
 	return findOption(res, handler, scope, opts, name, true, false)
 }
 
-func findOption(res hasOptionNode, handler ErrorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string, exact, first bool) (int, error) {
+func findOption(res hasOptionNode, handler errorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string, exact, first bool) (int, error) {
 	found := -1
 	for i, opt := range opts {
 		if exact && len(opt.Name) != 1 {
@@ -50,7 +52,7 @@ func findOption(res hasOptionNode, handler ErrorHandler, scope string, opts []*d
 			fn := res.FileNode()
 			node := optNode.GetName()
 			nodeInfo := fn.NodeInfo(node)
-			return -1, handler.HandleErrorf(nodeInfo, "%s: option %s cannot be defined more than once", scope, name)
+			return -1, handler(nodeInfo, "%s: option %s cannot be defined more than once", scope, name)
 		}
 		found = i
 	}
@@ -66,16 +68,4 @@ func RemoveOption(uo []*descriptorpb.UninterpretedOption, indexToRemove int) []*
 	default:
 		return append(uo[:indexToRemove], uo[indexToRemove+1:]...)
 	}
-}
-
-// ErrorHandler is a value that handles errors and warnings. If it returns an error
-// from any of its handle calls, compilation aborts with that error. If it returns
-// nil, compilation will continue to the end of the current stage.
-//
-// See [reporter.Handler].
-type ErrorHandler interface {
-	HandleErrorf(span ast.SourceSpan, format string, args ...interface{}) error
-	HandleError(err error) error
-	HandleErrorWithPos(span ast.SourceSpan, err error) error
-	HandleWarningf(span ast.SourceSpan, format string, args ...interface{})
 }

--- a/parser/result.go
+++ b/parser/result.go
@@ -686,7 +686,7 @@ func (r *result) addMessageBody(msgd *descriptorpb.DescriptorProto, body *ast.Me
 
 func (r *result) isMessageSetWireFormat(scope string, md *descriptorpb.DescriptorProto, handler *reporter.Handler) (*descriptorpb.UninterpretedOption, error) {
 	uo := md.GetOptions().GetUninterpretedOption()
-	index, err := internal.FindOption(r, handler, scope, uo, "message_set_wire_format")
+	index, err := internal.FindOption(r, handler.HandleErrorf, scope, uo, "message_set_wire_format")
 	if err != nil {
 		return nil, err
 	}

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -112,7 +112,7 @@ func validateNoFeatures(res *result, syntax protoreflect.Syntax, scope string, o
 		// Editions is allowed to use features
 		return nil
 	}
-	if index, err := internal.FindFirstOption(res, handler, scope, opts, "features"); err != nil {
+	if index, err := internal.FindFirstOption(res, handler.HandleErrorf, scope, opts, "features"); err != nil {
 		return err
 	} else if index >= 0 {
 		optNode := res.OptionNode(opts[index])
@@ -135,7 +135,7 @@ func validateMessage(res *result, syntax protoreflect.Syntax, name protoreflect.
 		}
 	}
 
-	if index, err := internal.FindOption(res, handler, scope, md.Options.GetUninterpretedOption(), "map_entry"); err != nil {
+	if index, err := internal.FindOption(res, handler.HandleErrorf, scope, md.Options.GetUninterpretedOption(), "map_entry"); err != nil {
 		return err
 	} else if index >= 0 {
 		optNode := res.OptionNode(md.Options.GetUninterpretedOption()[index])
@@ -331,7 +331,7 @@ func validateEnum(res *result, syntax protoreflect.Syntax, name protoreflect.Ful
 
 	allowAlias := false
 	var allowAliasOpt *descriptorpb.UninterpretedOption
-	if index, err := internal.FindOption(res, handler, scope, ed.Options.GetUninterpretedOption(), "allow_alias"); err != nil {
+	if index, err := internal.FindOption(res, handler.HandleErrorf, scope, ed.Options.GetUninterpretedOption(), "allow_alias"); err != nil {
 		return err
 	} else if index >= 0 {
 		allowAliasOpt = ed.Options.UninterpretedOption[index]
@@ -481,7 +481,7 @@ func validateField(res *result, syntax protoreflect.Syntax, name protoreflect.Fu
 					return err
 				}
 			}
-			if index, err := internal.FindOption(res, handler, scope, fld.Options.GetUninterpretedOption(), "packed"); err != nil {
+			if index, err := internal.FindOption(res, handler.HandleErrorf, scope, fld.Options.GetUninterpretedOption(), "packed"); err != nil {
 				return err
 			} else if index >= 0 {
 				optNode := res.OptionNode(fld.Options.GetUninterpretedOption()[index])
@@ -491,7 +491,7 @@ func validateField(res *result, syntax protoreflect.Syntax, name protoreflect.Fu
 				}
 			}
 		} else if syntax == protoreflect.Proto3 {
-			if index, err := internal.FindOption(res, handler, scope, fld.Options.GetUninterpretedOption(), "default"); err != nil {
+			if index, err := internal.FindOption(res, handler.HandleErrorf, scope, fld.Options.GetUninterpretedOption(), "default"); err != nil {
 				return err
 			} else if index >= 0 {
 				optNode := res.OptionNode(fld.Options.GetUninterpretedOption()[index])

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -153,13 +153,7 @@ func (h *Handler) HandleError(err error) error {
 // call to HandleError or HandleErrorf), that same error is returned and the
 // given error is not reported.
 func (h *Handler) HandleErrorWithPos(span ast.SourceSpan, err error) error {
-	if ewp, ok := err.(ErrorWithPos); ok {
-		// replace existing position with given one
-		err = errorWithSpan{SourceSpan: span, underlying: ewp.Unwrap()}
-	} else {
-		err = errorWithSpan{SourceSpan: span, underlying: err}
-	}
-	return h.HandleError(err)
+	return h.HandleError(Error(span, err))
 }
 
 // HandleErrorf handles an error with the given source position, creating the
@@ -191,14 +185,7 @@ func (h *Handler) HandleWarning(err ErrorWithPos) {
 // HandleWarningWithPos handles a warning with the given source position. This will
 // delegate to the handler's configured reporter.
 func (h *Handler) HandleWarningWithPos(span ast.SourceSpan, err error) {
-	ewp, ok := err.(ErrorWithPos)
-	if ok {
-		// replace existing position with given one
-		ewp = errorWithSpan{SourceSpan: span, underlying: ewp.Unwrap()}
-	} else {
-		ewp = errorWithSpan{SourceSpan: span, underlying: err}
-	}
-	h.HandleWarning(ewp)
+	h.HandleWarning(Error(span, err))
 }
 
 // HandleWarningf handles a warning with the given source position, creating the


### PR DESCRIPTION
The panic fix is tiny. But this PR is not because other changes/improvements were called for: most of the code changes are to improve error handling when in lenient mode. After I fixed the panic, the test case was failing in a different way, due to an issue with how errors (even in lenient mode) were still being passed to an error reporter and causing the stage to fail.

This issue was introduced in #279. That PR moved things around, pushing the responsibility of calling `interp.reporter.HandleError` down, so that interpreting a single option could potentially report multiple errors (instead of failing fast and only reporting the first).

But when in lenient mode, we don't actually want to send those errors to the reporter: sending the error to the reporter meant the error would get memoized and then returned in subsequent handle calls, which could cause the process to fail when it should be lenient and also can cause it to report the wrong error in lenient mode. So now we demarcate the parts of the process where errors are tolerated (i.e. where lenience mode is actually activated) with a new field on the interpreter that is examined when errors are reported.

This will resolve https://github.com/jhump/protoreflect/issues/620.