### PR TITLE
Unbreak CI due to bad merge

### DIFF
--- a/experimental/ast/syntax/editions.go
+++ b/experimental/ast/syntax/editions.go
@@ -15,8 +15,9 @@
 package syntax
 
 import (
+	"iter"
+
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
-	"github.com/bufbuild/protocompile/internal/iter"
 )
 
 // IsEdition returns whether this represents an edition.

--- a/experimental/ast/syntax/syntax.go
+++ b/experimental/ast/syntax/syntax.go
@@ -18,8 +18,7 @@ package syntax
 
 import (
 	"fmt"
-
-	"github.com/bufbuild/protocompile/internal/iter"
+	"iter"
 )
 
 // Syntax is a known syntax pragma.

--- a/experimental/ast/syntax/syntax_test.go
+++ b/experimental/ast/syntax/syntax_test.go
@@ -15,6 +15,7 @@
 package syntax_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,13 +24,12 @@ import (
 	"github.com/bufbuild/protocompile/internal/editions"
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
 	"github.com/bufbuild/protocompile/internal/ext/mapsx"
-	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 )
 
 func TestEditions(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, []syntax.Syntax{syntax.Edition2023}, slicesx.Collect(syntax.Editions()))
+	assert.Equal(t, []syntax.Syntax{syntax.Edition2023}, slices.Collect(syntax.Editions()))
 	assert.Equal(t,
 		mapsx.KeySet(editions.SupportedEditions),
 		mapsx.CollectSet(iterx.Strings(syntax.Editions())),

--- a/experimental/parser/legalize_decl.go
+++ b/experimental/parser/legalize_decl.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -319,7 +320,7 @@ func legalizeRange(p *parser, parent classified, decl ast.DeclRange) {
 		edits = append(edits, report.Edit{
 			Start: span.Len(), End: span.Len(),
 			Replace: fmt.Sprintf("\n%sreserved %s;", span.Indentation(), iterx.Join(
-				iterx.Map(slicesx.Values(least), func(e ast.ExprAny) string { return e.Span().Text() }),
+				iterx.Map(slices.Values(least), func(e ast.ExprAny) string { return e.Span().Text() }),
 				", ",
 			)),
 		})


### PR DESCRIPTION
#438 and #460 interacted poorly and broke CI. This regenerated some generated code to fix it.