### PR TITLE
Capitalize the first word "package" of the package docs of a bunch of packages

### DIFF
--- a/experimental/ast/doc.go
+++ b/experimental/ast/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package ast is a high-performance implementation of a Protobuf IDL abstract
+// Package ast is a high-performance implementation of a Protobuf IDL abstract
 // syntax tree. It is intended to be end-all, be-all AST for the following
 // use-cases:
 //

--- a/experimental/ast/predeclared/doc.go
+++ b/experimental/ast/predeclared/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package predeclared provides all of the identifiers with a special meaning
+// Package predeclared provides all of the identifiers with a special meaning
 // in Protobuf.
 //
 // These are not keywords, but are rather special names injected into scope in

--- a/experimental/incremental/queries/queries.go
+++ b/experimental/incremental/queries/queries.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package queries provides specific [incremental.Query] types for various parts
+// Package queries provides specific [incremental.Query] types for various parts
 // of Protocompile. It is separate from package incremental itself because it is
 // Protocompile-specific.
 package queries

--- a/experimental/internal/taxa/taxa.go
+++ b/experimental/internal/taxa/taxa.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package taxa (plural of taxon, an element of a taxonomy) provides support for
+// Package taxa (plural of taxon, an element of a taxonomy) provides support for
 // classifying Protobuf syntax productions for use in the parser and in
 // diagnostics.
 //

--- a/experimental/seq/seq.go
+++ b/experimental/seq/seq.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package seq provides an interface for sequence-like types that can be indexed
+// Package seq provides an interface for sequence-like types that can be indexed
 // and inserted into.
 //
 // Protocompile avoids storing slices of its public types as a means of achieving

--- a/experimental/source/source.go
+++ b/experimental/source/source.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package source provides standard queries and interfaces for accessing the
+// Package source provides standard queries and interfaces for accessing the
 // contents of source files.
 package source
 

--- a/experimental/token/doc.go
+++ b/experimental/token/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package token provides a memory-efficient representation of a token tree
+// Package token provides a memory-efficient representation of a token tree
 // stream for the Protobuf IDL.
 //
 // # Token Trees

--- a/internal/arena/arena.go
+++ b/internal/arena/arena.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package arena defines an [Arena] type with compressed pointers.
+// Package arena defines an [Arena] type with compressed pointers.
 //
 // The benefits of using compressed pointers are as follows:
 //

--- a/internal/ext/iterx/iterx.go
+++ b/internal/ext/iterx/iterx.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package iterx contains extensions to Go's package iter.
+// Package iterx contains extensions to Go's package iter.
 package iterx
 
 import "github.com/bufbuild/protocompile/internal/iter"

--- a/internal/ext/osx/perms.go
+++ b/internal/ext/osx/perms.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package osx contains extensions to the os package.
+// Package osx contains extensions to the os package.
 package osx
 
 // Go does not consider it worthy to include constants for the user permission

--- a/internal/ext/slicesx/slicesx.go
+++ b/internal/ext/slicesx/slicesx.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package slicesx contains extensions to Go's package slices.
+// Package slicesx contains extensions to Go's package slices.
 package slicesx
 
 import (

--- a/internal/ext/stringsx/stringsx.go
+++ b/internal/ext/stringsx/stringsx.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package stringsx contains extensions to Go's package strings.
+// Package stringsx contains extensions to Go's package strings.
 package stringsx
 
 import (

--- a/internal/ext/unsafex/unsafex.go
+++ b/internal/ext/unsafex/unsafex.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package unsafex contains extensions to Go's package unsafe.
+// Package unsafex contains extensions to Go's package unsafe.
 //
 // Importing this package should be treated as equivalent to importing unsafe.
 package unsafex

--- a/internal/golden/golden.go
+++ b/internal/golden/golden.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package golden provides a framework for writing file-based golden tests.
+// Package golden provides a framework for writing file-based golden tests.
 //
 // The primary entry-point is [Corpus]. Define a new corpus in an ordinary Go
 // test body and call [Corpus.Run] to execute it.

--- a/internal/intern/char6.go
+++ b/internal/intern/char6.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package intern provides an interning table abstraction to optimize symbol
-// resolution.
 package intern
 
 import (

--- a/internal/intern/intern.go
+++ b/internal/intern/intern.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package intern provides an interning table abstraction to optimize symbol
+// Package intern provides an interning table abstraction to optimize symbol
 // resolution.
 package intern
 

--- a/internal/intern/intern_test.go
+++ b/internal/intern/intern_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package intern provides an interning table abstraction to optimize symbol
-// resolution.
 package intern_test
 
 import (

--- a/internal/iter/iter.go
+++ b/internal/iter/iter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package iter is a collection of polyfills for the standard iter package.
+// Package iter is a collection of polyfills for the standard iter package.
 package iter
 
 type Seq[T any] func(yield func(T) bool) // The "yield" name here helps code completion.


### PR DESCRIPTION
Mea culpa: for some reason I had it in my head that it was Go style to *not* capitalize this word. I only just learned i was wrong. This PR rights that wrong in every package I have contributed.