### PR TITLE
Document the grammar parsed by each `ast` type

### DIFF
--- a/experimental/ast/decl.go
+++ b/experimental/ast/decl.go
@@ -46,6 +46,13 @@ type DeclKind int8
 // This type is used in lieu of a putative Decl interface type to avoid heap
 // allocations in functions that would return one of many different Decl*
 // types.
+//
+// # Grammar
+//
+//	DeclAny := DeclEmpty | DeclSyntax | DeclPackage | DeclImport | DeclDef | DeclBody | DeclRange
+//
+// Note that this grammar is highly ambiguous. TODO: document the rules under
+// which parse DeclSyntax, DeclPackage, DeclImport, and DeclRange.
 type DeclAny struct {
 	// NOTE: These fields are sorted by alignment.
 	withContext // Must be nil if raw is nil.

--- a/experimental/ast/decl_body.go
+++ b/experimental/ast/decl_body.go
@@ -29,6 +29,13 @@ import (
 // so on.
 //
 // DeclBody implements [Slice], providing access to its declarations.
+//
+// # Grammar
+//
+//	DeclBody := `{` DeclAny* `}`
+//
+// Note that a [File] is simply a DeclBody that is delimited by the bounds of
+// the source file, rather than braces.
 type DeclBody struct{ declImpl[rawDeclBody] }
 
 type rawDeclBody struct {

--- a/experimental/ast/decl_def.go
+++ b/experimental/ast/decl_def.go
@@ -52,16 +52,14 @@ type DefKind int8
 //
 // # Grammar
 //
-//	DeclDef := (Type Path | Type | Ident) followers*`;`?
+//	DeclDef := (Type Path | Type | Ident) followers* (`;` | DeclBody)?
 //
-//	followers := inputs | outputs | value | CompactOptions | DeclBody
-//	inputs    := `(` (Type `,`)* Type? `)`
-//	outputs   := `returns` (Type | inputs)
+//	followers := inputs | outputs | value | CompactOptions
+//	inputs    := `(` (Type `,`?)* `)`
+//	outputs   := `returns` (Type | inputs)?
 //	value     := (`=` Expr) | ExprPath | ExprLiteral | ExprRange | ExprField
 //
-// Note that this type will only record the first appearance of any follower,
-// and will stop parsing a def if it sees (but does not consume) a second
-// DeclBody follower.
+// Note that this type will only record the first appearance of any follower.
 type DeclDef struct{ declImpl[rawDeclDef] }
 
 type rawDeclDef struct {

--- a/experimental/ast/decl_def.go
+++ b/experimental/ast/decl_def.go
@@ -49,6 +49,19 @@ type DefKind int8
 //
 // Generally, you should not need to work with DeclDef directly; instead, use the As* methods
 // to access the correct concrete syntax production a DeclDef represents.
+//
+// # Grammar
+//
+//	DeclDef := (Type Path | Type | Ident) followers*`;`?
+//
+//	followers := inputs | outputs | value | CompactOptions | DeclBody
+//	inputs    := `(` (Type `,`)* Type? `)`
+//	outputs   := `returns` (Type | inputs)
+//	value     := (`=` Expr) | ExprPath | ExprLiteral | ExprRange | ExprField
+//
+// Note that this type will only record the first appearance of any follower,
+// and will stop parsing a def if it sees (but does not consume) a second
+// DeclBody follower.
 type DeclDef struct{ declImpl[rawDeclDef] }
 
 type rawDeclDef struct {

--- a/experimental/ast/decl_empty.go
+++ b/experimental/ast/decl_empty.go
@@ -21,6 +21,10 @@ import (
 )
 
 // DeclEmpty is an empty declaration, a lone ;.
+//
+// # Grammar
+//
+//	DeclEmpty := `;`
 type DeclEmpty struct{ declImpl[rawDeclEmpty] }
 
 type rawDeclEmpty struct {

--- a/experimental/ast/decl_file.go
+++ b/experimental/ast/decl_file.go
@@ -81,6 +81,9 @@ func (f File) Imports() iter.Seq2[int, DeclImport] {
 // # Grammar
 //
 //	DeclSyntax := (`syntax` | `edition`) (`=`? Expr)? CompactOptions? `;`?
+//
+// Note: options are not permitted on syntax declarations in Protobuf, but we
+// parse them for diagnosis.
 type DeclSyntax struct{ declImpl[rawDeclSyntax] }
 
 type rawDeclSyntax struct {
@@ -171,6 +174,9 @@ func wrapDeclSyntax(c Context, ptr arena.Pointer[rawDeclSyntax]) DeclSyntax {
 // # Grammar
 //
 //	DeclPackage := `package` Path? CompactOptions? `;`?
+//
+// Note: options are not permitted on package declarations in Protobuf, but we
+// parse them for diagnosis.
 type DeclPackage struct{ declImpl[rawDeclPackage] }
 
 type rawDeclPackage struct {
@@ -235,6 +241,9 @@ func wrapDeclPackage(c Context, ptr arena.Pointer[rawDeclPackage]) DeclPackage {
 // # Grammar
 //
 //	DeclImport := `import` (`weak` | `public`)? Expr? CompactOptions? `;`?
+//
+// Note: options are not permitted on import declarations in Protobuf, but we
+// parse them for diagnosis.
 type DeclImport struct{ declImpl[rawDeclImport] }
 
 type rawDeclImport struct {

--- a/experimental/ast/decl_file.go
+++ b/experimental/ast/decl_file.go
@@ -23,8 +23,13 @@ import (
 
 // File is the top-level AST node for a Protobuf file.
 //
-// A file is a list of declarations (in other words, it is a [DeclBody]). The File type provides
-// convenience functions for extracting salient elements, such as the [DeclSyntax] and the [DeclPackage].
+// A file is a list of declarations (in other words, it is a [DeclBody]). The
+// File type provides convenience functions for extracting salient elements,
+// such as the [DeclSyntax] and the [DeclPackage].
+//
+// # Grammar
+//
+//	File := DeclAny*
 type File struct {
 	DeclBody
 }
@@ -70,7 +75,12 @@ func (f File) Imports() iter.Seq2[int, DeclImport] {
 	}
 }
 
-// DeclSyntax represents a language pragma, such as the syntax or edition keywords.
+// DeclSyntax represents a language pragma, such as the syntax or edition
+// keywords.
+//
+// # Grammar
+//
+//	DeclSyntax := (`syntax` | `edition`) (`=`? Expr)? CompactOptions? `;`?
 type DeclSyntax struct{ declImpl[rawDeclSyntax] }
 
 type rawDeclSyntax struct {
@@ -157,6 +167,10 @@ func wrapDeclSyntax(c Context, ptr arena.Pointer[rawDeclSyntax]) DeclSyntax {
 }
 
 // DeclPackage is the package declaration for a file.
+//
+// # Grammar
+//
+//	DeclPackage := `package` Path? CompactOptions? `;`?
 type DeclPackage struct{ declImpl[rawDeclPackage] }
 
 type rawDeclPackage struct {
@@ -217,6 +231,10 @@ func wrapDeclPackage(c Context, ptr arena.Pointer[rawDeclPackage]) DeclPackage {
 }
 
 // DeclImport is an import declaration within a file.
+//
+// # Grammar
+//
+//	DeclImport := `import` (`weak` | `public`)? Expr? CompactOptions? `;`?
 type DeclImport struct{ declImpl[rawDeclImport] }
 
 type rawDeclImport struct {

--- a/experimental/ast/decl_range.go
+++ b/experimental/ast/decl_range.go
@@ -27,6 +27,10 @@ import (
 //
 // In the Protocompile AST, ranges can contain arbitrary expressions. Thus, DeclRange
 // implements [Comma[ExprAny]].
+//
+// # Grammar
+//
+//	DeclRange := (`extensions` | `reserved`) (Expr `,`)* Expr? CompactOptions? `;`?
 type DeclRange struct{ declImpl[rawDeclRange] }
 
 type rawDeclRange struct {

--- a/experimental/ast/doc.go
+++ b/experimental/ast/doc.go
@@ -52,6 +52,11 @@
 // The parser (and other parts of the compiler) will diagnose invalid Protobuf
 // syntax, but this AST is able to represent the extended syntax it documents.
 //
+// These grammars are provided for illustration only: the complete grammar is
+// ambiguous in the absence of greediness decisions, which, except where
+// otherwise noted, neither affect the parsing of correct Protobuf files, nor
+// are they specified and are subject to change.
+//
 // # AST Context
 //
 // Virtually all operations in this package involve a [Context] (no, not a

--- a/experimental/ast/doc.go
+++ b/experimental/ast/doc.go
@@ -34,6 +34,24 @@
 // goals, we make the tradeoff, but we attempt to maintain a high degree of ease
 // of use.
 //
+// # Node Types
+//
+// Most types in this package represent AST nodes of some kind. Each such type
+// contains a grammar for the lenient extension of the Protobuf grammar that it
+// represents. The grammar is notated using regular expression syntax, with the
+// following modifications:
+//  1. Whitespace is ignored.
+//  2. Literal strings (except in character classes) are represented with Go
+//     strings.
+//  3. Unquoted names refer to other productions.
+//
+// Productions that represent a type from this package, or a [token.Kind]
+// (without the token. prefix), are in PascalCase; all other productions are in
+// camelCase and are scoped to that type.
+//
+// The parser (and other parts of the compiler) will diagnose invalid Protobuf
+// syntax, but this AST is able to represent the extended syntax it documents.
+//
 // # AST Context
 //
 // Virtually all operations in this package involve a [Context] (no, not a
@@ -46,7 +64,7 @@
 // passed by value, because they are essentially pointers (and, in fact,
 // expose a Nil function for checking if they refer to a nil Context pointer).
 //
-// # Pointer-like types
+// # Pointer-like Types
 //
 // Virtually all AST nodes in this library are "pointer-like" types, in that
 // although they are not Go pointers, they do refer to something stored in a

--- a/experimental/ast/doc.go
+++ b/experimental/ast/doc.go
@@ -45,9 +45,9 @@
 //     strings.
 //  3. Unquoted names refer to other productions.
 //
-// Productions that represent a type from this package, or a [token.Kind]
-// (without the token. prefix), are in PascalCase; all other productions are in
-// camelCase and are scoped to that type.
+// Productions that represent a type from this package, a [token.Kind], or
+// a production used by a different type, are in PascalCase; all other
+// productions are in camelCase and are scoped to that type.
 //
 // The parser (and other parts of the compiler) will diagnose invalid Protobuf
 // syntax, but this AST is able to represent the extended syntax it documents.

--- a/experimental/ast/expr.go
+++ b/experimental/ast/expr.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:dupword
+//nolint:dupword // Disable for whole file, because the error is in a comment.
 package ast
 
 import (
@@ -54,9 +54,15 @@ type ExprKind int8
 // In addition to the Expr type, we define some exported productions for
 // handling operator precedence.
 //
-//	Expr     := ExprField | ExprOp1
-//	ExprOp   := ExprRange | ExprPrefix | ExprSolo
-//	ExprSolo := ExprLiteral | ExprPath | ExprArray | ExprDict
+//	Expr      := ExprField | ExprOp
+//	ExprJuxta := ExprFieldWithColon | ExprOp
+//	ExprOp    := ExprRange | ExprPrefix | ExprSolo
+//	ExprSolo  := ExprLiteral | ExprPath | ExprArray | ExprDict
+//
+// Note: ExprJuxta is the expression production that is unambiguous when
+// expressions are juxtaposed with each other; i.e., ExprJuxta* does not make
+// e.g. "foo {}" ambiguous between an [ExprField] or an [ExprPath] followed by
+// an [ExprDict].
 type ExprAny struct {
 	withContext // Must be nil if raw is nil.
 

--- a/experimental/ast/expr.go
+++ b/experimental/ast/expr.go
@@ -47,6 +47,15 @@ type ExprKind int8
 // This type is used in lieu of a putative ExprAny interface type to avoid heap
 // allocations in functions that would return one of many different ExprAny*
 // types.
+//
+// # Grammar
+//
+// In addition to the Expr type, we define some exported productions for
+// handling operator precedence.
+//
+//	Expr     := ExprField | ExprOp1
+//	ExprOp   := ExprRange | ExprPrefix | ExprSolo
+//	ExprSolo := ExprLiteral | ExprPath | ExprArray | ExprDict
 type ExprAny struct {
 	withContext // Must be nil if raw is nil.
 

--- a/experimental/ast/expr.go
+++ b/experimental/ast/expr.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:dupword
 package ast
 
 import (

--- a/experimental/ast/expr_array.go
+++ b/experimental/ast/expr_array.go
@@ -23,7 +23,11 @@ import (
 
 // ExprArray represents an array of expressions between square brackets.
 //
-// ExprArray implements [Commas[ExprAny]].
+// ExprArray implements [Commas][ExprAny].
+//
+// # Grammar
+//
+//	ExprArray := `[` (Expr ,)* Expr? `]`
 type ExprArray struct{ exprImpl[rawExprArray] }
 
 type rawExprArray struct {

--- a/experimental/ast/expr_array.go
+++ b/experimental/ast/expr_array.go
@@ -23,11 +23,11 @@ import (
 
 // ExprArray represents an array of expressions between square brackets.
 //
-// ExprArray implements [Commas][ExprAny].
+// ExprArray implements [Commas].
 //
 // # Grammar
 //
-//	ExprArray := `[` (Expr ,)* Expr? `]`
+//	ExprArray := `[` (ExprJuxta `,`?)*`]`
 type ExprArray struct{ exprImpl[rawExprArray] }
 
 type rawExprArray struct {

--- a/experimental/ast/expr_dict.go
+++ b/experimental/ast/expr_dict.go
@@ -29,7 +29,7 @@ import (
 // # Grammar
 //
 //	ExprDict := `{` fields `}` | `<` fields `>`
-//	fields := (Expr [,;]?)* Expr
+//	fields := (Expr (`,` | `;`)?)*
 //
 // Note that if a non-[ExprField] occurs as a field of a dict, the parser will
 // rewrite it into an [ExprField] with a missing key.
@@ -129,7 +129,11 @@ func (e ExprDict) Span() report.Span {
 //
 // # Grammar
 //
-//	ExprField := Expr [:=]
+//	ExprField := ExprFieldWithColon | Expr (ExprDict | ExprArray)
+//	ExprFieldWithColon := Expr (`:` | `=`) Expr
+//
+// Note: ExprFieldWithColon appears in ExprJuxta, the expression production that
+// is unambiguous when expressions are juxtaposed with each other.
 type ExprField struct{ exprImpl[rawExprField] }
 
 type rawExprField struct {

--- a/experimental/ast/expr_dict.go
+++ b/experimental/ast/expr_dict.go
@@ -23,6 +23,16 @@ import (
 )
 
 // ExprDict represents a an array of message fields between curly braces.
+//
+// ExprArray implements [Commas].
+//
+// # Grammar
+//
+//	ExprDict := `{` fields `}` | `<` fields `>`
+//	fields := (Expr [,;]?)* Expr
+//
+// Note that if a non-[ExprField] occurs as a field of a dict, the parser will
+// rewrite it into an [ExprField] with a missing key.
 type ExprDict struct{ exprImpl[rawExprDict] }
 
 type rawExprDict struct {
@@ -114,7 +124,12 @@ func (e ExprDict) Span() report.Span {
 
 // ExprField is a key-value pair within an [ExprDict].
 //
-// It implements [ExprAny], since it can appear inside of e.g. an array if the user incorrectly writes [foo: bar].
+// It implements [ExprAny], since it can appear inside of e.g. an array if the
+// user incorrectly writes [foo: bar].
+//
+// # Grammar
+//
+//	ExprField := Expr [:=]
 type ExprField struct{ exprImpl[rawExprField] }
 
 type rawExprField struct {

--- a/experimental/ast/expr_literal.go
+++ b/experimental/ast/expr_literal.go
@@ -22,7 +22,7 @@ import (
 //
 // # Grammar
 //
-//	ExprLiteral := Number | String
+//	ExprLiteral := token.Number | token.String
 type ExprLiteral struct {
 	// The token backing this expression. Must be [token.String] or [token.Number],
 	// and its Context() must be an ast.Context.

--- a/experimental/ast/expr_literal.go
+++ b/experimental/ast/expr_literal.go
@@ -19,6 +19,10 @@ import (
 )
 
 // ExprLiteral is an expression corresponding to a string or number literal.
+//
+// # Grammar
+//
+//	ExprLiteral := Number | String
 type ExprLiteral struct {
 	// The token backing this expression. Must be [token.String] or [token.Number],
 	// and its Context() must be an ast.Context.

--- a/experimental/ast/expr_prefixed.go
+++ b/experimental/ast/expr_prefixed.go
@@ -24,7 +24,7 @@ const (
 	ExprPrefixMinus
 )
 
-// TypePrefix is a prefix for an expression, such as a minus sign.
+// ExprPrefix is a prefix for an expression, such as a minus sign.
 type ExprPrefix int8
 
 // ExprPrefixByName looks up a prefix kind by name.
@@ -40,6 +40,10 @@ func ExprPrefixByName(name string) ExprPrefix {
 }
 
 // ExprPrefixed is an expression prefixed with an operator.
+//
+// # Grammar
+//
+//	ExprPrefix := `-` ExprSolo
 type ExprPrefixed struct{ exprImpl[rawExprPrefixed] }
 
 type rawExprPrefixed struct {

--- a/experimental/ast/expr_range.go
+++ b/experimental/ast/expr_range.go
@@ -22,6 +22,10 @@ import (
 // ExprRange represents a range of values, such as 1 to 4 or 5 to max.
 //
 // Note that max is not special syntax; it will appear as an [ExprPath] with the name "max".
+//
+// # Grammar
+//
+//	ExprRange := ExprPrefixed `to` ExprOp
 type ExprRange struct{ exprImpl[rawExprRange] }
 
 type rawExprRange struct {

--- a/experimental/ast/options.go
+++ b/experimental/ast/options.go
@@ -23,10 +23,15 @@ import (
 	"github.com/bufbuild/protocompile/internal/arena"
 )
 
-// CompactOptions represents the collection of options attached to a field-like declaration,
+// CompactOptions represents the collection of options attached to a [DeclAny],
 // contained within square brackets.
 //
 // CompactOptions implements [Commas] over its options.
+//
+// # Grammar
+//
+//	CompactOptions := `[` (option `,`)* option? `]`
+//	option         := Path [:=]? Expr?
 type CompactOptions struct {
 	withContext
 	raw *rawCompactOptions

--- a/experimental/ast/options.go
+++ b/experimental/ast/options.go
@@ -30,7 +30,7 @@ import (
 //
 // # Grammar
 //
-//	CompactOptions := `[` (option `,`)* option? `]`
+//	CompactOptions := `[` (option `,`?)? `]`
 //	option         := Path [:=]? Expr?
 type CompactOptions struct {
 	withContext

--- a/experimental/ast/path.go
+++ b/experimental/ast/path.go
@@ -29,6 +29,13 @@ import (
 //
 // This includes single identifiers like foo, references like foo.bar,
 // and fully-qualified names like .foo.bar.
+//
+// # Grammar
+//
+//	Path      := `.`? component (sep component)*
+//
+//	component := Ident | `(` Path `)`
+//	sep       := `.` | `/`
 type Path struct {
 	// The layout of this type is depended on in ast2/path.go
 	withContext
@@ -169,6 +176,10 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 }
 
 // TypePath is a simple path reference as a type.
+//
+// # Grammar
+//
+//	TypePath := Path
 type TypePath struct {
 	// The path that refers to this type.
 	Path
@@ -181,7 +192,11 @@ func (t TypePath) AsAny() TypeAny {
 	return newTypeAny(t.Context(), wrapPath[TypeKind](t.raw))
 }
 
-// TypePath is a simple path reference in expression position.
+// ExprPath is a simple path reference in expression position.
+//
+// # Grammar
+//
+//	ExprPath := Path
 type ExprPath struct {
 	// The path backing this expression.
 	Path

--- a/experimental/ast/path.go
+++ b/experimental/ast/path.go
@@ -34,7 +34,7 @@ import (
 //
 //	Path      := `.`? component (sep component)*
 //
-//	component := Ident | `(` Path `)`
+//	component := token.Ident | `(` Path `)`
 //	sep       := `.` | `/`
 type Path struct {
 	// The layout of this type is depended on in ast2/path.go

--- a/experimental/ast/type.go
+++ b/experimental/ast/type.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:dupword // Disable for whole file, because the error is in a comment.
 package ast
 
 import (

--- a/experimental/ast/type.go
+++ b/experimental/ast/type.go
@@ -48,18 +48,19 @@ type TypeKind int8
 //
 //	Type := TypePath | TypePrefixed | TypeGeneric
 //
-// Note that there is an ambiguity when parsing a Type followed by a Path:
-// "optional optional foo" could be parsed as:
+// Note that parsing a type cannot always be greedy. Consider that, if parsed
+// as a type, "optional optional foo" could be parsed as:
 //
 //	TypePrefix{Optional, TypePrefix{Optional, TypePath("foo")}}
 //
-// However, this should be parsed as follows:
+// However, if we want to parse a type followed by a [Path], it needs to parse
+// as follows:
 //
-//	TypePrefix{Optional, TypePath("optional")}, TypePath("foo")
+//	TypePrefix{Optional, TypePath("optional")}, Path("foo")
 //
-// This means that when parsing a type followed by a path, we must reserve the
-// last path we see as the path to return, and only construct TypePrefixes
-// using all but this last path.
+// Thus, parsing a type is greedy except when the containing production contains
+// "Type Path?" or similar, in which case parsing must be greedy up to the last
+// [Path] it would otherwise consume.
 type TypeAny struct {
 	withContext // Must be nil if raw is nil.
 

--- a/experimental/ast/type.go
+++ b/experimental/ast/type.go
@@ -42,6 +42,23 @@ type TypeKind int8
 // This type is used in lieu of a putative Type interface type to avoid heap
 // allocations in functions that would return one of many different Type*
 // types.
+//
+// # Grammar
+//
+//	Type := TypePath | TypePrefixed | TypeGeneric
+//
+// Note that there is an ambiguity when parsing a Type followed by a Path:
+// "optional optional foo" could be parsed as:
+//
+//	TypePrefix{Optional, TypePrefix{Optional, TypePath("foo")}}
+//
+// However, this should be parsed as follows:
+//
+//	TypePrefix{Optional, TypePath("optional")}, TypePath("foo")
+//
+// This means that when parsing a type followed by a path, we must reserve the
+// last path we see as the path to return, and only construct TypePrefixes
+// using all but this last path.
 type TypeAny struct {
 	withContext // Must be nil if raw is nil.
 

--- a/experimental/ast/type_generic.go
+++ b/experimental/ast/type_generic.go
@@ -33,6 +33,10 @@ import (
 // that all generic types understood by your code are maps.
 //
 // TypeGeneric implements [Commas[TypeAny]] for accessing its arguments.
+//
+// # Grammar
+//
+//	TypeGeneric := TypePath `<` (Type, )* Type? `>`
 type TypeGeneric struct{ typeImpl[rawTypeGeneric] }
 
 type rawTypeGeneric struct {

--- a/experimental/ast/type_generic.go
+++ b/experimental/ast/type_generic.go
@@ -36,7 +36,7 @@ import (
 //
 // # Grammar
 //
-//	TypeGeneric := TypePath `<` (Type, )* Type? `>`
+//	TypeGeneric := TypePath `<` (Type `,`?`)* `>`
 type TypeGeneric struct{ typeImpl[rawTypeGeneric] }
 
 type rawTypeGeneric struct {

--- a/experimental/ast/type_prefixed.go
+++ b/experimental/ast/type_prefixed.go
@@ -25,6 +25,16 @@ import (
 //
 // Unlike in ordinary Protobuf, the Protocompile AST permits arbitrary nesting
 // of modifiers.
+//
+// # Grammar
+//
+//	TypePrefixed := (`optional` | `repeated` | `required` | `stream`) Type
+//
+// Note that there are ambiguities when Type is an absolute [TypePath].
+// The source "optional .foo" names the type "optional.foo" only when inside
+// of a [TypeGeneric]'s brackets or a [Signature]'s method parameters.
+//
+// Also, the `stream` prefix may only occur inside of a [Signature].
 type TypePrefixed struct{ typeImpl[rawTypePrefixed] }
 
 type rawTypePrefixed struct {


### PR DESCRIPTION
I chose to use modified regex syntax for the grammar definition, for two reasons:

1. EBNF is quite verbose and difficult to read, which is why it's not actually used by very many language specifications (Go and Python are the only ones I can think of that do; C++, Java, Rust, and EcmaScript all use something closer to regular expressions; none of them use `{}` and `[]` the way EBNF does).

2. Everyone knows regex syntax, and I frankly find it more succinct and easier to follow.