### PR TITLE
Add a generic topological sort implementation

### DIFF
--- a/internal/ext/iterx/consume.go
+++ b/internal/ext/iterx/consume.go
@@ -55,3 +55,14 @@ func Every[T any](seq iter.Seq[T], p func(T) bool) bool {
 	}
 	return true
 }
+
+// Exhaust runs an iterator to completion for its side-effects.
+//
+// This mostly exists because there is a noisy lint that incorrectly thinks all
+// range loops are side-effect free, and because gofmt won't format
+// "for range iter {}" on one line.
+func Exhaust[T any](seq iter.Seq[T]) {
+	//nolint:revive // Empty block has side-effects.
+	for range seq {
+	}
+}

--- a/internal/ext/iterx/iterx.go
+++ b/internal/ext/iterx/iterx.go
@@ -18,6 +18,7 @@ package iterx
 import (
 	"fmt"
 	"iter"
+	"slices"
 )
 
 // Take returns an iterator over the first n elements of a sequence.
@@ -63,4 +64,9 @@ func Chain[T any](seqs ...iter.Seq[T]) iter.Seq[T] {
 			}
 		}
 	}
+}
+
+// Of returns an iterator that yields the given values.
+func Of[T any](v ...T) iter.Seq[T] {
+	return slices.Values(v)
 }

--- a/internal/ext/slicesx/iter.go
+++ b/internal/ext/slicesx/iter.go
@@ -27,6 +27,11 @@ func Map[S ~[]E, E, U any](s S, f func(E) U) iter.Seq[U] {
 	return iterx.Map(slices.Values(s), f)
 }
 
+// Join is a helper for applying [iterx.Join] to a slice.
+func Join[S ~[]E, E any](s S, sep string) string {
+	return iterx.Join(slices.Values(s), sep)
+}
+
 // PartitionFunc returns an iterator of the largest substrings of s of equal
 // elements.
 //

--- a/internal/ext/slicesx/slicesx.go
+++ b/internal/ext/slicesx/slicesx.go
@@ -73,6 +73,26 @@ func LastPointer[S ~[]E, E any](s S) *E {
 	return GetPointer(s, len(s)-1)
 }
 
+// LastIndex is like [slices.Index], but from the end of the slice.
+func LastIndex[S ~[]E, E comparable](s S, needle E) int {
+	for i, v := range slices.Backward(s) {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// LastIndex is like [slices.IndexFunc], but from the end of the slice.
+func LastIndexFunc[S ~[]E, E any](s S, p func(E) bool) int {
+	for i, v := range slices.Backward(s) {
+		if p(v) {
+			return i
+		}
+	}
+	return -1
+}
+
 // BoundsCheck performs a generic bounds check as efficiently as possible.
 //
 // This function assumes that len is the length of a slice, i.e, it is

--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -1,0 +1,125 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package toposort provides a generic topological sort implementation.
+package toposort
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/bufbuild/protocompile/internal/ext/slicesx"
+)
+
+const (
+	unsorted byte = iota
+	working
+	sorted
+)
+
+// Sort sorts a DAG topologically.
+//
+// Roots are the nodes whose dependencies we are querying. key returns a
+// comparable key for each node. dag contains the data of the DAG being sorted,
+// and returns the children of a node.
+func Sort[Node any, Key comparable](
+	roots []Node,
+	key func(Node) Key,
+	dag func(Node) iter.Seq[Node],
+) iter.Seq[Node] {
+	s := Sorter[Node, Key]{Key: key}
+	return s.Sort(roots, dag)
+}
+
+// Sorter is reusable scratch space for a particular stencil of [Sort], which
+// needs to allocate memory for book-keeping. This struct allows amortizing that
+// cost.
+type Sorter[Node any, Key comparable] struct {
+	// A function to extract a unique key from each node, for marking.
+	Key func(Node) Key
+
+	state     map[Key]byte
+	stack     []Node
+	visited   []bool
+	iterating bool
+}
+
+// Sort is like [Sort], but re-uses allocated resources stored in s.
+func (s *Sorter[Node, Key]) Sort(
+	roots []Node,
+	dag func(Node) iter.Seq[Node],
+) iter.Seq[Node] {
+	if s.state == nil {
+		s.state = make(map[Key]byte)
+	} else {
+		clear(s.state)
+	}
+	s.stack = s.stack[0:]
+	s.visited = s.visited[0:]
+
+	return func(yield func(Node) bool) {
+		if s.iterating {
+			panic("internal/toposort: Sort() called reëntrantly")
+		}
+		s.iterating = true
+		defer func() { s.iterating = false }()
+
+		for _, root := range roots {
+			s.push(root)
+			// This algorithm is DFS that has been tail-call-optimized into a loop.
+			// Each node is visited twice in the loop: once to add its children to
+			// the stack, and once to pop it and add it to the output. The visited
+			// stack tracks whether this is the first or second visit through the
+			// loop.
+			for len(s.stack) > 0 {
+				node, _ := slicesx.Last(s.stack)
+				visit := slicesx.LastPointer(s.visited)
+
+				if !*visit {
+					for child := range dag(node) {
+						s.push(child)
+					}
+
+					*visit = true
+					continue
+				}
+
+				s.stack = s.stack[:len(s.stack)-1]
+				s.visited = s.visited[:len(s.visited)-1]
+				s.state[s.Key(node)] = sorted
+				if !yield(node) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (s *Sorter[Node, Key]) push(v Node) {
+	k := s.Key(v)
+	switch s.state[k] {
+	case unsorted:
+		s.state[k] = working
+		s.stack = append(s.stack, v)
+		s.visited = append(s.visited, false)
+	case working:
+		prev := slicesx.LastIndexFunc(s.stack, func(n Node) bool {
+			return s.Key(n) == k
+		})
+		suffix := s.stack[prev:]
+		panic(fmt.Sprintf("protocompile/internal: cycle detected: %v -> %v", slicesx.Join(suffix, "->"), v))
+	case sorted:
+		return
+	}
+}

--- a/internal/toposort/toposort_test.go
+++ b/internal/toposort/toposort_test.go
@@ -1,0 +1,141 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toposort_test
+
+import (
+	"iter"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bufbuild/protocompile/internal/ext/iterx"
+	"github.com/bufbuild/protocompile/internal/toposort"
+)
+
+type dag map[int][]int
+
+func (d dag) children(n int) iter.Seq[int] {
+	return slices.Values(d[n])
+}
+
+func TestSort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		dag   dag
+		roots []int
+		want  []int
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:  "list",
+			dag:   dag{1: {2}, 2: {3}, 3: {4}, 4: {}},
+			roots: []int{1},
+			want:  []int{4, 3, 2, 1},
+		},
+		{
+			name:  "list",
+			dag:   dag{1: {2}, 2: {3}, 3: {4}, 4: {}},
+			roots: []int{2, 1},
+			want:  []int{4, 3, 2, 1},
+		},
+		{
+			name:  "list",
+			dag:   dag{1: {2}, 2: {3}, 3: {4}, 4: {}},
+			roots: []int{1, 2},
+			want:  []int{4, 3, 2, 1},
+		},
+		{
+			name:  "diamond",
+			dag:   dag{1: {2, 3}, 2: {4}, 3: {4}, 4: {}},
+			roots: []int{1},
+			want:  []int{4, 3, 2, 1},
+		},
+		{
+			name:  "diamond",
+			dag:   dag{1: {2, 3}, 2: {4}, 3: {4}, 4: {}},
+			roots: []int{2},
+			want:  []int{4, 2},
+		},
+		{
+			name:  "diamond",
+			dag:   dag{1: {2, 3}, 2: {4}, 3: {4}, 4: {}},
+			roots: []int{2, 3, 1},
+			want:  []int{4, 2, 3, 1},
+		},
+		{
+			name:  "y",
+			dag:   dag{1: {2}, 2: {4}, 3: {4}, 4: {}},
+			roots: []int{1},
+			want:  []int{4, 2, 1},
+		},
+		{
+			name:  "y",
+			dag:   dag{1: {2}, 2: {4}, 3: {4}, 4: {}},
+			roots: []int{1, 3},
+			want:  []int{4, 2, 1, 3},
+		},
+		{
+			name:  "y",
+			dag:   dag{1: {2}, 2: {4}, 3: {4}, 4: {}},
+			roots: []int{3, 1},
+			want:  []int{4, 3, 2, 1},
+		},
+	}
+
+	var mu sync.Mutex
+	s := toposort.Sorter[int, int]{Key: func(n int) int { return n }}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Serialize the tests, but run them in an arbitrary order.
+			t.Parallel()
+			mu.Lock()
+			defer mu.Unlock()
+
+			assert.Equal(t, tt.want, slices.Collect(s.Sort(
+				tt.roots,
+				tt.dag.children,
+			)))
+		})
+	}
+}
+
+func TestCycle(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		iterx.Exhaust(toposort.Sort(
+			[]int{0},
+			func(n int) int { return n },
+			func(_ int) iter.Seq[int] { return iterx.Of(0) },
+		))
+	})
+}
+
+func TestReentrant(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		s := toposort.Sorter[int, int]{Key: func(n int) int { return n }}
+		dag := func(_ int) iter.Seq[int] { return iterx.Of[int]() }
+
+		for range s.Sort([]int{0}, dag) {
+			iterx.Exhaust(s.Sort([]int{0}, dag))
+		}
+	})
+}


### PR DESCRIPTION
This already exists (implicitly) in the old linker, but I need this in a few places and having a standalone implementation avoids needing to write tests for it every time.