### PR TITLE
Add package internal/intern

### DIFF
--- a/internal/intern/char6.go
+++ b/internal/intern/char6.go
@@ -1,0 +1,109 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package intern provides an interning table abstraction to optimize symbol
+// resolution.
+package intern
+
+import (
+	"strings"
+	"unsafe"
+)
+
+const (
+	maxInlined = 32 / 6
+)
+
+var (
+	// NOTE: We do not use exactly the same alphabet as LLVM: we swap _ and .,
+	// so that . is encoded as 0b111111, aka 077.
+	char6ToByte = []byte("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_.")
+	byteToChar6 = func() []byte {
+		out := make([]byte, 256)
+		for i := range out {
+			out[i] = 0xff
+		}
+		for j, b := range char6ToByte {
+			out[int(b)] = byte(j)
+		}
+		return out
+	}()
+)
+
+// encodeChar6 attempts to encoding data using the char6 encoding. Returns
+// whether encoding was successful, and an encoded value.
+func encodeChar6(data string) (ID, bool) {
+	if data == "" {
+		return 0, true
+	}
+	if len(data) > maxInlined || strings.HasSuffix(data, ".") {
+		return 0, false
+	}
+
+	// The main encoding loop is outlined to promote inlining of the two
+	// above checks into Table.Intern.
+	return encodeOutlined(data)
+}
+
+func encodeOutlined(data string) (ID, bool) {
+	// Start by filling value with all ones. Once we shift in all of the
+	// encoded bytes from data, we will have two desired properties:
+	//
+	// 1. The sign bit will be set.
+	//
+	// 2. If there are less than five bytes, the trailing sextets will all
+	//    be 077, aka '.'. Because we do not allow trailing periods, we can
+	//    use this to determine the length of the original string.
+	//
+	//    Thus, "foo" is encoded as if it was the string "foo..".
+	value := ID(-1)
+	for i := len(data) - 1; i >= 0; i-- {
+		sextet := byteToChar6[data[i]]
+		if sextet == 0xff {
+			return 0, false
+		}
+		value <<= 6
+		value |= ID(sextet)
+	}
+
+	return value, true
+}
+
+// decodeChar6 decodes id assuming it contains a char6-encoded string.
+func decodeChar6(id ID) string {
+	// The main decoding loop is outlined to promote inlining of decodeChar6,
+	// and thus heap-promotion of the returned string.
+	data, len := decodeOutlined(id) //nolint:predeclared,revive // For `len`.
+	return unsafe.String(&data[0], len)
+}
+
+//nolint:predeclared,revive // For `len`.
+func decodeOutlined(id ID) (data [maxInlined]byte, len int) {
+	for i := range data {
+		data[i] = char6ToByte[int(id&077)]
+		id >>= 6
+	}
+
+	// Figure out the length by removing a maximal suffix of
+	// '.' bytes. Note that an all-ones value will decode to "", but encode
+	// will never return that value.
+	len = maxInlined
+	for ; len > 0; len-- {
+		if data[len-1] != '.' {
+			break
+		}
+	}
+
+	return data, len
+}

--- a/internal/intern/intern.go
+++ b/internal/intern/intern.go
@@ -1,0 +1,157 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package intern provides an interning table abstraction to optimize symbol
+// resolution.
+package intern
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// ID is an interned string in a particular [Table].
+//
+// IDs can be compared very cheaply. The zero value of ID always
+// corresponds to the empty string.
+//
+// # Representation
+//
+// Interned strings are represented thus. If the high bit is cleared, then this
+// is an index into the stored strings inside of the [Table] that created it.
+//
+// Otherwise, it is up to five characters drawn from the [LLVM char6 encoding],
+// represented in-line using the bits of the ID.
+//
+// NOTE: The 32-bit length is chosen because it is small. However, if we used a
+// 64-bit ID this would allow us to inline 10-byte identifiers. We should
+// investigate whether this results in improved memory usage overall.
+//
+// [LLVM char6 encoding]: https://llvm.org/docs/BitCodeFormat.html#bit-characters
+type ID int32
+
+// String implements [fmt.Stringer].
+//
+// Note that this will not convert the ID back into a string; to do that, you
+// must call [Table.Value].
+func (id ID) String() string {
+	if id == 0 {
+		return `intern.ID("")`
+	}
+	if id < 0 {
+		return fmt.Sprintf("intern.ID(%q)", decodeChar6(id))
+	}
+	return fmt.Sprintf("intern.ID(%d)", int(id))
+}
+
+// GoString implements [fmt.GoStringer].
+func (id ID) GoString() string {
+	return id.String()
+}
+
+// Table is an interning table.
+//
+// A table can be used to convert strings into [ID]s and back again.
+//
+// The zero value of Table is empty and ready to use.
+type Table struct {
+	mu    sync.RWMutex
+	index map[string]ID
+	table []string
+}
+
+// Intern interns the given string into this table.
+//
+// This function may be called by multiple goroutines concurrently.
+func (t *Table) Intern(s string) ID {
+	if char6, ok := encodeChar6(s); ok {
+		return char6
+	}
+
+	// Fast path for strings that have already been interned. In the common case
+	// all strings are interned, so we can take a read lock to avoid needing
+	// to trap to the scheduler on concurrent access (all calls to Intern() will
+	// still contend mu.readCount, because RLock atomically increments it).
+	t.mu.RLock()
+	id, ok := t.index[s]
+	t.mu.RUnlock()
+	if ok {
+		// We never delete from this map, so if we see ok here, that cannot be
+		// changed by another goroutine.
+		return id
+	}
+
+	// Intern tables are expected to be long-lived. Avoid holding onto a larger
+	// buffer that s is an internal pointer to by cloning it.
+	s = strings.Clone(s)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Check if someone raced us to intern this string. We have to check again
+	// because in the unsynchronized section between RUnlock and Lock, another
+	// goroutine might have successfully interned s.
+	//
+	// TODO: We can reduce the number of map hits if we switch to a different
+	// Map implementation that provides an upsert primitive.
+	if id, ok := t.index[s]; ok {
+		return id
+	}
+
+	// As of here, we have unique ownership of the table, and s has not been
+	// inserted yet.
+
+	t.table = append(t.table, s)
+
+	// The first ID will have value 1. ID 0 is reserved for "".
+	id = ID(len(t.table))
+	if id < 0 {
+		panic(fmt.Sprintf("internal/intern: %d interning IDs exhausted", len(t.table)))
+	}
+
+	if t.index == nil {
+		t.index = make(map[string]ID)
+	}
+	t.index[s] = id
+
+	return id
+}
+
+// Value converts an [ID] back into its corresponding string.
+//
+// If id was created by a different [Table], the results are unspecified,
+// including potentially a panic.
+//
+// This function may be called by multiple goroutines concurrently.
+func (t *Table) Value(id ID) string {
+	if id == 0 {
+		return ""
+	}
+
+	if id < 0 {
+		return decodeChar6(id)
+	}
+
+	// The locking part of Get is outlined to promote inlining of the two
+	// fast paths above. This in turn allows decodeChar6 to be inlined, which
+	// allows the returned string to be stack-promoted.
+	return t.getSlow(id)
+}
+
+func (t *Table) getSlow(id ID) string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.table[int(id)-1]
+}

--- a/internal/intern/intern_test.go
+++ b/internal/intern/intern_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package intern provides an interning table abstraction to optimize symbol
+// resolution.
+package intern_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bufbuild/protocompile/internal/intern"
+)
+
+func TestIntern(t *testing.T) {
+	t.Parallel()
+
+	data := []string{
+		"",
+		"a",
+		"abc",
+		"?",
+		"xy.z",
+		"a_b_c",
+		".....",
+		"foo.",
+		"foo.a",
+		"very long",
+		" ",
+		"verylong",
+	}
+
+	var table intern.Table
+	for i := 0; i < 3; i++ {
+		for _, s := range data {
+			s := s
+
+			t.Run(fmt.Sprintf("%s/%d", s, i), func(t *testing.T) {
+				t.Parallel()
+
+				id := table.Intern(s)
+				assert.Equal(t, s, table.Value(id), "id: %v", id)
+			})
+		}
+	}
+}

--- a/internal/intern/intern_test.go
+++ b/internal/intern/intern_test.go
@@ -18,6 +18,7 @@ package intern_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,28 @@ func TestIntern(t *testing.T) {
 
 				id := table.Intern(s)
 				assert.Equal(t, s, table.Value(id), "id: %v", id)
+				assert.Equal(t, shouldInline(s), id < 0)
 			})
 		}
 	}
+}
+
+func shouldInline(s string) bool {
+	if s == "" || len(s) > 5 || strings.HasSuffix(s, ".") {
+		return false
+	}
+
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r == '_', r == '.':
+
+		default:
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
This PR adds a simple interning table with 32-bit IDs. It currently implements interning using a slice plus a reverse index, protected by a read-write lock. This will be used so that qualified Protobuf names can be represented as slices: `name []intern.ID`.

The table supports up to two billion interned names, which is unlikely to ever be overflown by a single complier session. Also, ASCII identifiers up to five characters (which may contain, but not end with, a period) are encoded directly in the ID using the LLVM bitcode `char6` encoding. This removes the need to hit the reverse index for very small common identifiers, such as "data", "value", "error", "bytes", and "msg".

It may be worthwhile to investigate in the future whether using 64-bit IDs (or some `[n]uint64`), which would allow identifiers with at most `64 / 6 ~ 10` characters to be encoded inline. Whether this is worth doing will depend on what most common identifier lengths on the BSR are.