### PR TITLE
Fix minor diagnostic rendering issues

### DIFF
--- a/experimental/parser/testdata/lexer/strings/bad-contents.proto.stderr.txt
+++ b/experimental/parser/testdata/lexer/strings/bad-contents.proto.stderr.txt
@@ -1,18 +1,14 @@
 error: unescaped newlines are not permitted in string literals
   --> testdata/lexer/strings/bad-contents.proto:1:13
    | 
- 1 |   "this string
-   |  ____________^
- 2 | / contains a newline"
-   | \^ replace this with `\n`
+ 1 | "this string
+   |             ^ replace this with `\n`
 
 error: unescaped newlines are not permitted in string literals
   --> testdata/lexer/strings/bad-contents.proto:3:2
    | 
- 3 |   "
-   |  _^
- 4 | / "
-   | \^ replace this with `\n`
+ 3 | "
+   |  ^ replace this with `\n`
 
 error: unescaped NUL bytes are not permitted in string literals
   --> testdata/lexer/strings/bad-contents.proto:6:30

--- a/experimental/report/renderer.go
+++ b/experimental/report/renderer.go
@@ -821,7 +821,7 @@ func (w *window) Render(lineBarWidth int, ss *styleSheet, out *strings.Builder) 
 		// Ok, we are definitely printing this line out.
 		//
 		// Note that sidebar already includes a trailing ss.reset for us.
-		fmt.Fprintf(out, "\n%s%*d | %s", ss.nAccent, lineBarWidth, lineno, sidebar)
+		fmt.Fprintf(out, "\n%s%*d | %s%s", ss.nAccent, lineBarWidth, lineno, sidebar, ss.reset)
 		lastEmit = lineno
 
 		// Re-use the logic from width calculation to correctly format a line for
@@ -906,7 +906,6 @@ func renderSidebar(bars, lineno, slashAt int, ss *styleSheet, multis []*multilin
 	for sidebar.Len() < bars*2 {
 		sidebar.WriteByte(' ')
 	}
-	sidebar.WriteString(ss.reset)
 	return sidebar.String()
 }
 

--- a/experimental/report/testdata/i18n.yaml.color.txt
+++ b/experimental/report/testdata/i18n.yaml.color.txt
@@ -2,19 +2,19 @@
 ⟨blu⟩  --> foo.proto:5:9
    | 
 ⟨blu⟩ 5 | ⟨reset⟩message 🐈<U+200D>⬛ {
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.red⟩^^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩
+⟨blu⟩   | ⟨reset⟩        ⟨b.red⟩^^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩
 ⟨blu⟩ 6 | ⟨reset⟩  string 黑猫 = 1;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩         ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩note: some surfaces render CJK as sub-two-column
+⟨blu⟩   | ⟨reset⟩         ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩note: some surfaces render CJK as sub-two-column
 ⟨blu⟩  ::: bar.proto:1:9
    | 
 ⟨blu⟩ 1 | ⟨reset⟩import "חתול שחור.proto";
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.blu⟩---------------⟨reset⟩ ⟨b.blu⟩bidi works if it's quoted, at least⟨reset⟩
+⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩---------------⟨reset⟩ ⟨b.blu⟩bidi works if it's quoted, at least⟨reset⟩
 
 ⟨b.red⟩error: bidi (Arabic, Hebrew, Farsi, etc) is broken in some contexts⟨reset⟩
 ⟨blu⟩  --> foo.proto:7:10
    | 
 ⟨blu⟩ 7 | ⟨reset⟩  string القطة السوداء = 2;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩         ⟨b.red⟩^^^^^^^^⟨reset⟩ ⟨b.red⟩⟨reset⟩
+⟨blu⟩   | ⟨reset⟩         ⟨b.red⟩^^^^^^^^⟨reset⟩ ⟨b.red⟩⟨reset⟩
 
 ⟨b.red⟩encountered 2 errors⟨reset⟩
 ⟨reset⟩

--- a/experimental/report/testdata/multi-file.yaml.color.txt
+++ b/experimental/report/testdata/multi-file.yaml.color.txt
@@ -2,28 +2,28 @@
 ⟨blu⟩  --> foo.proto:3:9
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.red⟩^^^^^^^⟨reset⟩ ⟨b.red⟩foo
+⟨blu⟩   | ⟨reset⟩        ⟨b.red⟩^^^^^^^⟨reset⟩ ⟨b.red⟩foo
 ⟨blu⟩ 4 | ⟨reset⟩
 ⟨blu⟩ 5 | ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩bar
+⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩bar
 ⟨blu⟩  ::: bar.proto:3:9
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz2;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.blu⟩-------⟨reset⟩ ⟨b.blu⟩baz⟨reset⟩
+⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩-------⟨reset⟩ ⟨b.blu⟩baz⟨reset⟩
 
 ⟨b.red⟩error: three files⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:9
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.red⟩^^^^^^^⟨reset⟩ ⟨b.red⟩foo
+⟨blu⟩   | ⟨reset⟩        ⟨b.red⟩^^^^^^^⟨reset⟩ ⟨b.red⟩foo
 ⟨blu⟩  ::: bar.proto:3:9
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz2;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.blu⟩-------⟨reset⟩ ⟨b.blu⟩baz
+⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩-------⟨reset⟩ ⟨b.blu⟩baz
 ⟨blu⟩  ::: foo.proto:5:9
    | 
 ⟨blu⟩ 5 | ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩bar⟨reset⟩
+⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩bar⟨reset⟩
 
 ⟨b.red⟩encountered 2 errors⟨reset⟩
 ⟨reset⟩

--- a/experimental/report/testdata/multi-underline.yaml.color.txt
+++ b/experimental/report/testdata/multi-underline.yaml.color.txt
@@ -2,20 +2,20 @@
 ⟨blu⟩  --> foo.proto:6:12
    | 
 ⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
-⟨blu⟩   | ⟨reset⟩⟨reset⟩         ⟨b.blu⟩--------⟨reset⟩ ⟨b.blu⟩syntax version specified here
+⟨blu⟩   | ⟨reset⟩         ⟨b.blu⟩--------⟨reset⟩ ⟨b.blu⟩syntax version specified here
 ⟨blu⟩ 2 | ⟨reset⟩
-⟨blu⟩...  ⟨reset⟩
+⟨blu⟩...  
 ⟨blu⟩ 6 | ⟨reset⟩  required size_t x = 0;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩           ⟨b.red⟩^^^^^⟨reset⟩ ⟨b.red⟩⟨reset⟩
+⟨blu⟩   | ⟨reset⟩           ⟨b.red⟩^^^^^⟨reset⟩ ⟨b.red⟩⟨reset⟩
 
 ⟨b.ylw⟩warning: these are pretty bad names⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:9
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.ylw⟩^^^^^^^⟨reset⟩ ⟨b.ylw⟩could be better
+⟨blu⟩   | ⟨reset⟩        ⟨b.ylw⟩^^^^^^^⟨reset⟩ ⟨b.ylw⟩could be better
 ⟨blu⟩ 4 | ⟨reset⟩
 ⟨blu⟩ 5 | ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩blah to you too!!⟨reset⟩
+⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩blah to you too!!⟨reset⟩
 
 ⟨b.red⟩encountered 1 error and 1 warning⟨reset⟩
 ⟨reset⟩

--- a/experimental/report/testdata/multiline.yaml.color.txt
+++ b/experimental/report/testdata/multiline.yaml.color.txt
@@ -2,9 +2,9 @@
 ⟨blu⟩  --> foo.proto:5:1
    | 
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
-⟨blu⟩...  ⟨b.ylw⟩| ⟨reset⟩
+⟨blu⟩...  ⟨b.ylw⟩| 
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.ylw⟩  [0\_^ this block⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\_^ this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nested blocks⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:1
@@ -12,11 +12,11 @@
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩  message Bonk {
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| 
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩  [0\___- and this block
+⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩\___- and this block
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.ylw⟩  [0\___^ this block⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\___^ this block⟨reset⟩
 
 ⟨b.ylw⟩warning: parallel blocks⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:1
@@ -24,22 +24,22 @@
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨reset⟩  message Bonk {
-⟨blu⟩   | ⟨b.ylw⟩  [0\__^ this block
-⟨blu⟩...  ⟨b.blu⟩  ⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\__^ this block
+⟨blu⟩...  ⟨b.blu⟩  
 ⟨blu⟩11 | ⟨b.blu⟩  ⟨reset⟩  }
-⟨blu⟩   | ⟨b.blu⟩| [0 ___-
+⟨blu⟩   | ⟨b.blu⟩ ___-
 ⟨blu⟩12 | ⟨b.blu⟩/ ⟨reset⟩}
-⟨blu⟩   | ⟨b.blu⟩  [0\_- and this block⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩\_- and this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nested blocks same start⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:1
    | 
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨b.blu⟩/ ⟨reset⟩message Blah {
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| 
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩  [0\___- and this block
+⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩\___- and this block
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.ylw⟩  [0\___^ this block⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\___^ this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nested blocks same end⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:1
@@ -47,10 +47,10 @@
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩  message Bonk {
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| 
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.ylw⟩  [0\___^ this block
-⟨blu⟩   | ⟨b.ylw⟩  ⟨b.blu⟩  [0\_- and this block⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\___^ this block
+⟨blu⟩   | ⟨b.ylw⟩  ⟨b.blu⟩\_- and this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nested overlap⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:1
@@ -58,77 +58,77 @@
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩  message Bonk {
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩| 
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.ylw⟩  [0\_____^ this block
+⟨blu⟩   | ⟨b.ylw⟩\_____^ this block
 ⟨blu⟩12 |   ⟨b.blu⟩| ⟨reset⟩}
-⟨blu⟩   |   ⟨b.blu⟩| [0\_- and this block⟨reset⟩
+⟨blu⟩   |   ⟨b.blu⟩\_- and this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nesting just the braces⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:15
    | 
 ⟨blu⟩ 5 | ⟨b.ylw⟩  ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨b.ylw⟩| [0 ________________^
+⟨blu⟩   | ⟨b.ylw⟩ ________________^
 ⟨blu⟩ 6 | ⟨b.ylw⟩/ ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩  ⟨reset⟩  message Bonk {
-⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩| [0 ________________-
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩ ________________-
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩/ 
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩  [0\___- and this block
+⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩\___- and this block
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.ylw⟩  [0\___^ this block⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\___^ this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nesting just the braces same start⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:15
    | 
 ⟨blu⟩ 5 | ⟨b.ylw⟩  ⟨b.blu⟩  ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨b.ylw⟩| [0 ________________^
-⟨blu⟩   | ⟨b.ylw⟩/ ⟨b.blu⟩| [0 ______________-
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩ ________________^
+⟨blu⟩   | ⟨b.ylw⟩/ ⟨b.blu⟩ ______________-
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩/ 
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩  [0\___- and this block
+⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩\___- and this block
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.ylw⟩  [0\___^ this block⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩\___^ this block⟨reset⟩
 
 ⟨b.ylw⟩warning: nesting just the braces same start (2)⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:15
    | 
 ⟨blu⟩ 5 | ⟨b.blu⟩  ⟨b.ylw⟩  ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨b.blu⟩| [0 ________________-
-⟨blu⟩   | ⟨b.blu⟩/ ⟨b.ylw⟩| [0 ______________^
-⟨blu⟩...  ⟨b.blu⟩| ⟨b.ylw⟩/ ⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩ ________________-
+⟨blu⟩   | ⟨b.blu⟩/ ⟨b.ylw⟩ ______________^
+⟨blu⟩...  ⟨b.blu⟩| ⟨b.ylw⟩/ 
 ⟨blu⟩11 | ⟨b.blu⟩| ⟨b.ylw⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.blu⟩| ⟨b.ylw⟩  [0\___^ and this block
+⟨blu⟩   | ⟨b.blu⟩| ⟨b.ylw⟩\___^ and this block
 ⟨blu⟩12 | ⟨b.blu⟩| ⟨reset⟩}
-⟨blu⟩   | ⟨b.blu⟩  [0\___- this block⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩\___- this block⟨reset⟩
 
 ⟨b.ylw⟩warning: braces nesting overlap⟨reset⟩
 ⟨blu⟩  --> foo.proto:5:15
    | 
 ⟨blu⟩ 5 | ⟨b.ylw⟩  ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨b.ylw⟩| [0 ________________^
+⟨blu⟩   | ⟨b.ylw⟩ ________________^
 ⟨blu⟩ 6 | ⟨b.ylw⟩/ ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩  ⟨reset⟩  message Bonk {
-⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩| [0 ________________-
-⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩
+⟨blu⟩   | ⟨b.ylw⟩| ⟨b.blu⟩ ________________-
+⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩/ 
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.ylw⟩  [0\_____^ this block
+⟨blu⟩   | ⟨b.ylw⟩\_____^ this block
 ⟨blu⟩12 |   ⟨b.blu⟩| ⟨reset⟩}
-⟨blu⟩   |   ⟨b.blu⟩| [0\_- and this block⟨reset⟩
+⟨blu⟩   |   ⟨b.blu⟩\_- and this block⟨reset⟩
 
 ⟨b.ylw⟩warning: braces nesting overlap (2)⟨reset⟩
 ⟨blu⟩  --> foo.proto:7:17
    | 
 ⟨blu⟩ 5 | ⟨b.blu⟩  ⟨reset⟩message Blah {
-⟨blu⟩   | ⟨b.blu⟩| [0 ________________-
+⟨blu⟩   | ⟨b.blu⟩ ________________-
 ⟨blu⟩ 6 | ⟨b.blu⟩/ ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.blu⟩| ⟨b.ylw⟩  ⟨reset⟩  message Bonk {
-⟨blu⟩   | ⟨b.blu⟩| ⟨b.ylw⟩| [0 ________________^
-⟨blu⟩...  ⟨b.blu⟩| ⟨b.ylw⟩/ ⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩| ⟨b.ylw⟩ ________________^
+⟨blu⟩...  ⟨b.blu⟩| ⟨b.ylw⟩/ 
 ⟨blu⟩11 | ⟨b.blu⟩| ⟨b.ylw⟩| ⟨reset⟩  }
-⟨blu⟩   | ⟨b.blu⟩  [0\_____- this block
+⟨blu⟩   | ⟨b.blu⟩\_____- this block
 ⟨blu⟩12 |   ⟨b.ylw⟩| ⟨reset⟩}
-⟨blu⟩   |   ⟨b.ylw⟩| [0\_^ and this block⟨reset⟩
+⟨blu⟩   |   ⟨b.ylw⟩\_^ and this block⟨reset⟩
 
 ⟨b.ylw⟩ encountered  11 warnings
 ⟨reset⟩

--- a/experimental/report/testdata/single-line.yaml
+++ b/experimental/report/testdata/single-line.yaml
@@ -32,7 +32,24 @@ diagnostics:
       - message: 'help: change this to "proto5"'
         file: 0
         start: 9
-        end: 17
+        end: 18   # Includes the newline.
+  
+  - message: 'missing `;`'
+    level: LEVEL_ERROR
+    annotations:
+      - message: 'here'
+        file: 0
+        start: 17
+        end: 18
+
+  # Make sure the EOF renders as if the file ends in a newline.
+  - message: EOF
+    level: LEVEL_REMARK
+    annotations:
+      - message: 'here'
+        file: 0
+        start: 78
+        end: 78
 
   - message: package
     level: LEVEL_ERROR

--- a/experimental/report/testdata/single-line.yaml.color.txt
+++ b/experimental/report/testdata/single-line.yaml.color.txt
@@ -2,7 +2,19 @@
 ⟨blu⟩  --> foo.proto:1:10
    | 
 ⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
-⟨blu⟩   | ⟨reset⟩         ⟨b.cyn⟩^^^^^^^^⟨reset⟩ ⟨b.cyn⟩help: change this to "proto5"⟨reset⟩
+⟨blu⟩   | ⟨reset⟩         ⟨b.cyn⟩^^^^^^^^^⟨reset⟩ ⟨b.cyn⟩help: change this to "proto5"⟨reset⟩
+
+⟨b.red⟩error: missing `;`⟨reset⟩
+⟨blu⟩  --> foo.proto:1:18
+   | 
+⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
+⟨blu⟩   | ⟨reset⟩                 ⟨b.red⟩^⟨reset⟩ ⟨b.red⟩here⟨reset⟩
+
+⟨b.cyn⟩remark: EOF⟨reset⟩
+⟨blu⟩  --> foo.proto:7:2
+   | 
+⟨blu⟩ 7 | ⟨reset⟩}
+⟨blu⟩   | ⟨reset⟩ ⟨b.cyn⟩^⟨reset⟩ ⟨b.cyn⟩here⟨reset⟩
 
 ⟨b.red⟩error: package⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:1
@@ -50,5 +62,5 @@
 ⟨blu⟩   |   ⟨b.blu⟩|
 ⟨blu⟩   |   ⟨b.blu⟩k⟨reset⟩
 
-⟨b.red⟩encountered 5 errors⟨reset⟩
+⟨b.red⟩encountered 6 errors⟨reset⟩
 ⟨reset⟩

--- a/experimental/report/testdata/single-line.yaml.color.txt
+++ b/experimental/report/testdata/single-line.yaml.color.txt
@@ -2,53 +2,53 @@
 ⟨blu⟩  --> foo.proto:1:10
    | 
 ⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
-⟨blu⟩   | ⟨reset⟩⟨reset⟩         ⟨b.cyn⟩^^^^^^^^⟨reset⟩ ⟨b.cyn⟩help: change this to "proto5"⟨reset⟩
+⟨blu⟩   | ⟨reset⟩         ⟨b.cyn⟩^^^^^^^^⟨reset⟩ ⟨b.cyn⟩help: change this to "proto5"⟨reset⟩
 
 ⟨b.red⟩error: package⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:1
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩^^^^^^^⟨reset⟩        ⟨b.blu⟩-⟨reset⟩ ⟨b.blu⟩semicolon
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩package⟨reset⟩
+⟨blu⟩   | ⟨b.red⟩^^^^^^^⟨reset⟩        ⟨b.blu⟩-⟨reset⟩ ⟨b.blu⟩semicolon
+⟨blu⟩   | ⟨b.red⟩|
+⟨blu⟩   | ⟨b.red⟩package⟨reset⟩
 
 ⟨b.red⟩error: this is an overlapping error⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:1
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩^^^^^^^⟨b.blu⟩---------⟨reset⟩ ⟨b.blu⟩package decl
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩package⟨reset⟩
+⟨blu⟩   | ⟨b.red⟩^^^^^^^⟨b.blu⟩---------⟨reset⟩ ⟨b.blu⟩package decl
+⟨blu⟩   | ⟨b.red⟩|
+⟨blu⟩   | ⟨b.red⟩package⟨reset⟩
 
 ⟨b.red⟩error: P A C K A G E⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:1
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩help: ge
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩| ⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩help: p⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩  ⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩  ⟨b.blu⟩help: ck⟨reset⟩
+⟨blu⟩   | ⟨b.red⟩^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩help: ge
+⟨blu⟩   | ⟨b.red⟩| ⟨b.blu⟩|
+⟨blu⟩   | ⟨b.red⟩help: p⟨b.blu⟩|
+⟨blu⟩   |   ⟨b.blu⟩|
+⟨blu⟩   |   ⟨b.blu⟩help: ck⟨reset⟩
 
 ⟨b.red⟩error: P A C K A G E (different order)⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:3
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩-⟨reset⟩ ⟨b.red⟩^^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩help: ge
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩| ⟨b.red⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩| ⟨b.red⟩help: ck
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩help: p⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩-⟨reset⟩ ⟨b.red⟩^^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩help: ge
+⟨blu⟩   | ⟨b.blu⟩| ⟨b.red⟩|
+⟨blu⟩   | ⟨b.blu⟩| ⟨b.red⟩help: ck
+⟨blu⟩   | ⟨b.blu⟩|
+⟨blu⟩   | ⟨b.blu⟩help: p⟨reset⟩
 
 ⟨b.red⟩error: P A C K A G E (single letters)⟨reset⟩
 ⟨blu⟩  --> foo.proto:3:1
    | 
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩g
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩| ⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.red⟩p ⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩  ⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩  ⟨b.blu⟩k⟨reset⟩
+⟨blu⟩   | ⟨b.red⟩^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩g
+⟨blu⟩   | ⟨b.red⟩| ⟨b.blu⟩|
+⟨blu⟩   | ⟨b.red⟩p ⟨b.blu⟩|
+⟨blu⟩   |   ⟨b.blu⟩|
+⟨blu⟩   |   ⟨b.blu⟩k⟨reset⟩
 
 ⟨b.red⟩encountered 5 errors⟨reset⟩
 ⟨reset⟩

--- a/experimental/report/testdata/single-line.yaml.fancy.txt
+++ b/experimental/report/testdata/single-line.yaml.fancy.txt
@@ -2,7 +2,19 @@ remark: "proto4" isn't real, it can't hurt you
   --> foo.proto:1:10
    | 
  1 | syntax = "proto4"
-   |          ^^^^^^^^ help: change this to "proto5"
+   |          ^^^^^^^^^ help: change this to "proto5"
+
+error: missing `;`
+  --> foo.proto:1:18
+   | 
+ 1 | syntax = "proto4"
+   |                  ^ here
+
+remark: EOF
+  --> foo.proto:7:2
+   | 
+ 7 | }
+   |  ^ here
 
 error: package
   --> foo.proto:3:1
@@ -50,4 +62,4 @@ error: P A C K A G E (single letters)
    |   |
    |   k
 
-encountered 5 errors
+encountered 6 errors

--- a/experimental/report/testdata/single-line.yaml.simple.txt
+++ b/experimental/report/testdata/single-line.yaml.simple.txt
@@ -1,4 +1,6 @@
 remark: foo.proto:1:10: "proto4" isn't real, it can't hurt you
+error: foo.proto:1:18: missing `;`
+remark: foo.proto:7:2: EOF
 error: foo.proto:3:1: package
 error: foo.proto:3:1: this is an overlapping error
 error: foo.proto:3:1: P A C K A G E

--- a/experimental/report/testdata/suggestions.yaml.color.txt
+++ b/experimental/report/testdata/suggestions.yaml.color.txt
@@ -17,7 +17,7 @@
 ⟨blu⟩  --> foo.proto:5:9
    | 
 ⟨blu⟩ 5 | ⟨reset⟩service Foo {
-⟨blu⟩   | ⟨reset⟩⟨reset⟩        ⟨b.ylw⟩^^^⟨reset⟩ ⟨b.ylw⟩
+⟨blu⟩   | ⟨reset⟩        ⟨b.ylw⟩^^^⟨reset⟩ ⟨b.ylw⟩
 ⟨blu⟩  help: change the name to `FooService`
    | 
 ⟨blu⟩ 5 | ⟨reset⟩service Foo⟨grn⟩Service⟨reset⟩ {
@@ -27,7 +27,7 @@
 ⟨blu⟩  --> foo.proto:6:31
    | 
 ⟨blu⟩ 6 | ⟨reset⟩  rpc Get(GetRequest) returns GetResponse;
-⟨blu⟩   | ⟨reset⟩⟨reset⟩                              ⟨b.red⟩^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩
+⟨blu⟩   | ⟨reset⟩                              ⟨b.red⟩^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩
 ⟨blu⟩  help: add `(...)` around the type
    | 
 ⟨blu⟩ 6 | ⟨reset⟩  rpc Get(GetRequest) returns ⟨grn⟩(⟨reset⟩GetResponse⟨grn⟩)⟨reset⟩;
@@ -37,7 +37,7 @@
 ⟨blu⟩  --> foo.proto:7:45
    | 
 ⟨blu⟩ 7 | ⟨reset⟩  rpc Put(PutRequest) returns (PutResponse) [foo = bar];
-⟨blu⟩   | ⟨reset⟩⟨reset⟩                                            ⟨b.red⟩^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩compact options not allowed here
+⟨blu⟩   | ⟨reset⟩                                            ⟨b.red⟩^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩compact options not allowed here
 ⟨blu⟩  help: use `option` settings inside of the method body
    | 
 ⟨blu⟩ 7 | ⟨b.red⟩-⟨red⟩   rpc Put(PutRequest) returns (PutResponse) [foo = bar];

--- a/experimental/report/testdata/tabstops.yaml.color.txt
+++ b/experimental/report/testdata/tabstops.yaml.color.txt
@@ -2,17 +2,17 @@
 ⟨blu⟩  --> foo.proto:6:9
    | 
 ⟨blu⟩ 6 | ⟨reset⟩        field
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩--------⟨b.ylw⟩^^^^^⟨reset⟩ ⟨b.ylw⟩this is in front of some tabstops
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩specifically these⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩--------⟨b.ylw⟩^^^^^⟨reset⟩ ⟨b.ylw⟩this is in front of some tabstops
+⟨blu⟩   | ⟨b.blu⟩|
+⟨blu⟩   | ⟨b.blu⟩specifically these⟨reset⟩
 
 ⟨b.ylw⟩warning: partial tabstop⟨reset⟩
 ⟨blu⟩  --> foo.proto:7:2
    | 
 ⟨blu⟩ 7 | ⟨reset⟩    field
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩-⟨b.ylw⟩^^^⟨reset⟩ ⟨b.ylw⟩tabstop
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩|
-⟨blu⟩   | ⟨reset⟩⟨b.blu⟩spaces⟨reset⟩
+⟨blu⟩   | ⟨b.blu⟩-⟨b.ylw⟩^^^⟨reset⟩ ⟨b.ylw⟩tabstop
+⟨blu⟩   | ⟨b.blu⟩|
+⟨blu⟩   | ⟨b.blu⟩spaces⟨reset⟩
 
 ⟨b.ylw⟩ encountered  2 warnings
 ⟨reset⟩

--- a/go.work.sum
+++ b/go.work.sum
@@ -89,6 +89,7 @@ golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOM
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
 golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
@@ -160,6 +161,7 @@ golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=
 golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=
 golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=


### PR DESCRIPTION
While writing diagnostics in another PR, I noticed two small bugs:

1. Multiline pipes are not rendered correctly in color mode.
2. A span consisting of a single newline generates an ugly multi-line diagnostic.

This PR fixes both issues.