### PR TITLE
Ensure zero values of all `report.Spanner` types return the nil span

### DIFF
--- a/experimental/ast/decl_body.go
+++ b/experimental/ast/decl_body.go
@@ -52,15 +52,16 @@ func (d DeclBody) Braces() token.Token {
 
 // Span implements [report.Spanner].
 func (d DeclBody) Span() report.Span {
-	if !d.Braces().Nil() {
-		return d.Braces().Span()
-	}
-
-	if d.Len() == 0 {
+	switch {
+	case d.Nil():
 		return report.Span{}
+	case !d.Braces().Nil():
+		return d.Braces().Span()
+	case d.Len() == 0:
+		return report.Span{}
+	default:
+		return report.Join(d.At(0), d.At(d.Len()-1))
 	}
-
-	return report.Join(d.At(0), d.At(d.Len()-1))
 }
 
 // Len returns the number of declarations inside of this body.

--- a/experimental/ast/decl_def.go
+++ b/experimental/ast/decl_def.go
@@ -431,6 +431,7 @@ func (d DeclDef) Span() report.Span {
 	if d.Nil() {
 		return report.Span{}
 	}
+
 	return report.Join(
 		d.Type(),
 		d.Name(),
@@ -485,6 +486,10 @@ func (s Signature) Outputs() TypeList {
 
 // Span implemented [report.Spanner].
 func (s Signature) Span() report.Span {
+	if s.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(s.Inputs(), s.Returns(), s.Outputs())
 }
 

--- a/experimental/ast/decl_empty.go
+++ b/experimental/ast/decl_empty.go
@@ -36,6 +36,10 @@ func (d DeclEmpty) Semicolon() token.Token {
 
 // Span implements [report.Spanner].
 func (d DeclEmpty) Span() report.Span {
+	if d.Nil() {
+		return report.Span{}
+	}
+
 	return d.Semicolon().Span()
 }
 

--- a/experimental/ast/decl_file.go
+++ b/experimental/ast/decl_file.go
@@ -149,6 +149,10 @@ func (d DeclSyntax) Semicolon() token.Token {
 
 // report.Span implements [report.Spanner].
 func (d DeclSyntax) Span() report.Span {
+	if d.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(d.Keyword(), d.Equals(), d.Value(), d.Semicolon())
 }
 
@@ -209,6 +213,10 @@ func (d DeclPackage) Semicolon() token.Token {
 
 // report.Span implements [report.Spanner].
 func (d DeclPackage) Span() report.Span {
+	if d.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(d.Keyword(), d.Path(), d.Semicolon())
 }
 
@@ -293,6 +301,10 @@ func (d DeclImport) Semicolon() token.Token {
 
 // report.Span implements [report.Spanner].
 func (d DeclImport) Span() report.Span {
+	if d.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(d.Keyword(), d.Modifier(), d.ImportPath(), d.Semicolon())
 }
 

--- a/experimental/ast/decl_range.go
+++ b/experimental/ast/decl_range.go
@@ -134,11 +134,18 @@ func (d DeclRange) Semicolon() token.Token {
 
 // Span implements [report.Spanner].
 func (d DeclRange) Span() report.Span {
-	span := report.Join(d.Keyword(), d.Semicolon(), d.Options())
-	for _, arg := range d.raw.args {
-		span = report.Join(span, newExprAny(d.Context(), arg.Value), arg.Comma.In(d.Context()))
+	switch {
+	case d.Nil():
+		return report.Span{}
+	case d.Len() == 0:
+		return report.Join(d.Keyword(), d.Semicolon(), d.Options())
+	default:
+		return report.Join(
+			d.Keyword(), d.Semicolon(), d.Options(),
+			d.At(0),
+			d.At(d.Len()-1),
+		)
 	}
-	return span
 }
 
 func wrapDeclRange(c Context, ptr arena.Pointer[rawDeclRange]) DeclRange {

--- a/experimental/ast/expr_array.go
+++ b/experimental/ast/expr_array.go
@@ -93,5 +93,9 @@ func (e ExprArray) InsertComma(n int, expr ExprAny, comma token.Token) {
 
 // Span implements [report.Spanner].
 func (e ExprArray) Span() report.Span {
+	if e.Nil() {
+		return report.Span{}
+	}
+
 	return e.Brackets().Span()
 }

--- a/experimental/ast/expr_dict.go
+++ b/experimental/ast/expr_dict.go
@@ -109,6 +109,10 @@ func (e ExprDict) AsMessage() Commas[ExprField] {
 
 // Span implements [report.Spanner].
 func (e ExprDict) Span() report.Span {
+	if e.Nil() {
+		return report.Span{}
+	}
+
 	return e.Braces().Span()
 }
 
@@ -165,5 +169,9 @@ func (e ExprField) SetValue(expr ExprAny) {
 
 // Span implements [report.Spanner].
 func (e ExprField) Span() report.Span {
+	if e.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(e.Key(), e.Colon(), e.Value())
 }

--- a/experimental/ast/expr_prefixed.go
+++ b/experimental/ast/expr_prefixed.go
@@ -77,5 +77,9 @@ func (e ExprPrefixed) SetExpr(expr ExprAny) {
 
 // report.Span implements [report.Spanner].
 func (e ExprPrefixed) Span() report.Span {
+	if e.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(e.PrefixToken(), e.Expr())
 }

--- a/experimental/ast/expr_range.go
+++ b/experimental/ast/expr_range.go
@@ -56,6 +56,10 @@ func (e ExprRange) Keyword() token.Token {
 
 // Span implements [report.Spanner].
 func (e ExprRange) Span() report.Span {
+	if e.Nil() {
+		return report.Span{}
+	}
+
 	lo, hi := e.Bounds()
 	return report.Join(lo, e.Keyword(), hi)
 }

--- a/experimental/ast/nil_test.go
+++ b/experimental/ast/nil_test.go
@@ -1,0 +1,77 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/token"
+)
+
+func TestNilSpans(t *testing.T) {
+	testNil[ast.DeclAny](t)
+	testNil[ast.DeclBody](t)
+	testNil[ast.DeclDef](t)
+	testNil[ast.DeclEmpty](t)
+	testNil[ast.DeclImport](t)
+	testNil[ast.DeclPackage](t)
+	testNil[ast.DeclRange](t)
+	testNil[ast.DefEnum](t)
+
+	testNil[ast.DefEnumValue](t)
+	testNil[ast.DefExtend](t)
+	testNil[ast.DefField](t)
+	testNil[ast.DefGroup](t)
+	testNil[ast.DefMessage](t)
+	testNil[ast.DefMethod](t)
+	testNil[ast.DefOneof](t)
+	testNil[ast.DefOption](t)
+	testNil[ast.DefService](t)
+
+	testNil[ast.ExprAny](t)
+	testNil[ast.ExprArray](t)
+	testNil[ast.ExprDict](t)
+	testNil[ast.ExprField](t)
+	testNil[ast.ExprLiteral](t)
+	testNil[ast.ExprPath](t)
+	testNil[ast.ExprPrefixed](t)
+
+	testNil[ast.TypeAny](t)
+	testNil[ast.TypeGeneric](t)
+	testNil[ast.TypeList](t)
+	testNil[ast.TypePath](t)
+	testNil[ast.TypePrefixed](t)
+
+	testNil[ast.CompactOptions](t)
+	testNil[ast.File](t)
+	testNil[ast.Signature](t)
+	testNil[ast.Path](t)
+	testNil[token.Token](t)
+}
+
+// testNil validates that the nil value of some Spanner produces the nil span.
+func testNil[N report.Spanner](t *testing.T) {
+	t.Helper()
+	var Nil N
+
+	t.Run(fmt.Sprintf("%T", Nil), func(t *testing.T) {
+		assert.Zero(t, Nil.Span())
+	})
+}

--- a/experimental/ast/nil_test.go
+++ b/experimental/ast/nil_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestNilSpans(t *testing.T) {
+	t.Parallel()
+
 	testNil[ast.DeclAny](t)
 	testNil[ast.DeclBody](t)
 	testNil[ast.DeclDef](t)

--- a/experimental/ast/options.go
+++ b/experimental/ast/options.go
@@ -117,7 +117,11 @@ func (o CompactOptions) InsertComma(n int, option Option, comma token.Token) {
 
 // Span implements [report.Spanner].
 func (o CompactOptions) Span() report.Span {
-	return report.Join(o.Brackets())
+	if o.Nil() {
+		return report.Span{}
+	}
+
+	return o.Brackets().Span()
 }
 
 func wrapOptions(c Context, ptr arena.Pointer[rawCompactOptions]) CompactOptions {

--- a/experimental/ast/path.go
+++ b/experimental/ast/path.go
@@ -80,6 +80,8 @@ func (p Path) AsPredeclared() predeclared.Name {
 
 // report.Span implements [report.Spanner].
 func (p Path) Span() report.Span {
+	// No need to check for nil here, if p is nil both start and end will be
+	// nil tokens.
 	return report.Join(p.raw.Start.In(p.Context()), p.raw.End.In(p.Context()))
 }
 

--- a/experimental/ast/type_generic.go
+++ b/experimental/ast/type_generic.go
@@ -77,6 +77,10 @@ func (t TypeGeneric) Args() TypeList {
 
 // Span implements [report.Spanner].
 func (t TypeGeneric) Span() report.Span {
+	if t.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(t.Path(), t.Args())
 }
 
@@ -159,13 +163,14 @@ func (d TypeList) InsertComma(n int, ty TypeAny, comma token.Token) {
 
 // Span implements [report.Spanner].
 func (d TypeList) Span() report.Span {
-	if !d.Brackets().Nil() {
+	switch {
+	case d.Nil():
+		return report.Span{}
+	case !d.Brackets().Nil():
 		return d.Brackets().Span()
+	case d.Len() == 0:
+		return report.Span{}
+	default:
+		return report.Join(d.At(0), d.At(d.Len()-1))
 	}
-
-	var span report.Span
-	for _, arg := range d.raw.args {
-		span = report.Join(span, newTypeAny(d.Context(), arg.Value), arg.Comma.In(d.Context()))
-	}
-	return span
 }

--- a/experimental/ast/type_prefixed.go
+++ b/experimental/ast/type_prefixed.go
@@ -65,6 +65,10 @@ func (t TypePrefixed) SetType(ty TypeAny) {
 
 // Span implements [report.Spanner].
 func (t TypePrefixed) Span() report.Span {
+	if t.Nil() {
+		return report.Span{}
+	}
+
 	return report.Join(t.PrefixToken(), t.Type())
 }
 


### PR DESCRIPTION
Also adds a test to validate this, and updates the report package to not bother checking for `Nil()`.