### PR TITLE
Roll minimum Go version forward to 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x,1.22.x,1.23.x]
+        go-version: [1.22.x,1.23.x,1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,12 +35,12 @@ jobs:
         run: make test
       - name: Benchmarks
         # no need to run benchmarks for every Go version
-        if: matrix.go-version == '1.23.x'
+        if: matrix.go-version == '1.24.x'
         run: make benchmarks
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.23.x'
+        if: matrix.go-version == '1.24.x'
         run: make checkgenerate lint

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.21.x,1.22.x,1.23.x]
+        go-version: [1.22.x,1.23.x,1.24.x]
     steps:
       - name: Set git to use LF
         run: |

--- a/ast/ast_roundtrip_test.go
+++ b/ast/ast_roundtrip_test.go
@@ -100,7 +100,7 @@ func printAST(w io.Writer, file *ast.FileNode) error {
 }
 
 func printComments(sw stringWriter, comments ast.Comments) error {
-	for i := 0; i < comments.Len(); i++ {
+	for i := range comments.Len() {
 		comment := comments.Index(i)
 		if _, err := sw.WriteString(comment.LeadingWhitespace()); err != nil {
 			return err

--- a/ast/items_test.go
+++ b/ast/items_test.go
@@ -65,7 +65,7 @@ func testItemsSequence(t *testing.T, path string, data []byte) {
 	item, ok := seq.First()
 	require.True(t, ok)
 	checkComments := func(comments ast.Comments) {
-		for i := 0; i < comments.Len(); i++ {
+		for i := range comments.Len() {
 			c := comments.Index(i)
 			astItem := c.AsItem()
 			require.Equal(t, astItem, item)

--- a/ast/visitor_test.go
+++ b/ast/visitor_test.go
@@ -494,7 +494,6 @@ func TestVisitorAll(t *testing.T) {
 	}
 
 	for n := range testCases {
-		n := n
 		expectedCalls := testCases[n]
 		t.Run(fmt.Sprintf("%T", n), func(t *testing.T) {
 			t.Parallel()

--- a/experimental/ast/zero_test.go
+++ b/experimental/ast/zero_test.go
@@ -86,7 +86,7 @@ func testZero[Node report.Spanner](t *testing.T) {
 		// 2. Returns zero values.
 		v := reflect.ValueOf(z)
 		ty := v.Type()
-		for i := 0; i < ty.NumMethod(); i++ {
+		for i := range ty.NumMethod() {
 			m := ty.Method(i)
 			if m.Func.Type().NumIn() != 1 {
 				continue // NumIn includes the receiver.

--- a/experimental/incremental/executor_test.go
+++ b/experimental/incremental/executor_test.go
@@ -248,7 +248,7 @@ func TestUnchanged(t *testing.T) {
 		gsPerRun = 16
 	)
 
-	for i := 0; i < runs; i++ {
+	for range runs {
 		exec.Evict(ParseInt{"42"})
 		results, _, _ := incremental.Run(ctx, exec, queries...)
 		for j, r := range results[1:] {
@@ -263,9 +263,8 @@ func TestUnchanged(t *testing.T) {
 
 		exec.Evict(ParseInt{"42"})
 		barrier.Add(1)
-		for i := 0; i < gsPerRun; i++ {
+		for i := range gsPerRun {
 			wg.Add(1)
-			i := i
 			go func() {
 				barrier.Wait() // Ensure all goroutines start together.
 				defer wg.Done()

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -94,8 +94,6 @@ func Resolve[T any](caller Task, queries ...Query[T]) (results []Result[T], expi
 	// *every* query.
 	anyAsync := false
 	for i, q := range queries {
-		i := i // Avoid pesky capture-by-ref of loop induction variables.
-
 		q := AsAny(q) // This will also cache the result of q.Key() for us.
 		deps[i] = caller.exec.getTask(q.Key())
 

--- a/experimental/report/renderer.go
+++ b/experimental/report/renderer.go
@@ -625,7 +625,7 @@ func (r *renderer) window(w *window) {
 					// If we got here, it means we're going to crop an escape if
 					// we don't do something about it.
 					spaceNeeded := len(writeTo) - lastEsc
-					for i := 0; i < spaceNeeded; i++ {
+					for range spaceNeeded {
 						buf = append(buf, 0)
 					}
 					copy(buf[actualStart+lastEsc+spaceNeeded:], buf[actualStart+lastEsc:])
@@ -1009,7 +1009,7 @@ func (r *renderer) suggestion(snip snippet) {
 		prev := column
 		column = stringWidth(column, hunk.content, false, nil)
 		r.WriteString(hunk.bold(&r.ss))
-		for i := 0; i < column-prev; i++ {
+		for range column - prev {
 			r.WriteString(string(hunk.kind))
 		}
 	}
@@ -1029,7 +1029,7 @@ func adjustLineOffsets(text string, start, end int) (int, int) {
 }
 
 func padByRune(out *strings.Builder, spaces int, r rune) {
-	for i := 0; i < spaces; i++ {
+	for range spaces {
 		out.WriteRune(r)
 	}
 }

--- a/experimental/report/report.go
+++ b/experimental/report/report.go
@@ -352,7 +352,7 @@ func (r *Report) push(skip int, level Level) *Diagnostic {
 			buf  strings.Builder
 		)
 		frames := runtime.CallersFrames(pc)
-		for i := 0; i < r.Tracing; i++ {
+		for range r.Tracing {
 			frame, more := frames.Next()
 			if frame == zero || !more {
 				break

--- a/experimental/seq/seq.go
+++ b/experimental/seq/seq.go
@@ -63,7 +63,7 @@ type Inserter[T any] interface {
 func All[T any](seq Indexer[T]) iter.Seq2[int, T] {
 	return func(yield func(int, T) bool) {
 		n := seq.Len()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if !yield(i, seq.At(i)) {
 				return
 			}
@@ -75,7 +75,7 @@ func All[T any](seq Indexer[T]) iter.Seq2[int, T] {
 func Values[T any](seq Indexer[T]) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		n := seq.Len()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if !yield(seq.At(i)) {
 				return
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protocompile
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.8.1

--- a/go.work
+++ b/go.work
@@ -1,7 +1,5 @@
 go 1.22
 
-toolchain go1.23.0
-
 use (
 	.
 	./internal/benchmarks

--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.21
+go 1.22
+
+toolchain go1.23.0
 
 use (
 	.

--- a/internal/arena/arena_test.go
+++ b/internal/arena/arena_test.go
@@ -32,14 +32,14 @@ func TestPointers(t *testing.T) {
 	p2 := a.Deref(p1)
 	assert.Equal(5, *a.Deref(p1))
 
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		a.New(i + 5)
 	}
 	assert.Equal(19, *a.Deref(16))
 	assert.Equal(20, *a.Deref(17))
 	assert.Same(a.Deref(p1), p2)
 
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		a.New(i + 21)
 	}
 	assert.Equal(51, *a.Deref(48))
@@ -62,7 +62,7 @@ func TestCompress(t *testing.T) {
 	assert.Equal(arena.Pointer[int](0), a.Compress(nil))
 	assert.Equal(arena.Pointer[int](0), a.Compress(new(int)))
 
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		a.New(i + 5)
 	}
 	x = a.NewCompressed(5)

--- a/internal/benchmarks/benchmark_test.go
+++ b/internal/benchmarks/benchmark_test.go
@@ -258,7 +258,7 @@ func BenchmarkGoogleapisProtocompileNoSourceInfo(b *testing.B) {
 }
 
 func benchmarkGoogleapisProtocompile(b *testing.B, factory func() *protocompile.Compiler) {
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		benchmarkProtocompile(b, factory(), googleapisSources)
 	}
 }
@@ -299,12 +299,12 @@ func benchmarkGoogleapisProtoparse(b *testing.B, factory func() *protoparse.Pars
 	if par > cpus {
 		par = cpus
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Buf currently batches files into chunks and then runs all chunks in parallel
 		chunks := make([][]string, par)
 		j := 0
 		total := 0
-		for ch := 0; ch < par; ch++ {
+		for ch := range par {
 			chunkStart := j
 			chunkEnd := (ch + 1) * len(googleapisSources) / par
 			chunks[ch] = googleapisSources[chunkStart:chunkEnd]
@@ -316,7 +316,6 @@ func benchmarkGoogleapisProtoparse(b *testing.B, factory func() *protoparse.Pars
 		results := make([][]*desc.FileDescriptor, par)
 		errors := make([]error, par)
 		for ch, chunk := range chunks {
-			ch, chunk := ch, chunk
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -349,7 +348,7 @@ func BenchmarkGoogleapisFastScan(b *testing.B) {
 		filename   string
 		scanResult fastscan.Result
 	}
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		workCh := make(chan string, par)
 		resultsCh := make(chan entry, par)
 		grp, ctx := errgroup.WithContext(context.Background())
@@ -367,7 +366,7 @@ func BenchmarkGoogleapisFastScan(b *testing.B) {
 		})
 		var numProcs atomic.Int32
 		numProcs.Store(int32(par))
-		for i := 0; i < par; i++ {
+		for range par {
 			// consumers/processors
 			grp.Go(func() error {
 				defer func() {

--- a/internal/benchmarks/go.mod
+++ b/internal/benchmarks/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protocompile/internal/benchmarks
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bufbuild/protocompile v0.14.1

--- a/internal/benchmarks/measure.go
+++ b/internal/benchmarks/measure.go
@@ -132,7 +132,7 @@ func (t *measuringTape) measure(value reflect.Value) {
 		if !t.insert(value.Pointer(), uint64(value.Cap())*uint64(value.Type().Elem().Size())) {
 			return
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := range value.Len() {
 			t.measure(value.Index(i))
 		}
 
@@ -173,7 +173,7 @@ func (t *measuringTape) measure(value reflect.Value) {
 		t.insert(value.Pointer(), uint64(value.Len()))
 
 	case reflect.Struct:
-		for i := 0; i < value.NumField(); i++ {
+		for i := range value.NumField() {
 			t.measure(value.Field(i))
 		}
 

--- a/internal/ext/slicesx/index.go
+++ b/internal/ext/slicesx/index.go
@@ -26,7 +26,7 @@ import (
 //go:nosplit
 func PointerIndex[S ~[]E, E any](s S, p *E) int {
 	a := unsafe.Pointer(p)
-	b := unsafe.Pointer(unsafex.SliceData(s))
+	b := unsafe.Pointer(unsafe.SliceData(s))
 
 	diff := uintptr(a) - uintptr(b)
 	size := unsafex.Size[E]()

--- a/internal/ext/slicesx/partition_test.go
+++ b/internal/ext/slicesx/partition_test.go
@@ -67,7 +67,6 @@ func TestPartition(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprint(test.slice), func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ext/slicesx/slicesx.go
+++ b/internal/ext/slicesx/slicesx.go
@@ -17,6 +17,7 @@ package slicesx
 
 import (
 	"slices"
+	"unsafe"
 
 	"github.com/bufbuild/protocompile/internal/ext/unsafex"
 	"github.com/bufbuild/protocompile/internal/iter"
@@ -38,7 +39,7 @@ func Get[S ~[]E, E any, I SliceIndex](s S, idx I) (element E, ok bool) {
 
 	// Dodge the bounds check, since Go probably won't be able to
 	// eliminate it even after stenciling.
-	return *unsafex.Add(unsafex.SliceData(s), idx), true
+	return *unsafex.Add(unsafe.SliceData(s), idx), true
 }
 
 // GetPointer is like [Get], but it returns a pointer to the selected element
@@ -53,7 +54,7 @@ func GetPointer[S ~[]E, E any, I SliceIndex](s S, idx I) *E {
 
 	// Dodge the bounds check, since Go probably won't be able to
 	// eliminate it even after stenciling.
-	return unsafex.Add(unsafex.SliceData(s), idx)
+	return unsafex.Add(unsafe.SliceData(s), idx)
 }
 
 // Last returns the last element of the slice, unless it is empty, in which

--- a/internal/ext/stringsx/stringsx.go
+++ b/internal/ext/stringsx/stringsx.go
@@ -44,7 +44,7 @@ func Runes(s string) iter.Seq[rune] {
 // Bytes returns an iterator over the bytes in a string.
 func Bytes(s string) iter.Seq[byte] {
 	return func(yield func(byte) bool) {
-		for i := 0; i < len(s); i++ {
+		for i := range len(s) {
 			// Avoid performing a bounds check each loop step.
 			b := *unsafex.Add(unsafex.StringData(s), i)
 			if !yield(b) {

--- a/internal/ext/stringsx/stringsx.go
+++ b/internal/ext/stringsx/stringsx.go
@@ -17,6 +17,7 @@ package stringsx
 
 import (
 	"strings"
+	"unsafe"
 
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
 	"github.com/bufbuild/protocompile/internal/ext/unsafex"
@@ -46,7 +47,7 @@ func Bytes(s string) iter.Seq[byte] {
 	return func(yield func(byte) bool) {
 		for i := range len(s) {
 			// Avoid performing a bounds check each loop step.
-			b := *unsafex.Add(unsafex.StringData(s), i)
+			b := *unsafex.Add(unsafe.StringData(s), i)
 			if !yield(b) {
 				return
 			}

--- a/internal/ext/unsafex/unsafex.go
+++ b/internal/ext/unsafex/unsafex.go
@@ -117,20 +117,6 @@ func (badBitcast[To, From]) Error() string {
 	)
 }
 
-// StringData is like [unsafe.StringData], but it avoids a bug in Go 1.21 where
-// calling the StringData intrinsic (which is *not* a generic function) with
-// a generic type with a string constraint would be incorrectly diagnosed.
-func StringData[S ~string](data S) *byte {
-	return unsafe.StringData(string(data))
-}
-
-// SliceData is like [unsafe.SliceData], but it avoids a bug in Go 1.21 where
-// calling the SliceData intrinsic (which is *not* a generic function) with
-// a generic type with a slice constraint would be incorrectly diagnosed.
-func SliceData[S ~[]E, E any](data S) *E {
-	return unsafe.SliceData([]E(data))
-}
-
 // StringAlias returns a string that aliases a slice. This is useful for
 // situations where we're allocating a string on the stack, or where we have
 // a slice that will never be written to and we want to interpret as a string
@@ -144,7 +130,7 @@ func SliceData[S ~[]E, E any](data S) *E {
 //go:nosplit
 func StringAlias[S ~[]E, E any](data S) string {
 	return unsafe.String(
-		Bitcast[*byte](SliceData(data)),
+		Bitcast[*byte](unsafe.SliceData(data)),
 		len(data)*Size[E](),
 	)
 }

--- a/internal/golden/golden.go
+++ b/internal/golden/golden.go
@@ -106,8 +106,6 @@ func (c Corpus) Run(t *testing.T, test func(t *testing.T, path, text string, out
 
 	// Execute the tests.
 	for _, path := range tests {
-		path := path // Avoid loop variable capture.
-
 		// Make sure the path is normalized regardless of platform. This
 		// is necessary to avoid breakages on Windows.
 		name, _ := filepath.Rel(testDir, path)

--- a/internal/intern/intern_test.go
+++ b/internal/intern/intern_test.go
@@ -45,10 +45,8 @@ func TestIntern(t *testing.T) {
 	}
 
 	var table intern.Table
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		for _, s := range data {
-			s := s
-
 			t.Run(fmt.Sprintf("%s/%d", s, i), func(t *testing.T) {
 				t.Parallel()
 

--- a/internal/prototest/same_layout.go
+++ b/internal/prototest/same_layout.go
@@ -48,7 +48,7 @@ func RequireSameLayout(t *testing.T, a, b reflect.Type) {
 		require.Equal(t, a.NumField(), b.NumField(),
 			"mismatched field counts: %s has %d fields; %s has %d fields", a, a.NumField(), b, b.NumField())
 
-		for i := 0; i < a.NumField(); i++ {
+		for i := range a.NumField() {
 			RequireSameLayout(t, a.Field(i).Type, b.Field(i).Type)
 		}
 

--- a/internal/prototest/util.go
+++ b/internal/prototest/util.go
@@ -57,7 +57,7 @@ func checkFiles(t *testing.T, act protoreflect.FileDescriptor, expSet *descripto
 	ret := AssertMessagesEqual(t, expProto, actProto, expProto.GetName())
 
 	if recursive {
-		for i := 0; i < act.Imports().Len(); i++ {
+		for i := range act.Imports().Len() {
 			if !checkFiles(t, act.Imports().Get(i), expSet, true, checked) {
 				ret = false
 			}

--- a/internal/prototest/yaml.go
+++ b/internal/prototest/yaml.go
@@ -64,7 +64,7 @@ func (y *toYAML) message(m protoreflect.Message) *doc {
 	fs := desc.Fields()
 
 	d := new(doc)
-	for i := 0; i < fs.Len(); i++ {
+	for i := range fs.Len() {
 		f := fs.Get(i)
 
 		has := m.Has(f)
@@ -92,7 +92,7 @@ func (y *toYAML) value(v protoreflect.Value, f protoreflect.FieldDescriptor) any
 
 	case protoreflect.List:
 		d := new(doc)
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			d.push(nil, y.value(v.Get(i), f))
 		}
 		return d
@@ -219,7 +219,7 @@ func (y *toYAML) isOneLine(v any) bool {
 func (y *toYAML) indent() {
 	s := y.out.String()
 	if s == "" || strings.HasSuffix(s, "\n") {
-		for i := 0; i < y.nesting; i++ {
+		for range y.nesting {
 			y.out.WriteString("  ")
 		}
 	}

--- a/internal/util.go
+++ b/internal/util.go
@@ -65,7 +65,7 @@ func CreatePrefixList(pkg string) []string {
 
 	numDots := 0
 	// one pass to pre-allocate the returned slice
-	for i := 0; i < len(pkg); i++ {
+	for i := range len(pkg) {
 		if pkg[i] == '.' {
 			numDots++
 		}
@@ -76,7 +76,7 @@ func CreatePrefixList(pkg string) []string {
 
 	prefixes := make([]string, numDots+2)
 	// second pass to fill in returned slice
-	for i := 0; i < len(pkg); i++ {
+	for i := range len(pkg) {
 		if pkg[i] == '.' {
 			prefixes[numDots] = pkg[:i]
 			numDots--

--- a/linker/descriptors_ext_test.go
+++ b/linker/descriptors_ext_test.go
@@ -58,7 +58,6 @@ func TestFields(t *testing.T) {
 		{"file_default_delimited.proto", editionFiles},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase // must not capture loop variable below, for thread safety
 		t.Run(testCase.filename, func(t *testing.T) {
 			t.Parallel()
 			protocFd, err := testCase.fileSet.FindFileByPath(testCase.filename)
@@ -119,7 +118,7 @@ type container interface {
 
 func checkAttributes(t *testing.T, exp, actual container, path string) {
 	if assert.Equal(t, exp.Messages().Len(), actual.Messages().Len()) {
-		for i := 0; i < exp.Messages().Len(); i++ {
+		for i := range exp.Messages().Len() {
 			expMsg := exp.Messages().Get(i)
 			actMsg := actual.Messages().Get(i)
 			if !assert.Equal(t, expMsg.Name(), actMsg.Name(), "%s: message name at index %d", path, i) {
@@ -143,7 +142,7 @@ func checkAttributesInFields(t *testing.T, exp, actual protoreflect.ExtensionDes
 	if !assert.Equal(t, exp.Len(), actual.Len(), "%s: number of fields", where) {
 		return
 	}
-	for i := 0; i < exp.Len(); i++ {
+	for i := range exp.Len() {
 		expFld := exp.Get(i)
 		actFld := actual.Get(i)
 		if !assert.Equal(t, expFld.Name(), actFld.Name(), "%s: field name at index %d", where, i) {
@@ -220,7 +219,7 @@ func checkAttributesInOneofs(t *testing.T, exp, actual protoreflect.OneofDescrip
 	if !assert.Equal(t, exp.Len(), actual.Len(), "%s: number of fields", where) {
 		return
 	}
-	for i := 0; i < exp.Len(); i++ {
+	for i := range exp.Len() {
 		expOo := exp.Get(i)
 		actOo := actual.Get(i)
 		if !assert.Equal(t, expOo.Name(), actOo.Name(), "%s: oneof name at index %d", where, i) {
@@ -233,7 +232,7 @@ func checkAttributesInEnums(t *testing.T, exp, actual protoreflect.EnumDescripto
 	if !assert.Equal(t, exp.Len(), actual.Len(), "%s: number of enums", where) {
 		return
 	}
-	for i := 0; i < exp.Len(); i++ {
+	for i := range exp.Len() {
 		expEnum := exp.Get(i)
 		actEnum := actual.Get(i)
 		if !assert.Equal(t, expEnum.Name(), actEnum.Name(), "%s: enum name at index %d", where, i) {

--- a/linker/files.go
+++ b/linker/files.go
@@ -51,7 +51,7 @@ func NewFile(f protoreflect.FileDescriptor, deps Files) (File, error) {
 		return asFile, nil
 	}
 	checkedDeps := make(Files, f.Imports().Len())
-	for i := 0; i < f.Imports().Len(); i++ {
+	for i := range f.Imports().Len() {
 		imprt := f.Imports().Get(i)
 		dep := deps.FindFileByPath(imprt.Path())
 		if dep == nil {
@@ -108,7 +108,7 @@ func newFileRecursive(fd protoreflect.FileDescriptor, seen map[protoreflect.File
 
 	seen[fd] = nil
 	deps := make([]File, fd.Imports().Len())
-	for i := 0; i < fd.Imports().Len(); i++ {
+	for i := range fd.Imports().Len() {
 		imprt := fd.Imports().Get(i)
 		dep, err := newFileRecursive(imprt, seen)
 		if err != nil {
@@ -340,13 +340,13 @@ type hasExtensionsAndMessages interface {
 }
 
 func findExtension(d hasExtensionsAndMessages, message protoreflect.FullName, field protoreflect.FieldNumber) protoreflect.ExtensionTypeDescriptor {
-	for i := 0; i < d.Extensions().Len(); i++ {
+	for i := range d.Extensions().Len() {
 		if extType := isExtensionMatch(d.Extensions().Get(i), message, field); extType != nil {
 			return extType
 		}
 	}
 
-	for i := 0; i < d.Messages().Len(); i++ {
+	for i := range d.Messages().Len() {
 		if extType := findExtension(d.Messages().Get(i), message, field); extType != nil {
 			return extType
 		}

--- a/linker/linker_test.go
+++ b/linker/linker_test.go
@@ -3829,7 +3829,6 @@ func TestLinkerValidation(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		expectedPrefix := "success_"
 		if tc.expectedErr != "" {
 			expectedPrefix = "failure_"
@@ -3876,7 +3875,7 @@ func TestLinkerValidation(t *testing.T) {
 				if limit > len(errs) {
 					limit = len(errs)
 				}
-				for i := 0; i < limit; i++ {
+				for i := range limit {
 					err := errs[i]
 					var panicErr protocompile.PanicError
 					if errors.As(err, &panicErr) {
@@ -4212,7 +4211,6 @@ func TestSyntheticMapEntryUsageNoSource(t *testing.T) {
 			expectedPrefix = "failure_"
 		}
 		assert.Truef(t, strings.HasPrefix(name, expectedPrefix), "expected test name %q to have %q prefix", name, expectedPrefix)
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4500,7 +4498,7 @@ func addFileDescriptorsToMap[F protoreflect.FileDescriptor](files []F, allFiles 
 		}
 		allFiles[file.Path()] = protoutil.ProtoFromFileDescriptor(file)
 		deps := make([]protoreflect.FileDescriptor, file.Imports().Len())
-		for i := 0; i < file.Imports().Len(); i++ {
+		for i := range file.Imports().Len() {
 			deps[i] = file.Imports().Get(i).FileDescriptor
 		}
 		addFileDescriptorsToMap(deps, allFiles)

--- a/linker/resolve.go
+++ b/linker/resolve.go
@@ -358,7 +358,7 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, extendees ma
 		// make sure the tag number is in range
 		found := false
 		tag := protoreflect.FieldNumber(fld.GetNumber())
-		for i := 0; i < extd.ExtensionRanges().Len(); i++ {
+		for i := range extd.ExtensionRanges().Len() {
 			rng := extd.ExtensionRanges().Get(i)
 			if tag >= rng[0] && tag < rng[1] {
 				found = true
@@ -410,7 +410,7 @@ func resolveFieldTypes(f *fldDescriptor, handler *reporter.Handler, extendees ma
 				if isValid && f.index > 0 {
 					// also make sure there are no earlier fields that are valid for this map entry
 					flds := f.Parent().(protoreflect.MessageDescriptor).Fields() //nolint:errcheck
-					for i := 0; i < f.index; i++ {
+					for i := range f.index {
 						if isValidMap(flds.Get(i), dsc) {
 							isValid = false
 							break

--- a/linker/symbols.go
+++ b/linker/symbols.go
@@ -110,7 +110,7 @@ func (s *Symbols) Import(fd protoreflect.FileDescriptor, handler *reporter.Handl
 		return nil
 	}
 
-	for i := 0; i < fd.Imports().Len(); i++ {
+	for i := range fd.Imports().Len() {
 		if err := s.Import(fd.Imports().Get(i).FileDescriptor, handler); err != nil {
 			return err
 		}

--- a/linker/symbols_benchmark_test.go
+++ b/linker/symbols_benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkSymbols(b *testing.B) {
 	s := &Symbols{}
 	_, err := s.importPackages(nil, "foo.bar.baz.fizz.buzz.frob.nitz", nil)
 	require.NoError(b, err)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		pkg := s.getPackage("foo.bar.baz.fizz.buzz.frob.nitz", true)
 		require.NotNil(b, pkg)
 	}

--- a/linker/symbols_test.go
+++ b/linker/symbols_test.go
@@ -105,7 +105,6 @@ func TestSymbolsImport(t *testing.T) {
 	}
 
 	for name, fd := range testCases {
-		fd := fd
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/linker/validate.go
+++ b/linker/validate.go
@@ -931,7 +931,7 @@ func findOptionSpan(
 			limit = len(path)
 		}
 		var nextIsIndex bool
-		for i := 0; i < limit; i++ {
+		for i := range limit {
 			if desc == nil || nextIsIndex {
 				// Can't match anymore. Try next option.
 				return true

--- a/options/options.go
+++ b/options/options.go
@@ -814,7 +814,7 @@ func (interp *interpreter) validateRecursive(
 	if validateRequiredFields {
 		flds := msg.Descriptor().Fields()
 		var missingFields []string
-		for i := 0; i < flds.Len(); i++ {
+		for i := range flds.Len() {
 			fld := flds.Get(i)
 			if fld.Cardinality() == protoreflect.Required && !msg.Has(fld) {
 				missingFields = append(missingFields, fmt.Sprintf("%s%s", prefix, fld.Name()))
@@ -889,7 +889,7 @@ func (interp *interpreter) validateRecursive(
 					}
 				case fld.IsList():
 					sl := val.List()
-					for i := 0; i < sl.Len(); i++ {
+					for i := range sl.Len() {
 						v := sl.Get(i)
 						err = interp.validateEnumValueFeatureSupport(edition, enum, v.Enum(), append(chpath, int32(i)), element)
 						if err != nil {
@@ -918,7 +918,7 @@ func (interp *interpreter) validateRecursive(
 			}
 		case fld.IsList() && fld.Message() != nil:
 			sl := val.List()
-			for i := 0; i < sl.Len(); i++ {
+			for i := range sl.Len() {
 				v := sl.Get(i)
 				chprefix := fmt.Sprintf("%s%s[%d].", prefix, fieldName(fld), i)
 				if !inMap {
@@ -1083,7 +1083,7 @@ func isPathMatch(a, b []int32) bool {
 	if len(b) < length {
 		length = len(b)
 	}
-	for i := 0; i < length; i++ {
+	for i := range length {
 		if a[i] != b[i] {
 			return false
 		}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -48,7 +48,6 @@ type aggregate string
 func TestCustomOptionsAreKnown(t *testing.T) {
 	t.Parallel()
 	for _, withOverride := range []bool{false, true} {
-		withOverride := withOverride
 		name := "no overrides"
 		if withOverride {
 			name = "with override descriptor.proto"
@@ -234,7 +233,6 @@ func TestOptionsInUnlinkedFiles(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			h := reporter.NewHandler(nil)
@@ -380,7 +378,6 @@ func TestOptionsEncoding(t *testing.T) {
 		"defaults":              "desc_test_defaults.proto",
 	}
 	for testCaseName, file := range testCases {
-		file := file // must not capture loop variable below, for thread safety
 		t.Run(testCaseName, func(t *testing.T) {
 			t.Parallel()
 			fileToCompile := strings.TrimPrefix(file, "options/")

--- a/parser/fastscan/fastscan_test.go
+++ b/parser/fastscan/fastscan_test.go
@@ -161,7 +161,6 @@ func TestScan(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := Scan("", strings.NewReader(testCase.input))

--- a/parser/fastscan/lexer.go
+++ b/parser/fastscan/lexer.go
@@ -355,7 +355,7 @@ func (l *lexer) readStringLiteral(quote rune) string {
 					c, err := l.input.readRune()
 					if err != nil {
 						buf.WriteString("\\u")
-						for j := 0; j < i; j++ {
+						for j := range i {
 							buf.WriteRune(u[j])
 						}
 						break
@@ -379,7 +379,7 @@ func (l *lexer) readStringLiteral(quote rune) string {
 					c, err := l.input.readRune()
 					if err != nil {
 						buf.WriteString("\\U")
-						for j := 0; j < i; j++ {
+						for j := range i {
 							buf.WriteRune(u[j])
 						}
 						break

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -423,7 +423,6 @@ func TestLexerErrors(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			handler := reporter.NewHandler(nil)
@@ -475,7 +474,6 @@ func TestStringLiteralMultipleErrors(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var errors []reporter.ErrorWithPos

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -64,7 +64,6 @@ func TestJunkParse(t *testing.T) {
 		                }`,
 	}
 	for name, input := range inputs {
-		name, input := name, input
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			errHandler := reporter.NewHandler(reporter.NewReporter(
@@ -88,7 +87,6 @@ type parseErrorTestCase struct {
 
 func runParseErrorTestCases(t *testing.T, testCases map[string]parseErrorTestCase, expected string) {
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			protoName := name + ".proto"
@@ -954,7 +952,7 @@ func BenchmarkBasicSuccess(b *testing.B) {
 	require.NoError(b, err)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.ReportAllocs()
 		byteReader := bytes.NewReader(bs)
 		handler := reporter.NewHandler(nil)
@@ -991,7 +989,6 @@ func TestPathological(t *testing.T) {
 		"pathological3.proto": false,
 	}
 	for fileName := range testCases {
-		fileName, canParse := fileName, testCases[fileName] // don't want test func below to capture loop var
 		t.Run(fileName, func(t *testing.T) {
 			t.Parallel()
 			// Fuzz testing complains if this loop, with 100 iterations, takes longer
@@ -1014,14 +1011,14 @@ func TestPathological(t *testing.T) {
 				}
 				cancel()
 			}()
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				if ctx.Err() != nil {
 					break
 				}
 				r := readerForTestdata(t, fileName)
 				handler := reporter.NewHandler(nil)
 				fileNode, err := Parse(fileName, r, handler)
-				if canParse {
+				if testCases[fileName] {
 					require.NoError(t, err)
 					_, err = ResultFromAST(fileNode, true, handler)
 				}

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -992,7 +992,6 @@ func TestBasicValidation(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		expectedPrefix := "success_"
 		if tc.expectedErr != "" {
 			expectedPrefix = "failure_"

--- a/protoutil/editions_test.go
+++ b/protoutil/editions_test.go
@@ -307,7 +307,6 @@ func TestResolveCustomFeature(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.syntax, func(t *testing.T) {
 			t.Parallel()
 			sourceResolver := &protocompile.SourceResolver{
@@ -441,7 +440,6 @@ func TestResolveCustomFeature_Generated(t *testing.T) {
 		},
 	}
 	for _, testCase := range preEditionsTestCases {
-		testCase := testCase
 		t.Run(testCase.syntax, func(t *testing.T) {
 			t.Parallel()
 			sourceResolver := &protocompile.SourceResolver{
@@ -512,7 +510,6 @@ func TestResolveCustomFeature_Generated(t *testing.T) {
 	}
 
 	for _, testCase := range editionsTestCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/reporting_test.go
+++ b/reporting_test.go
@@ -411,7 +411,6 @@ func TestWarningReporting(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			var msgs []msg

--- a/sourceinfo/source_code_info_test.go
+++ b/sourceinfo/source_code_info_test.go
@@ -204,7 +204,6 @@ func TestSourceCodeInfoOptions(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			output := generateSourceInfoText(t, testCase.filename, testCase.mode)
@@ -232,7 +231,7 @@ var pathRoot = (&descriptorpb.FileDescriptorProto{}).ProtoReflect().Descriptor()
 
 func describeSourceCodeInfo(fileName string, locs protoreflect.SourceLocations, resolver linker.Resolver) string {
 	var buf bytes.Buffer
-	for i := 0; i < locs.Len(); i++ {
+	for i := range locs.Len() {
 		if i > 0 {
 			buf.WriteString("\n")
 		}

--- a/walk/walk_benchmark_test.go
+++ b/walk/walk_benchmark_test.go
@@ -26,7 +26,7 @@ import (
 
 func BenchmarkDescriptors(b *testing.B) {
 	file := (*descriptorpb.FileDescriptorProto)(nil).ProtoReflect().Descriptor().ParentFile()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		err := Descriptors(file, func(_ protoreflect.Descriptor) error {
 			return nil
 		})
@@ -36,7 +36,7 @@ func BenchmarkDescriptors(b *testing.B) {
 
 func BenchmarkDescriptorProtos(b *testing.B) {
 	file := protodesc.ToFileDescriptorProto((*descriptorpb.FileDescriptorProto)(nil).ProtoReflect().Descriptor().ParentFile())
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		err := DescriptorProtos(file, func(_ protoreflect.FullName, _ proto.Message) error {
 			return nil
 		})

--- a/wellknownimports/wellknownimports_test.go
+++ b/wellknownimports/wellknownimports_test.go
@@ -79,7 +79,7 @@ func TestWithStandardImports(t *testing.T) {
 			md, ok := d.(protoreflect.MessageDescriptor)
 			require.True(t, ok)
 			var extRangeCount int
-			for i := 0; i < md.ExtensionRanges().Len(); i++ {
+			for i := range md.ExtensionRanges().Len() {
 				opts, ok := md.ExtensionRangeOptions(i).(*descriptorpb.ExtensionRangeOptions)
 				require.True(t, ok)
 				extRangeCount += len(opts.GetDeclaration())


### PR DESCRIPTION
Go 1.24 released today. This means we can drop 1.21 support!

This PR bumps the minimum versions and then applies all necessary lint fixes.