### PR TITLE
Implement support for synthetic paths

### DIFF
--- a/experimental/ast/nodes.go
+++ b/experimental/ast/nodes.go
@@ -142,8 +142,7 @@ func (n *Nodes) NewPath(components ...PathComponent) Path {
 	}
 	stream.NewFused(start, end, children...)
 
-	path := rawPath{Start: start.ID()}
-	path.setSynthRange(0, len(children))
+	path := rawPath{Start: start.ID()}.withSynthRange(0, len(children))
 
 	if n.extnPathCache == nil {
 		n.extnPathCache = make(map[rawPath]token.ID)

--- a/experimental/ast/nodes.go
+++ b/experimental/ast/nodes.go
@@ -16,6 +16,7 @@ package ast
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/bufbuild/protocompile/experimental/internal"
 	"github.com/bufbuild/protocompile/experimental/token"
@@ -32,6 +33,10 @@ type Nodes struct {
 	types   types
 	exprs   exprs
 	options arena.Arena[rawCompactOptions]
+
+	// A cache of raw paths that have been converted into parenthesized
+	// components in NewExtensionComponent.
+	extnPathCache map[rawPath]token.ID
 }
 
 // Root returns the root AST node for this context.
@@ -41,6 +46,111 @@ func (n *Nodes) Root() File {
 	// file. We use a 1 here, not a 0, because arena.Arena's indices are
 	// off-by-one to accommodate the zero representation.
 	return File{wrapDeclBody(n.Context, 1)}
+}
+
+// NewPathComponent returns a new path component with the given separator and
+// name.
+//
+// sep must be a [token.Punct] whose value is either '.' or '/'. name must be
+// a [token.Ident]. This function will panic if either condition does not
+// hold.
+//
+// To create a path component with an extension value, see [Nodes.NewExtensionComponent].
+func (n *Nodes) NewPathComponent(separator, name token.Token) PathComponent {
+	n.panicIfNotOurs(separator, name)
+	if !separator.IsZero() {
+		if separator.Kind() != token.Punct || (separator.Text() != "." && separator.Text() != "/") {
+			panic(fmt.Sprintf("protocompile/ast: passed non '.' or '/' separator to NewPathComponent: %s", separator))
+		}
+	}
+	if name.Kind() != token.Ident {
+		panic("protocompile/ast: passed non-identifier name to NewPathComponent")
+	}
+
+	return PathComponent{
+		withContext: internal.NewWith(n.Context),
+		separator:   separator.ID(),
+		name:        name.ID(),
+	}
+}
+
+// NewExtensionComponent returns a new extension path component containing the
+// given path.
+func (n *Nodes) NewExtensionComponent(separator token.Token, path Path) PathComponent {
+	n.panicIfNotOurs(separator, path)
+	if !separator.IsZero() {
+		if separator.Kind() != token.Punct || (separator.Text() != "." && separator.Text() != "/") {
+			panic(fmt.Sprintf("protocompile/ast: passed non '.' or '/' separator to NewPathComponent: %s", separator))
+		}
+	}
+
+	name, ok := n.extnPathCache[path.raw]
+	if !ok {
+		stream := n.Context.Stream()
+		start := stream.NewPunct("(")
+		end := stream.NewPunct(")")
+		var children []token.Token
+		path.Components(func(pc PathComponent) bool {
+			if !pc.Separator().IsZero() {
+				children = append(children, pc.Separator())
+			}
+			if !pc.Name().IsZero() {
+				children = append(children, pc.Name())
+			}
+			return true
+		})
+		stream.NewFused(start, end, children...)
+
+		name = start.ID()
+		if n.extnPathCache == nil {
+			n.extnPathCache = make(map[rawPath]token.ID)
+		}
+		n.extnPathCache[path.raw] = name
+	}
+
+	return PathComponent{
+		withContext: internal.NewWith(n.Context),
+		separator:   separator.ID(),
+		name:        name,
+	}
+}
+
+// NewPath creates a new synthetic Path.
+func (n *Nodes) NewPath(components ...PathComponent) Path {
+	if len(components) > math.MaxInt16 {
+		panic("protocompile/ast: cannot build path with more than 2^15 components")
+	}
+
+	for _, t := range components {
+		n.panicIfNotOurs(t)
+	}
+
+	stream := n.Context.Stream()
+
+	// Every synthetic path looks like a (a.b.c) token tree. Users can't see the
+	// parens here.
+	start := stream.NewPunct("(")
+	end := stream.NewPunct(")")
+	var children []token.Token
+	for _, pc := range components {
+		if !pc.Separator().IsZero() {
+			children = append(children, pc.Separator())
+		}
+		if !pc.Name().IsZero() {
+			children = append(children, pc.Name())
+		}
+	}
+	stream.NewFused(start, end, children...)
+
+	path := rawPath{Start: start.ID()}
+	path.setSynthRange(0, len(children))
+
+	if n.extnPathCache == nil {
+		n.extnPathCache = make(map[rawPath]token.ID)
+	}
+	n.extnPathCache[path] = path.Start
+
+	return path.With(n.Context)
 }
 
 // NewDeclEmpty creates a new DeclEmpty node.

--- a/experimental/ast/path.go
+++ b/experimental/ast/path.go
@@ -172,7 +172,6 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 	var prev PathComponent
 	var found bool
 	for pc := range p.Components {
-		fmt.Println(pc)
 		if n > 0 {
 			prev = pc
 			n--

--- a/experimental/ast/path.go
+++ b/experimental/ast/path.go
@@ -187,11 +187,11 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 
 		if p.IsSynthetic() {
 			a, _ := prefix.raw.synthRange()
-			prefix.raw.setSynthRange(a, a+i)
+			prefix.raw = prefix.raw.withSynthRange(a, a+i)
 
 			a, b := suffix.raw.synthRange()
 			a += i
-			suffix.raw.setSynthRange(a, b)
+			suffix.raw = suffix.raw.withSynthRange(a, b)
 
 			continue
 		}
@@ -427,8 +427,9 @@ func (p rawPath) synthRange() (start, end int) {
 	return int(^uint16(p.End)), int(^uint16(p.End >> 16))
 }
 
-func (p *rawPath) setSynthRange(start, end int) {
+func (p rawPath) withSynthRange(start, end int) rawPath {
 	p.End = token.ID(^uint16(start)) | (token.ID(^uint16(end)) << 16)
+	return p
 }
 
 // With wraps this rawPath with a context to present to the user.

--- a/experimental/ast/path.go
+++ b/experimental/ast/path.go
@@ -170,7 +170,9 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 
 	var i int
 	var prev PathComponent
+	var found bool
 	for pc := range p.Components {
+		fmt.Println(pc)
 		if n > 0 {
 			prev = pc
 			n--
@@ -184,6 +186,7 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 		}
 
 		prefix, suffix = p, p
+		found = true
 
 		if p.IsSynthetic() {
 			a, _ := prefix.raw.synthRange()
@@ -196,7 +199,7 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 			continue
 		}
 
-		if !pc.name.IsZero() {
+		if !prev.name.IsZero() {
 			prefix.raw.End = prev.name
 		} else {
 			prefix.raw.End = prev.separator
@@ -211,11 +214,8 @@ func (p Path) Split(n int) (prefix, suffix Path) {
 		break
 	}
 
-	if prefix.raw.Start == prefix.raw.End {
-		prefix = Path{}
-	}
-	if suffix.raw.Start == suffix.raw.End {
-		suffix = Path{}
+	if !found {
+		return p, Path{}
 	}
 
 	return prefix, suffix

--- a/experimental/ast/path_test.go
+++ b/experimental/ast/path_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 Buf Technologies, Inc.
+// Copyright 2020-2025 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package ast_test
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,6 @@ import (
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/token"
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
-	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 )
 
 func TestNaturalSplit(t *testing.T) {
@@ -125,7 +125,7 @@ func TestSyntheticSplit(t *testing.T) {
 func pathEq(t *testing.T, path ast.Path, want [][2]token.Token) {
 	t.Helper()
 
-	components := slicesx.Collect(iterx.Map(path.Components, func(pc ast.PathComponent) [2]token.Token {
+	components := slices.Collect(iterx.Map(path.Components, func(pc ast.PathComponent) [2]token.Token {
 		return [2]token.Token{pc.Separator(), pc.Name()}
 	}))
 	stringEq(t, components, want)

--- a/experimental/ast/path_test.go
+++ b/experimental/ast/path_test.go
@@ -18,13 +18,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/internal/astx"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/token"
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
 	"github.com/bufbuild/protocompile/internal/ext/slicesx"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNaturalSplit(t *testing.T) {

--- a/experimental/ast/path_test.go
+++ b/experimental/ast/path_test.go
@@ -1,0 +1,141 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/internal/astx"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/token"
+	"github.com/bufbuild/protocompile/internal/ext/iterx"
+	"github.com/bufbuild/protocompile/internal/ext/slicesx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNaturalSplit(t *testing.T) {
+	t.Parallel()
+
+	c := ast.NewContext(report.NewFile("test.proto", "a.b./*idk*/(a.b.c )/*x*/.d"))
+
+	// Manually lex the Path above.
+	s := c.Stream()
+	tokens := []token.Token{
+		s.Push(1, token.Ident),   //  0 a
+		s.Push(1, token.Punct),   //  1 .
+		s.Push(1, token.Ident),   //  2 b
+		s.Push(1, token.Punct),   //  3 .
+		s.Push(7, token.Comment), //  4 /*idk*/
+		s.Push(1, token.Punct),   //  5 (
+		s.Push(1, token.Ident),   //  6 a
+		s.Push(1, token.Punct),   //  7 .
+		s.Push(1, token.Ident),   //  8 b
+		s.Push(1, token.Punct),   //  9 .
+		s.Push(1, token.Ident),   // 10 c
+		s.Push(1, token.Space),   // 11
+		s.Push(1, token.Punct),   // 12 )
+		s.Push(5, token.Comment), // 13 /*x*/
+		s.Push(1, token.Punct),   // 14 .
+		s.Push(1, token.Ident),   // 15 d
+	}
+
+	token.Fuse(tokens[5], tokens[12])
+
+	path := astx.NewPath(c, tokens[0], tokens[15])
+	components := [][2]token.Token{
+		{token.Zero, tokens[0]},  // a
+		{tokens[1], tokens[2]},   // .b
+		{tokens[3], tokens[5]},   // .(a.b.c)
+		{tokens[14], tokens[15]}, // .d
+	}
+
+	pathEq(t, path, components)
+
+	start, end := path.Split(0)
+	pathEq(t, start, [][2]token.Token{})
+	pathEq(t, end, components)
+
+	start, end = path.Split(2)
+	pathEq(t, start, components[:2])
+	pathEq(t, end, components[2:])
+}
+
+func TestSyntheticSplit(t *testing.T) {
+	t.Parallel()
+
+	ctx := ast.NewContext(report.NewFile("test.proto", "a.b.(a.b.c).d"))
+
+	// Manually build this path: a.b.(a.b.c).d
+	s := ctx.Stream()
+	p := s.NewPunct(".")
+	a := s.NewIdent("a")
+	b := s.NewIdent("b")
+	c := s.NewIdent("c")
+	d := s.NewIdent("d")
+	inner := ctx.Nodes().NewPath(
+		ctx.Nodes().NewPathComponent(token.Zero, a),
+		ctx.Nodes().NewPathComponent(p, b),
+		ctx.Nodes().NewPathComponent(p, c),
+	)
+	fmt.Println(inner)
+	extn := ctx.Nodes().NewExtensionComponent(p, inner)
+	path := ctx.Nodes().NewPath(
+		ctx.Nodes().NewPathComponent(token.Zero, a),
+		ctx.Nodes().NewPathComponent(p, b),
+		extn,
+		ctx.Nodes().NewPathComponent(p, d),
+	)
+	fmt.Println(path)
+
+	components := [][2]token.Token{
+		{token.Zero, a},  // a
+		{p, b},           // .b
+		{p, extn.Name()}, // .(a.b.c)
+		{p, d},           // .d
+	}
+
+	start, end := path.Split(0)
+	pathEq(t, start, [][2]token.Token{})
+	pathEq(t, end, components)
+
+	start, end = path.Split(2)
+	pathEq(t, start, components[:2])
+	pathEq(t, end, components[2:])
+}
+
+func pathEq(t *testing.T, path ast.Path, want [][2]token.Token) {
+	t.Helper()
+
+	components := slicesx.Collect(iterx.Map(path.Components, func(pc ast.PathComponent) [2]token.Token {
+		return [2]token.Token{pc.Separator(), pc.Name()}
+	}))
+	stringEq(t, components, want)
+}
+
+func stringEq[T any](t *testing.T, tokens []T, expected []T) {
+	t.Helper()
+
+	a := make([]string, len(tokens))
+	for i, t := range tokens {
+		a[i] = fmt.Sprint(t)
+	}
+	b := make([]string, len(expected))
+	for i, t := range expected {
+		b[i] = fmt.Sprint(t)
+	}
+	assert.Equal(t, b, a)
+}

--- a/experimental/ast/path_test.go
+++ b/experimental/ast/path_test.go
@@ -70,6 +70,10 @@ func TestNaturalSplit(t *testing.T) {
 	pathEq(t, start, [][2]token.Token{})
 	pathEq(t, end, components)
 
+	start, end = path.Split(1)
+	pathEq(t, start, components[:1])
+	pathEq(t, end, components[1:])
+
 	start, end = path.Split(2)
 	pathEq(t, start, components[:2])
 	pathEq(t, end, components[2:])

--- a/experimental/ast/pathlike.go
+++ b/experimental/ast/pathlike.go
@@ -43,7 +43,7 @@ type pathLike[Kind ~int8] struct {
 //
 // If either of kind or value are zero, both must be.
 func wrapPathLike[Value ~int32 | ~uint32, Kind ~int8](kind Kind, value Value) pathLike[Kind] {
-	if kind != 0 && value == 0 {
+	if kind != 0 && int32(value) <= 0 {
 		panic(fmt.Sprintf("protocompile/ast: invalid pathLike representation: %v, %v", kind, value))
 	}
 
@@ -75,7 +75,7 @@ func wrapPath[Kind ~int8](path rawPath) pathLike[Kind] {
 
 // kind returns the kind within this pathLike, if it is not a path.
 func (p pathLike[Kind]) kind() (Kind, bool) {
-	if p.StartOrKind < 0 && p.EndOrValue != 0 {
+	if p.StartOrKind < 0 && p.EndOrValue > 0 {
 		return Kind(^p.StartOrKind), true
 	}
 	return 0, false

--- a/experimental/token/cursor.go
+++ b/experimental/token/cursor.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"iter"
 
+	"github.com/bufbuild/protocompile/experimental/internal"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 )
@@ -61,6 +62,15 @@ func NewCursorAt(tok Token) *Cursor {
 		withContext: tok.withContext,
 		idx:         tok.ID().naturalIndex(), // Convert to 0-based index.
 		isBackwards: tok.nat().IsClose(),     // Set the direction to calculate the offset.
+	}
+}
+
+// NewSliceCursor returns a new cursor over a slice of token IDs in the given
+// context.
+func NewSliceCursor(ctx Context, slice []ID) *Cursor {
+	return &Cursor{
+		withContext: internal.NewWith(ctx),
+		stream:      slice,
 	}
 }
 

--- a/experimental/token/token.go
+++ b/experimental/token/token.go
@@ -353,10 +353,22 @@ func (t Token) Children() *Cursor {
 	if synth.IsClose() {
 		return synth.otherEnd.In(t.Context()).Children()
 	}
-	return &Cursor{
-		withContext: t.withContext,
-		stream:      synth.children,
+	return NewSliceCursor(t.Context(), synth.children)
+}
+
+// SyntheticChildren returns a cursor over the given subslice of the children
+// of this token.
+//
+// Panics if t is not synthetic.
+func (t Token) SyntheticChildren(i, j int) *Cursor {
+	synth := t.synth()
+	if synth == nil {
+		panic("protocompile/token: called SyntheticChildren() on non-synthetic token")
 	}
+	if synth.IsClose() {
+		return synth.otherEnd.In(t.Context()).SyntheticChildren(i, j)
+	}
+	return NewSliceCursor(t.Context(), synth.children[i:j])
 }
 
 // Name converts this token into its corresponding identifier name, potentially


### PR DESCRIPTION
This PR adds functions to `ast.Nodes` for creating synthetic paths, which are backed by a synthetic token tree containing `(<the path>)`.

The implementation is somewhat more complicated than I had originally planned, mostly because of a need to support `Path.Split` on synthetic paths (panicking in this case felt very rude).