### PR TITLE
Merge `report.File` and `report.IndexedFile`

### DIFF
--- a/experimental/ast/context.go
+++ b/experimental/ast/context.go
@@ -34,11 +34,11 @@ type Context interface {
 type withContext = internal.With[Context]
 
 // newContext creates a fresh context for a particular file.
-func NewContext(file report.File) Context {
+func NewContext(file *report.File) Context {
 	c := new(context)
 	c.stream = &token.Stream{
-		Context:     c,
-		IndexedFile: report.NewIndexedFile(file),
+		Context: c,
+		File:    file,
 	}
 	c.nodes = &Nodes{
 		Context: c,

--- a/experimental/ast/nodes.go
+++ b/experimental/ast/nodes.go
@@ -284,8 +284,8 @@ func (n *Nodes) panicIfNotOurs(that ...any) {
 
 		panic(fmt.Sprintf(
 			"protocompile/ast: attempt to mix different contexts: %q vs %q",
-			n.Context.Stream().File().Path,
-			thatCtx.Stream().File().Path,
+			n.Context.Stream().Path(),
+			thatCtx.Stream().Path(),
 		))
 	}
 }

--- a/experimental/parser/diagnostics_token.go
+++ b/experimental/parser/diagnostics_token.go
@@ -88,10 +88,10 @@ func (e ErrUnmatched) Diagnose(d *report.Diagnostic) {
 
 	if text == openTok {
 		d.With(report.Snippetf(e.Span, "expected a closing `%s`", closeTok))
-		if e.Mismatch.IndexedFile != nil {
+		if !e.Mismatch.Nil() {
 			d.With(report.Snippetf(e.Mismatch, "closed by this instead"))
 		}
-		if e.ShouldMatch.IndexedFile != nil {
+		if !e.ShouldMatch.Nil() {
 			d.With(report.Snippetf(e.ShouldMatch, "help: perhaps it was meant to match this?"))
 		}
 	} else {

--- a/experimental/parser/lex_state.go
+++ b/experimental/parser/lex_state.go
@@ -103,14 +103,6 @@ func (l *lexer) SeekEOF() string {
 	return rest
 }
 
-func (l *lexer) Span(start, end int) report.Span {
-	return report.Span{
-		IndexedFile: l.IndexedFile,
-		Start:       start,
-		End:         end,
-	}
-}
-
 func (l *lexer) SpanFrom(start int) report.Span {
 	return l.Span(start, l.cursor)
 }

--- a/experimental/parser/lex_test.go
+++ b/experimental/parser/lex_test.go
@@ -45,7 +45,7 @@ func TestRender(t *testing.T) {
 		text = unescapeTestCase(text)
 
 		errs := &report.Report{Tracing: 10}
-		ctx := ast.NewContext(report.File{Path: path, Text: text})
+		ctx := ast.NewContext(report.NewFile(path, text))
 		parser.Lex(ctx, errs)
 
 		stderr, _, _ := report.Renderer{
@@ -62,7 +62,7 @@ func TestRender(t *testing.T) {
 			count++
 
 			sp := tok.Span()
-			start := ctx.Stream().IndexedFile.Search(sp.Start)
+			start := ctx.Stream().Location(sp.Start)
 			fmt.Fprintf(
 				&tsv, "%v\t\t%v\t\t%03d:%03d\t\t%03d:%03d\t\t%q",
 				int32(tok.ID())-1, tok.Kind(),

--- a/experimental/report/doc.go
+++ b/experimental/report/doc.go
@@ -29,7 +29,7 @@ for how to render the result to the user.
 A Report can be converted into a Protobuf using [Report.ToProto]. This can
 be serialized to e.g. JSON as an alternative error output.
 
-The [IndexedFile] type is a generic utility for converting file offsets into
+The [File] type is a generic utility for converting file offsets into
 text editor coordinates. E.g., given a byte offset, what is the user-visible
 line and column number? package report expects the caller to construct this
 information themselves, to avoid recomputing it unnecessarily.

--- a/experimental/report/span.go
+++ b/experimental/report/span.go
@@ -21,23 +21,10 @@ import (
 	"strings"
 	"sync"
 	"unicode"
-	"unicode/utf8"
-
-	"github.com/rivo/uniseg"
 )
 
 // TabstopWidth is the size we render all tabstops as.
 const TabstopWidth int = 4
-
-// File is a source code file involved in a diagnostic.
-type File struct {
-	// The filesystem path for this string. It doesn't need to be a real path, but
-	// it will be used to deduplicate spans according to their file.
-	Path string
-
-	// The complete text of the file.
-	Text string
-}
 
 // Spanner is any type with a span.
 type Spanner interface {
@@ -48,25 +35,30 @@ type Spanner interface {
 type Span struct {
 	// The file this span refers to. The file must be indexed, since we plan to
 	// convert Start/End into editor coordinates.
-	*IndexedFile
+	*File
 
 	// The start and end byte offsets for this span.
 	Start, End int
 }
 
+// Nil returns whether or not this is the "nil" span.
+func (s Span) Nil() bool {
+	return s.File == nil
+}
+
 // Text returns the text corresponding to this span.
 func (s Span) Text() string {
-	return s.File().Text[s.Start:s.End]
+	return s.File.Text()[s.Start:s.End]
 }
 
 // StartLoc returns the start location for this span.
 func (s Span) StartLoc() Location {
-	return s.Search(s.Start)
+	return s.Location(s.Start)
 }
 
 // EndLoc returns the end location for this span.
 func (s Span) EndLoc() Location {
-	return s.Search(s.End)
+	return s.Location(s.End)
 }
 
 // Span implements [Spanner].
@@ -95,9 +87,9 @@ func Join(spans ...Spanner) Span {
 			continue
 		}
 		span := span.Span()
-		if joined.IndexedFile == nil {
-			joined.IndexedFile = span.IndexedFile
-		} else if joined.IndexedFile != span.IndexedFile {
+		if joined.File == nil {
+			joined.File = span.File
+		} else if joined.File != span.File {
 			panic("protocompile/report: passed spans with distinct files to JoinSpans()")
 		}
 
@@ -105,7 +97,7 @@ func Join(spans ...Spanner) Span {
 		joined.End = max(joined.End, span.End)
 	}
 
-	if joined.IndexedFile == nil {
+	if joined.File == nil {
 		return Span{}
 	}
 	return joined
@@ -128,10 +120,11 @@ type Location struct {
 	Line, Column int
 }
 
-// IndexedFile is an index of line information from a [File], which permits
-// O(log n) calculation of [Location]s from offsets.
-type IndexedFile struct {
-	file File
+// File is a source code file involved in a diagnostic.
+//
+// It contains additional book-keeping information for resolving span locations.
+type File struct {
+	path, text string
 
 	once sync.Once
 	// A prefix sum of the line lengths of text. Given a byte offset, it is possible
@@ -143,41 +136,58 @@ type IndexedFile struct {
 	lines []int
 }
 
-// NewIndexedFile constructs a line index for the given text. This is O(n) in the size
-// of the text.
-func NewIndexedFile(file File) *IndexedFile {
-	return &IndexedFile{file: file}
+// NewFile constructs a new source file.
+func NewFile(path, text string) *File {
+	return &File{path: path, text: text}
 }
 
-// File returns the file that this index indexes.
-func (i *IndexedFile) File() File {
-	return i.file
+// Path returns this file's filesystem path.
+//
+// It doesn't need to be a real path, but it will be used to deduplicate spans
+// according to their file.
+func (f *File) Path() string {
+	return f.path
 }
 
-// Path returns i.File().Path.
-func (i *IndexedFile) Path() string {
-	return i.File().Path
+// Text returns this file's textual contents.
+func (f *File) Text() string {
+	return f.text
 }
 
-// Text returns i.File().Text.
-func (i *IndexedFile) Text() string {
-	return i.File().Text
+// Location searches this index to build full Location information for the given
+// byte offset.
+//
+// This operation is O(log n).
+func (f *File) Location(offset int) Location {
+	return f.location(offset, true)
 }
 
-// Search searches this index to build full Location information for the given byte
-// offset.
-func (i *IndexedFile) Search(offset int) Location {
-	return i.search(offset, true)
+// Span is a shorthand for creating a new Span.
+func (f *File) Span(start, end int) Span {
+	return Span{f, start, end}
 }
 
-func (i *IndexedFile) search(offset int, allowNonPrint bool) Location {
+// EOF returns a Span pointing to the end-of-file.
+func (f *File) EOF() Span {
+	// Find the last non-space rune; we moor the span immediately after it.
+	eof := strings.LastIndexFunc(f.Text(), func(r rune) bool {
+		return !unicode.In(r, unicode.Pattern_White_Space)
+	})
+	if eof == -1 {
+		eof = 0 // The whole file is whitespace.
+	}
+
+	return f.Span(eof+1, eof+1)
+}
+
+func (f *File) location(offset int, allowNonPrint bool) Location {
 	// Compute the prefix sum on-demand.
-	i.once.Do(func() {
+	f.once.Do(func() {
 		var next int
 
 		// We add 1 to the return value of IndexByte because we want to work
 		// with the index immediately *after* the newline byte.
-		text := i.file.Text
+		text := f.Text()
 		for {
 			newline := strings.IndexByte(text, '\n') + 1
 			if newline == 0 {
@@ -186,88 +196,23 @@ func (i *IndexedFile) search(offset int, allowNonPrint bool) Location {
 
 			text = text[newline:]
 
-			i.lines = append(i.lines, next)
+			f.lines = append(f.lines, next)
 			next += newline
 		}
 
-		i.lines = append(i.lines, next)
+		f.lines = append(f.lines, next)
 	})
 
 	// Find the smallest index in c.lines such that lines[line] <= offset.
-	line, exact := slices.BinarySearch(i.lines, offset)
+	line, exact := slices.BinarySearch(f.lines, offset)
 	if !exact {
 		line--
 	}
 
-	column := stringWidth(0, i.file.Text[i.lines[line]:offset], allowNonPrint, nil)
+	column := stringWidth(0, f.Text()[f.lines[line]:offset], allowNonPrint, nil)
 	return Location{
 		Offset: offset,
 		Line:   line + 1,
 		Column: column + 1,
 	}
-}
-
-// stringWidth calculates the rendered width of text if placed at the given column,
-// accounting for tabstops.
-func stringWidth(column int, text string, allowNonPrint bool, out *strings.Builder) int {
-	// We can't just use StringWidth, because that doesn't respect tabstops
-	// correctly.
-	for text != "" {
-		nextTab := strings.IndexByte(text, '\t')
-		haveTab := nextTab != -1
-		next := text
-		if haveTab {
-			next, text = text[:nextTab], text[nextTab+1:]
-		} else {
-			text = ""
-		}
-
-		if !allowNonPrint {
-			// Handle unprintable characters. We render those as <U+NNNN>.
-			for next != "" {
-				nextNonPrint := strings.IndexFunc(next, NonPrint)
-				chunk := next
-				if nextNonPrint != -1 {
-					chunk, next = next[:nextNonPrint], next[nextNonPrint:]
-					nonPrint, runeLen := utf8.DecodeRuneInString(next)
-					next = next[runeLen:]
-
-					escape := fmt.Sprintf("<U+%04X>", nonPrint)
-					if out != nil {
-						out.WriteString(chunk)
-						out.WriteString(escape)
-					}
-
-					column += uniseg.StringWidth(chunk) + len(escape)
-				} else {
-					if out != nil {
-						out.WriteString(chunk)
-					}
-					column += uniseg.StringWidth(chunk)
-					next = ""
-				}
-			}
-		} else {
-			column += uniseg.StringWidth(next)
-			if out != nil {
-				out.WriteString(next)
-			}
-		}
-
-		if haveTab {
-			tab := TabstopWidth - (column % TabstopWidth)
-			column += tab
-			if out != nil {
-				padBy(out, tab)
-			}
-		}
-	}
-	return column
-}
-
-// NonPrint defines whether or not a rune is considered "unprintable for the
-// purposes of diagnostics", that is, whether it is a rune that the diagnostics
-// engine will replace with <U+NNNN> when printing.
-func NonPrint(r rune) bool {
-	return !strings.ContainsRune(" \r\t\n", r) && !unicode.IsPrint(r)
 }

--- a/experimental/report/width.go
+++ b/experimental/report/width.go
@@ -1,0 +1,89 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/rivo/uniseg"
+)
+
+// NonPrint defines whether or not a rune is considered "unprintable for the
+// purposes of diagnostics", that is, whether it is a rune that the diagnostics
+// engine will replace with <U+NNNN> when printing.
+func NonPrint(r rune) bool {
+	return !strings.ContainsRune(" \r\t\n", r) && !unicode.IsPrint(r)
+}
+
+// stringWidth calculates the rendered width of text if placed at the given column,
+// accounting for tabstops.
+func stringWidth(column int, text string, allowNonPrint bool, out *strings.Builder) int {
+	// We can't just use StringWidth, because that doesn't respect tabstops
+	// correctly.
+	for text != "" {
+		nextTab := strings.IndexByte(text, '\t')
+		haveTab := nextTab != -1
+		next := text
+		if haveTab {
+			next, text = text[:nextTab], text[nextTab+1:]
+		} else {
+			text = ""
+		}
+
+		if !allowNonPrint {
+			// Handle unprintable characters. We render those as <U+NNNN>.
+			for next != "" {
+				nextNonPrint := strings.IndexFunc(next, NonPrint)
+				chunk := next
+				if nextNonPrint != -1 {
+					chunk, next = next[:nextNonPrint], next[nextNonPrint:]
+					nonPrint, runeLen := utf8.DecodeRuneInString(next)
+					next = next[runeLen:]
+
+					escape := fmt.Sprintf("<U+%04X>", nonPrint)
+					if out != nil {
+						out.WriteString(chunk)
+						out.WriteString(escape)
+					}
+
+					column += uniseg.StringWidth(chunk) + len(escape)
+				} else {
+					if out != nil {
+						out.WriteString(chunk)
+					}
+					column += uniseg.StringWidth(chunk)
+					next = ""
+				}
+			}
+		} else {
+			column += uniseg.StringWidth(next)
+			if out != nil {
+				out.WriteString(next)
+			}
+		}
+
+		if haveTab {
+			tab := TabstopWidth - (column % TabstopWidth)
+			column += tab
+			if out != nil {
+				padBy(out, tab)
+			}
+		}
+	}
+	return column
+}

--- a/experimental/token/stream.go
+++ b/experimental/token/stream.go
@@ -37,7 +37,7 @@ type Stream struct {
 	Context
 
 	// The file this stream is over.
-	*report.IndexedFile
+	*report.File
 
 	// Storage for tokens.
 	nats   []nat

--- a/experimental/token/token.go
+++ b/experimental/token/token.go
@@ -171,11 +171,7 @@ func (t Token) Span() report.Span {
 		a, b = t.offsets()
 	}
 
-	return report.Span{
-		IndexedFile: t.Context().Stream().IndexedFile,
-		Start:       a,
-		End:         b,
-	}
+	return t.Context().Stream().Span(a, b)
 }
 
 // StartEnd returns the open and close tokens for this token.

--- a/experimental/token/token_test.go
+++ b/experimental/token/token_test.go
@@ -35,10 +35,7 @@ func NewContext(text string) *Context {
 	ctx := new(Context)
 	ctx.S = &token.Stream{
 		Context: ctx,
-		IndexedFile: report.NewIndexedFile(report.File{
-			Path: "test",
-			Text: text,
-		}),
+		File:    report.NewFile("test", text),
 	}
 	return ctx
 }


### PR DESCRIPTION
There are basically no uses of `report.File` on its own anymore, so this PR merges it with `report.IndexedFile` to be used everywhere. This simplifies callers somewhat, too.

This also adds `report.File.Span()`, a shorthand for creating spans in a file, and `report.File.EOF()`, which returns the EOF span. `IndexedFile.Search` is now called `File.Location`.