### PR TITLE
Allow `arena.Arena` to compress arbitrary Go pointers, if it owns them

### DIFF
--- a/experimental/ast/decl.go
+++ b/experimental/ast/decl.go
@@ -15,6 +15,8 @@
 package ast
 
 import (
+	"reflect"
+
 	"github.com/bufbuild/protocompile/internal/arena"
 )
 
@@ -156,21 +158,19 @@ func (d DeclAny) Span() Span {
 
 // declImpl is the common implementation of pointer-like Decl* types.
 type declImpl[Raw any] struct {
-	// NOTE: These fields are sorted by alignment.
 	withContext
-	raw  *Raw
-	ptr  arena.Pointer[Raw]
-	kind DeclKind
+	raw *Raw
 }
 
 // AsAny type-erases this declaration value.
 //
 // See [DeclAny] for more information.
 func (d declImpl[Raw]) AsAny() DeclAny {
+	kind, arena := declArena[Raw](&d.ctx.decls)
 	return DeclAny{
 		withContext: d.withContext,
-		ptr:         d.ptr.Untyped(),
-		kind:        d.kind,
+		ptr:         arena.Compress(d.raw).Untyped(),
+		kind:        kind,
 	}
 }
 
@@ -180,46 +180,10 @@ func wrapDecl[Raw any](c Contextual, ptr arena.Pointer[Raw]) declImpl[Raw] {
 		return declImpl[Raw]{}
 	}
 
-	var (
-		kind DeclKind
-		raw  Raw
-
-		// Needs to be an any because Go doesn't know that only the case below
-		// with the correct type for arena_ (if it were *arena.Arena[Raw]) will
-		// be evaluated.
-		arena_ any //nolint:revive // Named arena_ to avoid clashing with package arena.
-	)
-	switch any(raw).(type) {
-	case rawDeclEmpty:
-		kind = DeclKindEmpty
-		arena_ = &ctx.decls.empties
-	case rawDeclSyntax:
-		kind = DeclKindSyntax
-		arena_ = &ctx.decls.syntaxes
-	case rawDeclPackage:
-		kind = DeclKindPackage
-		arena_ = &ctx.decls.packages
-	case rawDeclImport:
-		kind = DeclKindImport
-		arena_ = &ctx.decls.imports
-	case rawDeclDef:
-		kind = DeclKindDef
-		arena_ = &ctx.decls.defs
-	case rawDeclBody:
-		kind = DeclKindBody
-		arena_ = &ctx.decls.bodies
-	case rawDeclRange:
-		kind = DeclKindRange
-		arena_ = &ctx.decls.ranges
-	default:
-		return declImpl[Raw]{}
-	}
-
+	_, arena := declArena[Raw](&ctx.decls)
 	return declImpl[Raw]{
 		withContext{ctx},
-		arena_.(*arena.Arena[Raw]).Deref(ptr), //nolint:errcheck
-		ptr,
-		kind,
+		arena.Deref(ptr),
 	}
 }
 
@@ -232,4 +196,43 @@ type decls struct {
 	defs     arena.Arena[rawDeclDef]
 	bodies   arena.Arena[rawDeclBody]
 	ranges   arena.Arena[rawDeclRange]
+}
+
+func declArena[Raw any](decls *decls) (DeclKind, *arena.Arena[Raw]) {
+	var (
+		kind DeclKind
+		raw  Raw
+		// Needs to be an any because Go doesn't know that only the case below
+		// with the correct type for arena_ (if it were *arena.Arena[Raw]) will
+		// be evaluated.
+		arena_ any //nolint:revive // Named arena_ to avoid clashing with package arena.
+	)
+
+	switch any(raw).(type) {
+	case rawDeclEmpty:
+		kind = DeclKindEmpty
+		arena_ = &decls.empties
+	case rawDeclSyntax:
+		kind = DeclKindSyntax
+		arena_ = &decls.syntaxes
+	case rawDeclPackage:
+		kind = DeclKindPackage
+		arena_ = &decls.packages
+	case rawDeclImport:
+		kind = DeclKindImport
+		arena_ = &decls.imports
+	case rawDeclDef:
+		kind = DeclKindDef
+		arena_ = &decls.defs
+	case rawDeclBody:
+		kind = DeclKindBody
+		arena_ = &decls.bodies
+	case rawDeclRange:
+		kind = DeclKindRange
+		arena_ = &decls.ranges
+	default:
+		panic("unknown decl type " + reflect.TypeOf(raw).Name())
+	}
+
+	return kind, arena_.(*arena.Arena[Raw])
 }

--- a/experimental/ast/decl.go
+++ b/experimental/ast/decl.go
@@ -234,5 +234,5 @@ func declArena[Raw any](decls *decls) (DeclKind, *arena.Arena[Raw]) {
 		panic("unknown decl type " + reflect.TypeOf(raw).Name())
 	}
 
-	return kind, arena_.(*arena.Arena[Raw])
+	return kind, arena_.(*arena.Arena[Raw]) //nolint:errcheck
 }

--- a/experimental/ast/decl_def.go
+++ b/experimental/ast/decl_def.go
@@ -181,7 +181,7 @@ func (d DeclDef) Options() CompactOptions {
 //
 // Setting it to a nil Options clears it.
 func (d DeclDef) SetOptions(opts CompactOptions) {
-	d.raw.options = opts.ptr
+	d.raw.options = d.ctx.options.Compress(opts.raw)
 }
 
 // Body returns this definition's body, if it has one.
@@ -191,7 +191,7 @@ func (d DeclDef) Body() DeclBody {
 
 // SetBody sets the body for this definition.
 func (d DeclDef) SetBody(b DeclBody) {
-	d.raw.body = b.ptr
+	d.raw.body = d.ctx.decls.bodies.Compress(b.raw)
 }
 
 // Semicolon returns the ending semicolon token for this definition.

--- a/experimental/ast/decl_file.go
+++ b/experimental/ast/decl_file.go
@@ -135,7 +135,7 @@ func (d DeclSyntax) Options() CompactOptions {
 //
 // Setting it to a nil Options clears it.
 func (d DeclSyntax) SetOptions(opts CompactOptions) {
-	d.raw.options = opts.ptr
+	d.raw.options = d.ctx.options.Compress(opts.raw)
 }
 
 // Semicolon returns this pragma's ending semicolon.
@@ -195,7 +195,7 @@ func (d DeclPackage) Options() CompactOptions {
 //
 // Setting it to a nil Options clears it.
 func (d DeclPackage) SetOptions(opts CompactOptions) {
-	d.raw.options = opts.ptr
+	d.raw.options = d.ctx.options.Compress(opts.raw)
 }
 
 // Semicolon returns this package's ending semicolon.
@@ -279,7 +279,7 @@ func (d DeclImport) Options() CompactOptions {
 //
 // Setting it to a nil Options clears it.
 func (d DeclImport) SetOptions(opts CompactOptions) {
-	d.raw.options = opts.ptr
+	d.raw.options = d.ctx.options.Compress(opts.raw)
 }
 
 // Semicolon returns this import's ending semicolon.

--- a/experimental/ast/decl_range.go
+++ b/experimental/ast/decl_range.go
@@ -120,7 +120,7 @@ func (d DeclRange) Options() CompactOptions {
 //
 // Setting it to a nil Options clears it.
 func (d DeclRange) SetOptions(opts CompactOptions) {
-	d.raw.options = opts.ptr
+	d.raw.options = d.ctx.options.Compress(opts.raw)
 }
 
 // Semicolon returns this range's ending semicolon.

--- a/experimental/ast/expr.go
+++ b/experimental/ast/expr.go
@@ -262,5 +262,5 @@ func exprArena[Raw any](exprs *exprs) (ExprKind, *arena.Arena[Raw]) {
 		panic("unknown expr type " + reflect.TypeOf(raw).Name())
 	}
 
-	return kind, arena_.(*arena.Arena[Raw])
+	return kind, arena_.(*arena.Arena[Raw]) //nolint:errcheck
 }

--- a/experimental/ast/expr.go
+++ b/experimental/ast/expr.go
@@ -15,6 +15,8 @@
 package ast
 
 import (
+	"reflect"
+
 	"github.com/bufbuild/protocompile/internal/arena"
 )
 
@@ -107,8 +109,6 @@ func (e ExprAny) AsPrefixed() ExprPrefixed {
 	return ExprPrefixed{exprImpl[rawExprPrefixed]{
 		e.withContext,
 		e.Context().exprs.prefixes.Deref(ptr),
-		ptr,
-		ExprKindPrefixed,
 	}}
 }
 
@@ -125,8 +125,6 @@ func (e ExprAny) AsRange() ExprRange {
 	return ExprRange{exprImpl[rawExprRange]{
 		e.withContext,
 		e.Context().exprs.ranges.Deref(ptr),
-		ptr,
-		ExprKindPrefixed,
 	}}
 }
 
@@ -143,8 +141,6 @@ func (e ExprAny) AsArray() ExprArray {
 	return ExprArray{exprImpl[rawExprArray]{
 		e.withContext,
 		e.Context().exprs.arrays.Deref(ptr),
-		ptr,
-		ExprKindPrefixed,
 	}}
 }
 
@@ -161,8 +157,6 @@ func (e ExprAny) AsDict() ExprDict {
 	return ExprDict{exprImpl[rawExprDict]{
 		e.withContext,
 		e.Context().exprs.dicts.Deref(ptr),
-		ptr,
-		ExprKindPrefixed,
 	}}
 }
 
@@ -179,8 +173,6 @@ func (e ExprAny) AsKV() ExprField {
 	return ExprField{exprImpl[rawExprField]{
 		e.withContext,
 		e.Context().exprs.fields.Deref(ptr),
-		ptr,
-		ExprKindPrefixed,
 	}}
 }
 
@@ -204,9 +196,7 @@ func (e ExprAny) Span() Span {
 type exprImpl[Raw any] struct {
 	// NOTE: These fields are sorted by alignment.
 	withContext
-	raw  *Raw
-	ptr  arena.Pointer[Raw]
-	kind ExprKind
+	raw *Raw
 }
 
 // AsAny type-erases this expression value.
@@ -216,9 +206,11 @@ func (e exprImpl[Raw]) AsAny() ExprAny {
 	if e.Nil() {
 		return ExprAny{}
 	}
+
+	kind, arena := exprArena[Raw](&e.ctx.exprs)
 	return ExprAny{
 		e.withContext,
-		rawExpr{^rawToken(e.kind), rawToken(e.ptr)},
+		rawExpr{^rawToken(kind), rawToken(arena.Compress(e.raw))},
 	}
 }
 
@@ -238,4 +230,37 @@ type exprs struct {
 	arrays   arena.Arena[rawExprArray]
 	dicts    arena.Arena[rawExprDict]
 	fields   arena.Arena[rawExprField]
+}
+
+func exprArena[Raw any](exprs *exprs) (ExprKind, *arena.Arena[Raw]) {
+	var (
+		kind ExprKind
+		raw  Raw
+		// Needs to be an any because Go doesn't know that only the case below
+		// with the correct type for arena_ (if it were *arena.Arena[Raw]) will
+		// be evaluated.
+		arena_ any //nolint:revive // Named arena_ to avoid clashing with package arena.
+	)
+
+	switch any(raw).(type) {
+	case rawExprPrefixed:
+		kind = ExprKindPrefixed
+		arena_ = &exprs.prefixes
+	case rawExprRange:
+		kind = ExprKindRange
+		arena_ = &exprs.ranges
+	case rawExprArray:
+		kind = ExprKindArray
+		arena_ = &exprs.arrays
+	case rawExprDict:
+		kind = ExprKindDict
+		arena_ = &exprs.dicts
+	case rawExprField:
+		kind = ExprKindField
+		arena_ = &exprs.fields
+	default:
+		panic("unknown expr type " + reflect.TypeOf(raw).Name())
+	}
+
+	return kind, arena_.(*arena.Arena[Raw])
 }

--- a/experimental/ast/expr_dict.go
+++ b/experimental/ast/expr_dict.go
@@ -48,8 +48,6 @@ func (e ExprDict) At(n int) ExprField {
 	return ExprField{exprImpl[rawExprField]{
 		e.withContext,
 		e.Context().exprs.fields.Deref(ptr),
-		ptr,
-		ExprKindField,
 	}}
 }
 
@@ -59,8 +57,6 @@ func (e ExprDict) Iter(yield func(int, ExprField) bool) {
 		e := ExprField{exprImpl[rawExprField]{
 			e.withContext,
 			e.Context().exprs.fields.Deref(f.Value),
-			f.Value,
-			ExprKindField,
 		}}
 		if !yield(i, e) {
 			break
@@ -100,7 +96,8 @@ func (e ExprDict) InsertComma(n int, expr ExprField, comma Token) {
 		panic("protocompile/ast: cannot append nil ExprField to ExprMessage")
 	}
 
-	e.raw.fields = slices.Insert(e.raw.fields, n, withComma[arena.Pointer[rawExprField]]{expr.ptr, comma.raw})
+	ptr := e.ctx.exprs.fields.Compress(expr.raw)
+	e.raw.fields = slices.Insert(e.raw.fields, n, withComma[arena.Pointer[rawExprField]]{ptr, comma.raw})
 }
 
 // AsMessage implements [ExprAny].

--- a/experimental/ast/options.go
+++ b/experimental/ast/options.go
@@ -26,8 +26,6 @@ import (
 // CompactOptions implements [Commas] over its options.
 type CompactOptions struct {
 	withContext
-
-	ptr arena.Pointer[rawCompactOptions]
 	raw *rawCompactOptions
 }
 
@@ -125,7 +123,6 @@ func wrapOptions(c Contextual, ptr arena.Pointer[rawCompactOptions]) CompactOpti
 	}
 	return CompactOptions{
 		withContext{c.Context()},
-		ptr,
 		c.Context().options.Deref(ptr),
 	}
 }

--- a/experimental/ast/type.go
+++ b/experimental/ast/type.go
@@ -183,5 +183,5 @@ func typeArena[Raw any](types *types) (TypeKind, *arena.Arena[Raw]) {
 		panic("unknown type type " + reflect.TypeOf(raw).Name())
 	}
 
-	return kind, arena_.(*arena.Arena[Raw])
+	return kind, arena_.(*arena.Arena[Raw]) //nolint:errcheck
 }

--- a/internal/arena/arena_test.go
+++ b/internal/arena/arena_test.go
@@ -28,7 +28,7 @@ func TestPointers(t *testing.T) {
 
 	var a arena.Arena[int]
 
-	p1 := a.New(5)
+	p1 := a.NewCompressed(5)
 	p2 := a.Deref(p1)
 	assert.Equal(5, *a.Deref(p1))
 
@@ -47,4 +47,18 @@ func TestPointers(t *testing.T) {
 	assert.Same(a.Deref(p1), p2)
 
 	assert.Equal("[5 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19|20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51|52]", a.String())
+}
+
+func TestCompress(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	var a arena.Arena[int]
+
+	x := a.NewCompressed(5)
+	y := a.Deref(x)
+	assert.Equal(x, a.Compress(y))
+
+	assert.Equal(arena.Pointer[int](0), a.Compress(nil))
+	assert.Equal(arena.Pointer[int](0), a.Compress(new(int)))
 }

--- a/internal/arena/unsafe.go
+++ b/internal/arena/unsafe.go
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package arena defines an [Arena] type with compressed pointers.
-//
-// The benefits of using compressed pointers are as follows:
-//
-//  1. Pointers are only four bytes wide and four-byte aligned, saving on space
-//     in pointer-heavy graph data structures.
-//
-//  2. The GC has to do substantially less work on such graph data structures,
-//     because from its perspective, structures that only contain compressed
-//     pointers are not deeply-nested and require less traversal (remember,
-//     the bane of a GC is something that looks like a linked list).
-//
-//  3. Improved cache locality. All values inside of the same arena are likelier
-//     to be near each other.
 package arena
 
 import (

--- a/internal/arena/unsafe.go
+++ b/internal/arena/unsafe.go
@@ -1,0 +1,74 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package arena defines an [Arena] type with compressed pointers.
+//
+// The benefits of using compressed pointers are as follows:
+//
+//  1. Pointers are only four bytes wide and four-byte aligned, saving on space
+//     in pointer-heavy graph data structures.
+//
+//  2. The GC has to do substantially less work on such graph data structures,
+//     because from its perspective, structures that only contain compressed
+//     pointers are not deeply-nested and require less traversal (remember,
+//     the bane of a GC is something that looks like a linked list).
+//
+//  3. Improved cache locality. All values inside of the same arena are likelier
+//     to be near each other.
+package arena
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+// pointerIndex returns an integer n such that p == &s[n], or -1 if there is
+// no such integer.
+func pointerIndex[T any](p *T, s []T) int {
+	a := unsafe.Pointer(p)
+	b := unsafe.Pointer(unsafe.SliceData(s))
+	// KeepAlive escapes its argument, so this ensures that a and b have
+	// escaped to the heap and won't be moved.
+	runtime.KeepAlive([2]unsafe.Pointer{a, b})
+
+	diff := uintptr(a) - uintptr(b)
+	size := unsafe.Sizeof(*p)
+	byteLen := uintptr(len(s)) * size
+
+	// This comparison checks for the following things:
+	//
+	// 1. Obviously, that diff is not past the end of s.
+	//
+	// 2. That the subtraction did not overflow. If it did, diff will be
+	//    negative two's complement, i.e. the MSB is set, so it will be
+	//	  greater than byteLen, which, due to allocation limitations on
+	//    every platform ever, cannot be greater than MaxInt, which all
+	//	  "negative" uintptrs are greater than.
+	//
+	// 3. That byteLen is not zero. If it is zero, this branch is taken
+	//    regardless of the value of diff.
+	//
+	// 4. That p is not nil. If it is nil, then either diff will be huge
+	//    (because s is a nonempty slice) or byteLen will be zero in which case
+	//    (3) applies.
+	//
+	// Doing this as one branch is much faster than checking all four
+	// separately; this is a fairly involved strength reduction that not even
+	// LLVM can figure out in many cases, nor can Go tip as of 2024-10-28.
+	if diff >= byteLen {
+		return -1
+	}
+
+	return int(diff / size)
+}

--- a/internal/arena/unsafe_test.go
+++ b/internal/arena/unsafe_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arena
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndex(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	x := []int{1, 2, 3, 4}
+	assert.Equal(-1, pointerIndex[int](nil, nil))
+	assert.Equal(-1, pointerIndex(nil, x))
+	assert.Equal(-1, pointerIndex(new(int), x))
+	assert.Equal(0, pointerIndex(&x[0], x))
+	assert.Equal(1, pointerIndex(&x[1], x))
+	assert.Equal(2, pointerIndex(&x[2], x))
+	assert.Equal(3, pointerIndex(&x[3], x))
+	assert.Equal(-1, pointerIndex(&x[0], x[1:]))
+	assert.Equal(-1, pointerIndex(&x[3], x[:2]))
+	assert.Equal(0, pointerIndex(&x[2], x[2:]))
+}


### PR DESCRIPTION
This PR adds `Arena[T].Compress`, which will take `*T` and compress it into an `arena.Pointer[T]` if the arena owns that pointer.

This in turn allows us to shrink the size of *every* AST node by a whole machine word, by dropping redundant arena pointers in typed exported nodes like `ast.Syntax`. We also don't bother to store the kind of the node either, since it can be recomputed from its type.

This change also renames `Arena.New` to `Arena.NewCompressed`, and now `Arena.New` returns a `*T`.