### PR TITLE
Allow queries to check if their dependencies were recomputed

### DIFF
--- a/experimental/incremental/executor.go
+++ b/experimental/incremental/executor.go
@@ -125,11 +125,11 @@ func Run[T any](ctx context.Context, e *Executor, queries ...Query[T]) (results 
 
 	generation := e.counter.Add(1)
 	root := Task{
-		ctx:        ctx,
-		cancel:     cancel,
-		exec:       e,
-		result:     &result{done: make(chan struct{})},
-		generation: generation,
+		ctx:    ctx,
+		cancel: cancel,
+		exec:   e,
+		result: &result{done: make(chan struct{})},
+		runID:  generation,
 	}
 
 	results, expired = Resolve(root, queries...)

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -35,10 +35,10 @@ type Task struct {
 	ctx    context.Context //nolint:containedctx
 	cancel func(error)
 
-	exec       *Executor
-	task       *task
-	result     *result
-	generation uint64
+	exec   *Executor
+	task   *task
+	result *result
+	runID  uint64
 
 	// Intrusive linked list node for cycle detection.
 	path path
@@ -113,7 +113,7 @@ func Resolve[T any](caller Task, queries ...Query[T]) (results []Result[T], expi
 
 				results[i].NonFatal = r.NonFatal
 				results[i].Fatal = r.Fatal
-				results[i].Unchanged = r.generation < caller.generation
+				results[i].Changed = r.runID == caller.runID
 			}
 
 			wg.Done()
@@ -192,21 +192,21 @@ type Result[T any] struct {
 	NonFatal []error
 	Fatal    error
 
-	// Set if this result has not changed since the last time [Run] call in
+	// Set if this result has possibly changed since the last time [Run] call in
 	// which this query was computed.
 	//
 	// This has important semantics wrt to calls to [Run]. If *any* call to
-	// [Resolve] downstream of a particular call to [Run] returns a false value
-	// for Unchanged for a particular query, all such calls to [Resolve] will.
-	// This ensures that the value of Unchanged is deterministic regardless of
+	// [Resolve] downstream of a particular call to [Run] returns a true value
+	// for Changed for a particular query, all such calls to [Resolve] will.
+	// This ensures that the value of Changed is deterministic regardless of
 	// the order in which queries are actually scheduled.
 	//
 	// This flag can be used to implement partial caching of a query. If a query
 	// calculates the result of merging several queries, it can use its own
 	// cached result (provided by the caller of [Run] in some way) and the value
-	// of [Unchanged] to only perform a partial mutation instead of a complete
+	// of [Changed] to only perform a partial mutation instead of a complete
 	// merge of the queries.
-	Unchanged bool
+	Changed bool
 }
 
 // result is a Result[any] with a completion channel appended to it.
@@ -214,10 +214,21 @@ type result struct {
 	Result[any]
 
 	// This is the sequence ID of the Run call that caused this result to be
-	// computed. If it is less than the sequence ID of the current call, it is
-	// unchanged from a prior call, so we can set Unchanged to true.
-	generation uint64
-	done       chan struct{}
+	// computed. If it is equal to the ID of the current Run, it was computed
+	// during the current call. Otherwise, it is cached from a previous Run.
+	//
+	// Proof of correctness. As long as any Runs are ongoing, it is not possible
+	// for queries to be evicted, so once a query is calculated, its runID is
+	// fixed. Suppose two Runs race the same query. One of them will win as the
+	// leader, and the other will wait until it's done. The leader will mark it
+	// with its run ID, so the leader sees Changed and the loser sees !Changed.
+	// Any other queries from the same or other Runs racing this query will see
+	// the same result.
+	//
+	// Note that runID itself does not require synchronization, because loads of
+	// runID are synchronized-after the done channel being closed.
+	runID uint64
+	done  chan struct{}
 }
 
 // path is a linked list node for tracking cycles in query dependencies.
@@ -317,11 +328,11 @@ func (t *task) run(caller Task, q *AnyQuery) (output *result) {
 	}
 
 	callee := Task{
-		ctx:        caller.ctx,
-		exec:       caller.exec,
-		generation: caller.generation,
-		task:       t,
-		result:     output,
+		ctx:    caller.ctx,
+		exec:   caller.exec,
+		runID:  caller.runID,
+		task:   t,
+		result: output,
 		path: path{
 			Query: q,
 			Prev:  &caller.path,
@@ -334,7 +345,7 @@ func (t *task) run(caller Task, q *AnyQuery) (output *result) {
 	defer callee.exec.sema.Release(1)
 
 	output.Value, output.Fatal = q.Execute(callee)
-	output.generation = callee.generation
+	output.runID = callee.runID
 	return output
 }
 


### PR DESCRIPTION
This change adds `incremental.Result.Changed`, which is set if the result was not cached from a prior call to `incremental.Run`. This is *not* the same as "this call to `Resolve` recomputed the query", because the value of `Changed` is the same for all calls to `Resolve` of that query (i.e., it is deterministic).

This is intended for cases where we want to merge the result of a huge number of queries in one query, and want to implement our own "partial caching" of that query. For example, consider a query which merges the symbol tables of many files. If only one of the files has changed, it is much cheaper to modify only the symbols belonging to that file, than to re-merge the whole table. This enables that optimization.

This PR includes a test that hammers the executor to ensure that we always get consistent results for Changed.