### PR TITLE
Fix cursor-at for close tokens

### DIFF
--- a/experimental/token/cursor.go
+++ b/experimental/token/cursor.go
@@ -60,7 +60,7 @@ func NewCursorAt(tok Token) *Cursor {
 	return &Cursor{
 		withContext: tok.withContext,
 		idx:         tok.ID().naturalIndex(), // Convert to 0-based index.
-		isBackwards: tok.nat().IsClose(),     // TODO: docs
+		isBackwards: tok.nat().IsClose(),     // Set the direction to calculate the offset.
 	}
 }
 

--- a/experimental/token/cursor.go
+++ b/experimental/token/cursor.go
@@ -61,7 +61,7 @@ func NewCursorAt(tok Token) *Cursor {
 	// Since open/close tokens are fused, for closed tokens, we must create the cursor at the
 	// open token.
 	if tok.nat().IsClose() {
-		idx = idx + tok.nat().Offset()
+		idx += tok.nat().Offset()
 	}
 
 	return &Cursor{

--- a/experimental/token/cursor.go
+++ b/experimental/token/cursor.go
@@ -57,16 +57,10 @@ func NewCursorAt(tok Token) *Cursor {
 		panic(fmt.Sprintf("protocompile/token: passed synthetic token to NewCursorAt: %v", tok))
 	}
 
-	idx := tok.ID().naturalIndex() // Convert to 0-based index.
-	// Since open/close tokens are fused, for closed tokens, we must create the cursor at the
-	// open token.
-	if tok.nat().IsClose() {
-		idx += tok.nat().Offset()
-	}
-
 	return &Cursor{
 		withContext: tok.withContext,
-		idx:         idx,
+		idx:         tok.ID().naturalIndex(), // Convert to 0-based index.
+		isBackwards: tok.nat().IsClose(),     // TODO: docs
 	}
 }
 

--- a/experimental/token/cursor.go
+++ b/experimental/token/cursor.go
@@ -57,9 +57,16 @@ func NewCursorAt(tok Token) *Cursor {
 		panic(fmt.Sprintf("protocompile/token: passed synthetic token to NewCursorAt: %v", tok))
 	}
 
+	idx := tok.ID().naturalIndex() // Convert to 0-based index.
+	// Since open/close tokens are fused, for closed tokens, we must create the cursor at the
+	// open token.
+	if tok.nat().IsClose() {
+		idx = idx + tok.nat().Offset()
+	}
+
 	return &Cursor{
 		withContext: tok.withContext,
-		idx:         tok.ID().naturalIndex(), // Convert to 0-based index.
+		idx:         idx,
 	}
 }
 

--- a/experimental/token/cursor_test.go
+++ b/experimental/token/cursor_test.go
@@ -128,7 +128,7 @@ func TestCursor(t *testing.T) {
 	// Test setting the cursor at the close brace
 	t.Run("close", func(t *testing.T) {
 		t.Parallel()
-		cursor := token.NewCursorAt(close) //nolint:revive,predeclared
+		cursor := token.NewCursorAt(close)
 		tokenEq(t, open, cursor.NextSkippable())
 		tokenEq(t, token.Zero, cursor.NextSkippable())
 	})

--- a/experimental/token/cursor_test.go
+++ b/experimental/token/cursor_test.go
@@ -129,7 +129,7 @@ func TestCursor(t *testing.T) {
 	t.Run("close", func(t *testing.T) {
 		t.Parallel()
 		cursor := token.NewCursorAt(close)
-		tokenEq(t, open, cursor.NextSkippable())
+		tokenEq(t, close, cursor.NextSkippable())
 		tokenEq(t, token.Zero, cursor.NextSkippable())
 	})
 }

--- a/experimental/token/cursor_test.go
+++ b/experimental/token/cursor_test.go
@@ -116,4 +116,20 @@ func TestCursor(t *testing.T) {
 		assert.Len(t, text, span.Start)
 		assert.Len(t, text, span.End)
 	})
+
+	// Test setting the cursor at the open brace
+	t.Run("open", func(t *testing.T) {
+		t.Parallel()
+		cursor := token.NewCursorAt(open)
+		tokenEq(t, open, cursor.NextSkippable())
+		tokenEq(t, token.Zero, cursor.NextSkippable())
+	})
+
+	// Test setting the cursor at the close brace
+	t.Run("close", func(t *testing.T) {
+		t.Parallel()
+		cursor := token.NewCursorAt(close) //nolint:revive,predeclared
+		tokenEq(t, open, cursor.NextSkippable())
+		tokenEq(t, token.Zero, cursor.NextSkippable())
+	})
 }


### PR DESCRIPTION
Since open/close tokens are fused, when we set the `idx` for
`NewCursorAt` for close tokens, we need to use the offset to
set it to the open token.