### PR TITLE
Use `any` instead of `interface{}`

### DIFF
--- a/ast/identifiers.go
+++ b/ast/identifiers.go
@@ -50,7 +50,7 @@ func NewIdentNode(val string, tok Token) *IdentNode {
 	}
 }
 
-func (n *IdentNode) Value() interface{} {
+func (n *IdentNode) Value() any {
 	return n.AsIdentifier()
 }
 
@@ -129,7 +129,7 @@ func NewCompoundIdentNode(leadingDot *RuneNode, components []*IdentNode, dots []
 	}
 }
 
-func (n *CompoundIdentNode) Value() interface{} {
+func (n *CompoundIdentNode) Value() any {
 	return n.AsIdentifier()
 }
 

--- a/ast/no_source.go
+++ b/ast/no_source.go
@@ -134,7 +134,7 @@ func (n *NoSourceNode) GetOutputType() Node {
 	return n
 }
 
-func (n *NoSourceNode) Value() interface{} {
+func (n *NoSourceNode) Value() any {
 	return nil
 }
 

--- a/ast/ranges.go
+++ b/ast/ranges.go
@@ -185,7 +185,7 @@ func (n *RangeNode) RangeEnd() Node {
 	return n.StartVal
 }
 
-func (n *RangeNode) StartValue() interface{} {
+func (n *RangeNode) StartValue() any {
 	return n.StartVal.Value()
 }
 
@@ -193,7 +193,7 @@ func (n *RangeNode) StartValueAsInt32(minVal, maxVal int32) (int32, bool) {
 	return AsInt32(n.StartVal, minVal, maxVal)
 }
 
-func (n *RangeNode) EndValue() interface{} {
+func (n *RangeNode) EndValue() any {
 	if n.EndVal == nil {
 		return nil
 	}

--- a/ast/values.go
+++ b/ast/values.go
@@ -40,7 +40,7 @@ type ValueNode interface {
 	// If the ValueNode is a NoSourceNode, indicating that there is no actual
 	// source code (and thus not AST information), then this method always
 	// returns nil.
-	Value() interface{}
+	Value() any
 }
 
 var _ ValueNode = (*IdentNode)(nil)
@@ -84,7 +84,7 @@ func NewStringLiteralNode(val string, tok Token) *StringLiteralNode {
 	}
 }
 
-func (n *StringLiteralNode) Value() interface{} {
+func (n *StringLiteralNode) Value() any {
 	return n.AsString()
 }
 
@@ -122,7 +122,7 @@ func NewCompoundLiteralStringNode(components ...*StringLiteralNode) *CompoundStr
 	}
 }
 
-func (n *CompoundStringLiteralNode) Value() interface{} {
+func (n *CompoundStringLiteralNode) Value() any {
 	return n.AsString()
 }
 
@@ -170,7 +170,7 @@ func NewUintLiteralNode(val uint64, tok Token) *UintLiteralNode {
 	}
 }
 
-func (n *UintLiteralNode) Value() interface{} {
+func (n *UintLiteralNode) Value() any {
 	return n.Val
 }
 
@@ -217,7 +217,7 @@ func NewNegativeIntLiteralNode(sign *RuneNode, i *UintLiteralNode) *NegativeIntL
 	}
 }
 
-func (n *NegativeIntLiteralNode) Value() interface{} {
+func (n *NegativeIntLiteralNode) Value() any {
 	return n.Val
 }
 
@@ -259,7 +259,7 @@ func NewFloatLiteralNode(val float64, tok Token) *FloatLiteralNode {
 	}
 }
 
-func (n *FloatLiteralNode) Value() interface{} {
+func (n *FloatLiteralNode) Value() any {
 	return n.AsFloat()
 }
 
@@ -291,7 +291,7 @@ func NewSpecialFloatLiteralNode(name *KeywordNode) *SpecialFloatLiteralNode {
 	}
 }
 
-func (n *SpecialFloatLiteralNode) Value() interface{} {
+func (n *SpecialFloatLiteralNode) Value() any {
 	return n.AsFloat()
 }
 
@@ -331,7 +331,7 @@ func NewSignedFloatLiteralNode(sign *RuneNode, f FloatValueNode) *SignedFloatLit
 	}
 }
 
-func (n *SignedFloatLiteralNode) Value() interface{} {
+func (n *SignedFloatLiteralNode) Value() any {
 	return n.Val
 }
 
@@ -400,7 +400,7 @@ func NewArrayLiteralNode(openBracket *RuneNode, vals []ValueNode, commas []*Rune
 	}
 }
 
-func (n *ArrayLiteralNode) Value() interface{} {
+func (n *ArrayLiteralNode) Value() any {
 	return n.Elements
 }
 
@@ -469,7 +469,7 @@ func NewMessageLiteralNode(openSym *RuneNode, vals []*MessageFieldNode, seps []*
 	}
 }
 
-func (n *MessageLiteralNode) Value() interface{} {
+func (n *MessageLiteralNode) Value() any {
 	return n.Elements
 }
 

--- a/compiler.go
+++ b/compiler.go
@@ -311,7 +311,7 @@ type PanicError struct {
 	// The file that was being processed when the panic occurred
 	File string
 	// The value returned by recover()
-	Value interface{}
+	Value any
 	// A formatted stack trace
 	Stack string
 }

--- a/internal/options.go
+++ b/internal/options.go
@@ -25,7 +25,7 @@ type hasOptionNode interface {
 	FileNode() ast.FileDeclNode // needed in order to query for NodeInfo
 }
 
-type errorHandler func(span ast.SourceSpan, format string, args ...interface{}) error
+type errorHandler func(span ast.SourceSpan, format string, args ...any) error
 
 func FindFirstOption(res hasOptionNode, handler errorHandler, scope string, opts []*descriptorpb.UninterpretedOption, name string) (int, error) {
 	return findOption(res, handler, scope, opts, name, false, true)

--- a/linker/descriptors.go
+++ b/linker/descriptors.go
@@ -280,8 +280,8 @@ func (r *result) SourceLocations() protoreflect.SourceLocations {
 	return &r.srcLocations
 }
 
-func computeSourceLocIndex(locs []protoreflect.SourceLocation) map[interface{}]int {
-	index := map[interface{}]int{}
+func computeSourceLocIndex(locs []protoreflect.SourceLocation) map[any]int {
+	index := map[any]int{}
 	for i, loc := range locs {
 		if loc.Next == 0 {
 			index[pathKey(loc.Path)] = i
@@ -368,7 +368,7 @@ type srcLocs struct {
 	protoreflect.SourceLocations
 	file  *result
 	locs  []protoreflect.SourceLocation
-	index map[interface{}]int
+	index map[any]int
 }
 
 func (s *srcLocs) Len() int {

--- a/linker/pathkey.go
+++ b/linker/pathkey.go
@@ -23,7 +23,7 @@ import (
 
 var pathElementType = reflect.TypeOf(protoreflect.SourcePath{}).Elem()
 
-func pathKey(p protoreflect.SourcePath) interface{} {
+func pathKey(p protoreflect.SourcePath) any {
 	if p == nil {
 		// Reflection code below doesn't work with nil slices
 		return [0]int32{}

--- a/options/options.go
+++ b/options/options.go
@@ -157,7 +157,7 @@ func interpretOptions(lenient bool, file file, res linker.Resolver, handler *rep
 	return interp.index, nil
 }
 
-func (interp *interpreter) handleErrorf(span ast.SourceSpan, msg string, args ...interface{}) error {
+func (interp *interpreter) handleErrorf(span ast.SourceSpan, msg string, args ...any) error {
 	if interp.lenienceEnabled {
 		interp.lenientErrReported = true
 		return nil
@@ -457,7 +457,7 @@ func (interp *interpreter) processDefaultOption(scope string, fqn string, fld *d
 	}
 
 	val := optNode.GetValue()
-	var v interface{}
+	var v any
 	if val.Value() == nil {
 		// no value in the AST, so we dig the value out of the uninterpreted option proto
 		v, err = interp.defaultValueFromProto(mc, fld, opt, val)
@@ -500,7 +500,7 @@ func (interp *interpreter) processDefaultOption(scope string, fqn string, fld *d
 	return found, nil
 }
 
-func (interp *interpreter) defaultValue(mc *internal.MessageContext, fld *descriptorpb.FieldDescriptorProto, val ast.ValueNode) (interface{}, error) {
+func (interp *interpreter) defaultValue(mc *internal.MessageContext, fld *descriptorpb.FieldDescriptorProto, val ast.ValueNode) (any, error) {
 	if _, ok := val.(*ast.MessageLiteralNode); ok {
 		return -1, reporter.Errorf(interp.nodeInfo(val), "%vdefault value cannot be a message", mc)
 	}
@@ -518,7 +518,7 @@ func (interp *interpreter) defaultValue(mc *internal.MessageContext, fld *descri
 	return interp.scalarFieldValue(mc, fld.GetType(), val, false)
 }
 
-func (interp *interpreter) defaultValueFromProto(mc *internal.MessageContext, fld *descriptorpb.FieldDescriptorProto, opt *descriptorpb.UninterpretedOption, node ast.Node) (interface{}, error) {
+func (interp *interpreter) defaultValueFromProto(mc *internal.MessageContext, fld *descriptorpb.FieldDescriptorProto, opt *descriptorpb.UninterpretedOption, node ast.Node) (any, error) {
 	if opt.AggregateValue != nil {
 		return -1, reporter.Errorf(interp.nodeInfo(node), "%vdefault value cannot be a message", mc)
 	}
@@ -1567,7 +1567,7 @@ func fieldName(fld protoreflect.FieldDescriptor) string {
 	return string(fld.Name())
 }
 
-func valueKind(val interface{}) string {
+func valueKind(val any) string {
 	switch val := val.(type) {
 	case ast.Identifier:
 		return "identifier"
@@ -1746,7 +1746,7 @@ func (interp *interpreter) scalarFieldValue(
 	fldType descriptorpb.FieldDescriptorProto_Type,
 	val ast.ValueNode,
 	insideMsgLiteral bool,
-) (interface{}, error) {
+) (any, error) {
 	v := val.Value()
 	switch fldType {
 	case descriptorpb.FieldDescriptorProto_TYPE_BOOL:
@@ -1884,7 +1884,7 @@ func (interp *interpreter) scalarFieldValueFromProto(
 	fldType descriptorpb.FieldDescriptorProto_Type,
 	opt *descriptorpb.UninterpretedOption,
 	node ast.Node,
-) (interface{}, error) {
+) (any, error) {
 	switch fldType {
 	case descriptorpb.FieldDescriptorProto_TYPE_BOOL:
 		if opt.IdentifierValue != nil {

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -109,7 +109,7 @@ foo
 		t          int
 		line, col  int
 		span       int
-		v          interface{}
+		v          any
 		comments   []string
 		trailCount int
 	}{
@@ -194,7 +194,7 @@ foo
 			t.Fatalf("lexer reported EOF but should have returned %v", exp)
 		}
 		var n ast.Node
-		var val interface{}
+		var val any
 		switch tok {
 		case _SYNTAX, _OPTION, _INT32, _SERVICE, _RPC, _MESSAGE, _NAME:
 			n = sym.id

--- a/reporter/errors.go
+++ b/reporter/errors.go
@@ -49,7 +49,7 @@ func Error(span ast.SourceSpan, err error) ErrorWithPos {
 
 // Errorf creates a new ErrorWithPos whose underlying error is created using the
 // given message format and arguments (via fmt.Errorf).
-func Errorf(span ast.SourceSpan, format string, args ...interface{}) ErrorWithPos {
+func Errorf(span ast.SourceSpan, format string, args ...any) ErrorWithPos {
 	return Error(span, fmt.Errorf(format, args...))
 }
 

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -162,7 +162,7 @@ func (h *Handler) HandleErrorWithPos(span ast.SourceSpan, err error) error {
 // If the handler has already aborted (by returning a non-nil error from a call
 // to HandleError or HandleErrorf), that same error is returned and the given
 // error is not reported.
-func (h *Handler) HandleErrorf(span ast.SourceSpan, format string, args ...interface{}) error {
+func (h *Handler) HandleErrorf(span ast.SourceSpan, format string, args ...any) error {
 	return h.HandleError(Errorf(span, format, args...))
 }
 
@@ -190,7 +190,7 @@ func (h *Handler) HandleWarningWithPos(span ast.SourceSpan, err error) {
 
 // HandleWarningf handles a warning with the given source position, creating the
 // actual error value using the given message format and arguments.
-func (h *Handler) HandleWarningf(span ast.SourceSpan, format string, args ...interface{}) {
+func (h *Handler) HandleWarningf(span ast.SourceSpan, format string, args ...any) {
 	h.HandleWarning(Errorf(span, format, args...))
 }
 


### PR DESCRIPTION
Minor cleanup. This repo was created after the introduction of `any`, but a lot of code was "inherited" from `github.com/jhump/protoreflect/desc/protoparse`, which was create before `any` was a thing and thus had lots of usages of `interface{}`.

This was a purely mechanical change made from the command-line:
```
git grep --name-only 'interface{}' | xargs sed -i.bk 's/interface{}/any/g'
```