### PR TITLE
Implement a fast n-way merge

### DIFF
--- a/internal/slicesx/heap.go
+++ b/internal/slicesx/heap.go
@@ -26,6 +26,14 @@ type Heap[K cmp.Ordered, V any] struct {
 	vals []V
 }
 
+// NewHeap returns a new heap with the given pre-allocated capacity.
+func NewHeap[K cmp.Ordered, V any](cap int) *Heap[K, V] {
+	return &Heap[K, V]{
+		keys: make([]K, 0, cap),
+		vals: make([]V, 0, cap),
+	}
+}
+
 // Len returns the number of elements in the heap.
 func (h *Heap[K, V]) Len() int {
 	return len(h.keys)
@@ -45,25 +53,6 @@ func (h *Heap[K, V]) Pop() (K, V) {
 	h.swap(0, n)
 	h.down(0, n)
 	return h.pop()
-}
-
-// Remove removes and returns the entry at index i from the heap.
-func (h *Heap[K, V]) Remove(i int) (K, V) {
-	n := h.Len() - 1
-	if n != i {
-		h.swap(i, n)
-		if !h.down(i, n) {
-			h.up(i)
-		}
-	}
-	return h.pop()
-}
-
-// Fix re-establishes the heap invariant after the key of the nth entry changes.
-func (h *Heap[K, V]) Fix(n int) {
-	if !h.down(n, h.Len()) {
-		h.up(n)
-	}
 }
 
 func (h *Heap[K, V]) up(j int) {
@@ -98,7 +87,7 @@ func (h *Heap[K, V]) down(i0, n int) bool {
 }
 
 func (h *Heap[K, V]) less(i, j int) bool {
-	return cmp.Compare(h.keys[i], h.keys[j]) < 0
+	return h.keys[i] < h.keys[j]
 }
 
 func (h *Heap[K, V]) swap(i, j int) {

--- a/internal/slicesx/heap.go
+++ b/internal/slicesx/heap.go
@@ -1,0 +1,119 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slicesx
+
+import "cmp"
+
+// Heap is a port of Go's [container/heap] package to use generics instead of
+// interface calls. Instead, entries consist of an ordered key and an arbitrary
+// value.ß
+//
+// A zero heap is empty and ready to use.
+type Heap[K cmp.Ordered, V any] struct {
+	keys []K
+	vals []V
+}
+
+// Len returns the number of elements in the heap.
+func (h *Heap[K, V]) Len() int {
+	return len(h.keys)
+}
+
+// Push pushes the element x onto the heap.
+func (h *Heap[K, V]) Push(k K, v V) {
+	h.push(k, v)
+	h.up(h.Len() - 1)
+}
+
+// Pop removes and returns the entry with the least key from the heap.
+//
+// Pop is equivalent to [Heap.Remove](0).
+func (h *Heap[K, V]) Pop() (K, V) {
+	n := h.Len() - 1
+	h.swap(0, n)
+	h.down(0, n)
+	return h.pop()
+}
+
+// Remove removes and returns the entry at index i from the heap.
+func (h *Heap[K, V]) Remove(i int) (K, V) {
+	n := h.Len() - 1
+	if n != i {
+		h.swap(i, n)
+		if !h.down(i, n) {
+			h.up(i)
+		}
+	}
+	return h.pop()
+}
+
+// Fix re-establishes the heap invariant after the key of the nth entry changes.
+func (h *Heap[K, V]) Fix(n int) {
+	if !h.down(n, h.Len()) {
+		h.up(n)
+	}
+}
+
+func (h *Heap[K, V]) up(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !h.less(j, i) {
+			break
+		}
+		h.swap(i, j)
+		j = i
+	}
+}
+
+func (h *Heap[K, V]) down(i0, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && h.less(j2, j1) {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if !h.less(j, i) {
+			break
+		}
+		h.swap(i, j)
+		i = j
+	}
+	return i > i0
+}
+
+func (h *Heap[K, V]) less(i, j int) bool {
+	return cmp.Compare(h.keys[i], h.keys[j]) < 0
+}
+
+func (h *Heap[K, V]) swap(i, j int) {
+	h.keys[i], h.keys[j] = h.keys[j], h.keys[i]
+	h.vals[i], h.vals[j] = h.vals[j], h.vals[i]
+}
+
+func (h *Heap[K, V]) push(k K, v V) {
+	h.keys = append(h.keys, k)
+	h.vals = append(h.vals, v)
+}
+
+func (h *Heap[K, V]) pop() (k K, v V) {
+	end := h.Len() - 1
+	k, h.keys = h.keys[end], h.keys[:end]
+	v, h.vals = h.vals[end], h.vals[:end]
+	return k, v
+}

--- a/internal/slicesx/heap.go
+++ b/internal/slicesx/heap.go
@@ -27,6 +27,8 @@ type Heap[K cmp.Ordered, V any] struct {
 }
 
 // NewHeap returns a new heap with the given pre-allocated capacity.
+//
+//nolint:revive,predeclared // cap used as a variable.
 func NewHeap[K cmp.Ordered, V any](cap int) *Heap[K, V] {
 	return &Heap[K, V]{
 		keys: make([]K, 0, cap),

--- a/internal/slicesx/merge.go
+++ b/internal/slicesx/merge.go
@@ -34,10 +34,11 @@ func MergeKey[T any, K cmp.Ordered](slices [][]T, key func(*T) K) []T {
 		// the second.
 	}
 
-	var heap Heap[K, []T] // Holds the slices according to key(slice[0]).
+	// Holds the slices according to key(slice[0]).
+	heap := NewHeap[K, []T](len(slices))
 
-	// Preload the heap with the first element of each slice. This is also
-	// an opportunity to learn the total number of elements so we can allocate
+	// Preload the heap with the first entry of each slice. This is also
+	// an opportunity to learn the total number of entries so we can allocate
 	// a slice of that size.
 	var total int
 	for _, slice := range slices {
@@ -47,9 +48,9 @@ func MergeKey[T any, K cmp.Ordered](slices [][]T, key func(*T) K) []T {
 		}
 	}
 
-	// As long as there are elements in the queue, pop the highest one, whose
-	// first element is the least among all of the slices. Pop the first element
-	// of that slice, write it the output, and the push the rest of the
+	// As long as there are entries in the queue, pop the first one, whose
+	// first entry is the least among all of the slices. Pop the first entry
+	// of that slice, write it to output, and the push the rest of the
 	// slice back onto the heap.
 	output := make([]T, 0, total)
 	for heap.Len() > 0 {

--- a/internal/slicesx/merge.go
+++ b/internal/slicesx/merge.go
@@ -1,0 +1,66 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slicesx
+
+import "cmp"
+
+// MergeKey an n-way merge of sorted slices, using a function to extract a
+// comparison key. This function will be called at most once per element.
+//
+// The resulting slice will be sorted, but not necessarily stably.
+//
+// Time complexity is O(m log n), where m is the total number of elements to
+// merge, and n is the number of slices to merge from.
+func MergeKey[T any, K cmp.Ordered](slices [][]T, key func(*T) K) []T {
+	switch len(slices) {
+	case 0:
+		return nil
+	case 1:
+		return slices[0]
+		// TODO: can implement other common cases here, such as a pair of slices
+		// where the last element of the first is less than the first element of
+		// the second.
+	}
+
+	var heap Heap[K, []T] // Holds the slices according to key(slice[0]).
+
+	// Preload the heap with the first element of each slice. This is also
+	// an opportunity to learn the total number of elements so we can allocate
+	// a slice of that size.
+	var total int
+	for _, slice := range slices {
+		total += len(slice)
+		if len(slice) > 0 {
+			heap.Push(key(&slice[0]), slice)
+		}
+	}
+
+	// As long as there are elements in the queue, pop the highest one, whose
+	// first element is the least among all of the slices. Pop the first element
+	// of that slice, write it the output, and the push the rest of the
+	// slice back onto the heap.
+	output := make([]T, 0, total)
+	for heap.Len() > 0 {
+		_, slice := heap.Pop()
+		output = append(output, slice[0])
+
+		if len(slice) > 1 {
+			slice = slice[1:]
+			heap.Push(key(&slice[0]), slice)
+		}
+	}
+
+	return output
+}

--- a/internal/slicesx/merge_test.go
+++ b/internal/slicesx/merge_test.go
@@ -26,7 +26,7 @@ func TestMerge(t *testing.T) {
 	t.Parallel()
 
 	type V [2]int
-	first := func(x *V) int { return (*x)[0] }
+	first := func(x V) int { return x[0] }
 	tests := []struct {
 		slices [][]V
 		want   []V
@@ -58,7 +58,7 @@ func TestMerge(t *testing.T) {
 				{1, 28}, {7, 32}, {12, 31}, {17, 79}, {32, 15},
 				{39, 64}, {40, 62}, {55, 98}, {59, 2}, {60, 37},
 				{66, 60}, {69, 54}, {72, 13}, {82, 97}, {83, 61},
-				{91, 27}, {95, 81}, {97, 54}, {98, 25}, {98, 1}},
+				{91, 27}, {95, 81}, {97, 54}, {98, 1}, {98, 25}},
 		},
 	}
 

--- a/internal/slicesx/merge_test.go
+++ b/internal/slicesx/merge_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slicesx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bufbuild/protocompile/internal/slicesx"
+)
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	type V [2]int
+	first := func(x *V) int { return (*x)[0] }
+	tests := []struct {
+		slices [][]V
+		want   []V
+	}{
+		{
+			slices: nil,
+			want:   nil,
+		},
+		{
+			slices: [][]V{{
+				{1, 28}, {12, 31}, {17, 79}, {40, 62}, {55, 98},
+				{59, 2}, {60, 37}, {66, 60}, {72, 13}, {98, 25}}},
+			want: []V{
+				{1, 28}, {12, 31}, {17, 79}, {40, 62}, {55, 98},
+				{59, 2}, {60, 37}, {66, 60}, {72, 13}, {98, 25}},
+		},
+		{
+			slices: [][]V{
+				{
+					{1, 28}, {12, 31}, {17, 79}, {40, 62}, {55, 98},
+					{59, 2}, {60, 37}, {66, 60}, {72, 13}, {98, 25},
+				},
+				{
+					{7, 32}, {32, 15}, {39, 64}, {69, 54}, {82, 97},
+					{83, 61}, {91, 27}, {95, 81}, {97, 54}, {98, 1},
+				},
+			},
+			want: []V{
+				{1, 28}, {7, 32}, {12, 31}, {17, 79}, {32, 15},
+				{39, 64}, {40, 62}, {55, 98}, {59, 2}, {60, 37},
+				{66, 60}, {69, 54}, {72, 13}, {82, 97}, {83, 61},
+				{91, 27}, {95, 81}, {97, 54}, {98, 25}, {98, 1}},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, slicesx.MergeKey(test.slices, first))
+	}
+}


### PR DESCRIPTION
This function will be used for building symbol tables incrementally. Given any file, we can construct a sorted list of all symbols it defines. That means a symbol table is essentially a sorted

```go
type Table []Symbol

type Symbol struct {
  Name intern.ID
  // ...
}
```

Each file's symbol table is incrementally cached. Then, we can build a table of all symbols *visible* in a file by merging the definition tables using `slicesx.MergeKey`, where `Symbol.Name` is the key. Symbol lookups can then be done against the table by doing binary search. This is expected to be MUCH faster than iterating over N maps and dumping their elements into a merged map.

This PR includes both `slicesx.MergeKey`, and `slicex.Heap[K, V]`, an improved version of Go's `container/heap` package that performs direct comparisons instead of hitting an interface repeatedly.