### PR TITLE
Add an analogue of `protoreflect.FullName` to the IR package

### DIFF
--- a/experimental/ir/ir_field.go
+++ b/experimental/ir/ir_field.go
@@ -90,7 +90,7 @@ func (f Field) FullName() FullName {
 	return FullName(f.Context().intern.Value(f.raw.fqn))
 }
 
-// InternedName returns the intern ID for [Field.FullName]().Name()
+// InternedName returns the intern ID for [Field.FullName]().Name().
 func (f Field) InternedName() intern.ID {
 	if f.IsZero() {
 		return 0
@@ -98,7 +98,7 @@ func (f Field) InternedName() intern.ID {
 	return f.raw.name
 }
 
-// InternedName returns the intern ID for [Field.FullName]
+// InternedName returns the intern ID for [Field.FullName].
 func (f Field) InternedFullName() intern.ID {
 	if f.IsZero() {
 		return 0
@@ -221,7 +221,7 @@ func (o Oneof) FullName() FullName {
 	return FullName(o.Context().intern.Value(o.raw.fqn))
 }
 
-// InternedName returns the intern ID for [Oneof.FullName]().Name()
+// InternedName returns the intern ID for [Oneof.FullName]().Name().
 func (o Oneof) InternedName() intern.ID {
 	if o.IsZero() {
 		return 0
@@ -229,7 +229,7 @@ func (o Oneof) InternedName() intern.ID {
 	return o.raw.name
 }
 
-// InternedName returns the intern ID for [Oneof.FullName]
+// InternedName returns the intern ID for [Oneof.FullName].
 func (o Oneof) InternedFullName() intern.ID {
 	if o.IsZero() {
 		return 0

--- a/experimental/ir/ir_field.go
+++ b/experimental/ir/ir_field.go
@@ -74,20 +74,36 @@ func (f Field) AST() ast.DeclDef {
 	return f.raw.def
 }
 
-// Name returns this fields's declared name.
-func (f Field) Name() string {
+// FullName returns this fields's name.
+func (f Field) Name() FullName {
 	if f.IsZero() {
 		return ""
 	}
-	return f.Context().intern.Value(f.raw.name)
+	return FullName(f.Context().intern.Value(f.raw.name))
 }
 
 // FullName returns this fields's fully-qualified name.
-func (f Field) FullName() string {
+func (f Field) FullName() FullName {
 	if f.IsZero() {
 		return ""
 	}
-	return f.Context().intern.Value(f.raw.fqn)
+	return FullName(f.Context().intern.Value(f.raw.fqn))
+}
+
+// InternedName returns the intern ID for [Field.FullName]().Name()
+func (f Field) InternedName() intern.ID {
+	if f.IsZero() {
+		return 0
+	}
+	return f.raw.name
+}
+
+// InternedName returns the intern ID for [Field.FullName]
+func (f Field) InternedFullName() intern.ID {
+	if f.IsZero() {
+		return 0
+	}
+	return f.raw.fqn
 }
 
 // Number returns the number for this field after expression evaluation.
@@ -198,11 +214,27 @@ func (o Oneof) Name() string {
 }
 
 // FullName returns this oneof's fully-qualified name.
-func (o Oneof) FullName() string {
+func (o Oneof) FullName() FullName {
 	if o.IsZero() {
 		return ""
 	}
-	return o.Context().intern.Value(o.raw.fqn)
+	return FullName(o.Context().intern.Value(o.raw.fqn))
+}
+
+// InternedName returns the intern ID for [Oneof.FullName]().Name()
+func (o Oneof) InternedName() intern.ID {
+	if o.IsZero() {
+		return 0
+	}
+	return o.raw.name
+}
+
+// InternedName returns the intern ID for [Oneof.FullName]
+func (o Oneof) InternedFullName() intern.ID {
+	if o.IsZero() {
+		return 0
+	}
+	return o.raw.fqn
 }
 
 // Members returns this oneof's member fields.

--- a/experimental/ir/ir_name.go
+++ b/experimental/ir/ir_name.go
@@ -1,0 +1,68 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir
+
+import "github.com/bufbuild/protocompile/internal/ext/stringsx"
+
+// FullName is a fully-qualified Protobuf name, which is a dot-separated list of
+// identifiers, with an optional dot prefix.
+//
+// This is a helper type for common operations on such names. This is essentially
+// protoreflect.FullName, without depending on protoreflect. Unlike protoreflect,
+// we do not provide validation methods.
+type FullName string
+
+// Absolute returns whether this is an absolute name, i.e., has a leading dot.
+func (n FullName) Absolute() bool {
+	return n != "" && n[0] == '.'
+}
+
+// ToAbsolute returns this name with a leading dot.
+func (n FullName) ToAbsolute() FullName {
+	if n.Absolute() {
+		return n
+	}
+	return "." + n
+}
+
+// Name returns the last component of this name.
+func (n FullName) Name() string {
+	_, name, _ := stringsx.CutLast(string(n), ".")
+	return name
+}
+
+// Parent returns the name of the parent entity for this name.
+//
+// If the name only has one component, returns the zero value. In particular,
+// the parent of ".foo" is "".
+func (n FullName) Parent() FullName {
+	parent, _, _ := stringsx.CutLast(string(n), ".")
+	return FullName(parent)
+}
+
+// Append returns a name with the given component(s) appended.
+//
+// If this is an empty name, the resulting name will not be absolute.
+func (n FullName) Append(names ...string) FullName {
+	for _, name := range names {
+		switch n {
+		case "":
+			n = FullName(name)
+		default:
+			n += "." + FullName(name)
+		}
+	}
+	return n
+}

--- a/experimental/ir/ir_name.go
+++ b/experimental/ir/ir_name.go
@@ -14,7 +14,11 @@
 
 package ir
 
-import "github.com/bufbuild/protocompile/internal/ext/stringsx"
+import (
+	"strings"
+
+	"github.com/bufbuild/protocompile/internal/ext/stringsx"
+)
 
 // FullName is a fully-qualified Protobuf name, which is a dot-separated list of
 // identifiers, with an optional dot prefix.
@@ -56,13 +60,28 @@ func (n FullName) Parent() FullName {
 //
 // If this is an empty name, the resulting name will not be absolute.
 func (n FullName) Append(names ...string) FullName {
-	for _, name := range names {
-		switch n {
-		case "":
-			n = FullName(name)
-		default:
-			n += "." + FullName(name)
-		}
+	if len(names) == 0 {
+		return n
 	}
-	return n
+
+	m := len(n) + len(names) - 1
+	if n != "" {
+		m++
+	}
+	for _, name := range names {
+		m += len(name)
+	}
+
+	var out strings.Builder
+	out.Grow(m)
+	out.WriteString(string(n))
+
+	for _, name := range names {
+		if out.Len() > 0 {
+			out.WriteByte('.')
+		}
+		out.WriteString(name)
+	}
+
+	return FullName(out.String())
 }

--- a/experimental/ir/ir_name_test.go
+++ b/experimental/ir/ir_name_test.go
@@ -1,0 +1,127 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir_test
+
+import (
+	"testing"
+
+	"github.com/bufbuild/protocompile/experimental/ir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFullNameAbsolute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		fqn, abs ir.FullName
+	}{
+		{fqn: "", abs: "."},
+		{fqn: "foo", abs: ".foo"},
+		{fqn: "foo.bar", abs: ".foo.bar"},
+		{fqn: ".", abs: "."},
+		{fqn: ".foo", abs: ".foo"},
+		{fqn: ".foo.bar", abs: ".foo.bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.fqn), func(t *testing.T) {
+			assert.Equal(t, tt.fqn == tt.abs, tt.fqn.Absolute())
+			assert.Equal(t, tt.abs, tt.fqn.ToAbsolute())
+		})
+	}
+}
+
+func TestFullNameParts(t *testing.T) {
+	tests := []struct {
+		fqn, parent ir.FullName
+		name        string
+	}{
+		{fqn: "", parent: "", name: ""},
+		{fqn: "foo", parent: "", name: "foo"},
+		{fqn: ".foo", parent: "", name: "foo"},
+		{fqn: "foo.bar", parent: "foo", name: "bar"},
+		{fqn: ".foo.bar", parent: ".foo", name: "bar"},
+		{fqn: "foo.bar.baz", parent: "foo.bar", name: "baz"},
+		{fqn: ".foo.bar.baz", parent: ".foo.bar", name: "baz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.fqn), func(t *testing.T) {
+			assert.Equal(t, tt.name, tt.fqn.Name())
+			assert.Equal(t, tt.parent, tt.fqn.Parent())
+		})
+	}
+}
+
+func TestFullNameAppend(t *testing.T) {
+	tests := []struct {
+		fqn, got ir.FullName
+		names    []string
+	}{
+		{
+			fqn:   "",
+			names: []string{},
+			got:   "",
+		},
+		{
+			fqn:   "",
+			names: []string{"foo"},
+			got:   "foo",
+		},
+		{
+			fqn:   "",
+			names: []string{"foo", "bar"},
+			got:   "foo.bar",
+		},
+
+		{
+			fqn:   "pkg",
+			names: []string{},
+			got:   "pkg",
+		},
+		{
+			fqn:   "pkg",
+			names: []string{"foo"},
+			got:   "pkg.foo",
+		},
+		{
+			fqn:   "pkg",
+			names: []string{"foo", "bar"},
+			got:   "pkg.foo.bar",
+		},
+
+		{
+			fqn:   ".pkg",
+			names: []string{},
+			got:   ".pkg",
+		},
+		{
+			fqn:   ".pkg",
+			names: []string{"foo"},
+			got:   ".pkg.foo",
+		},
+		{
+			fqn:   ".pkg",
+			names: []string{"foo", "bar"},
+			got:   ".pkg.foo.bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.fqn), func(t *testing.T) {
+			assert.Equal(t, tt.got, tt.fqn.Append(tt.names...))
+		})
+	}
+}

--- a/experimental/ir/ir_name_test.go
+++ b/experimental/ir/ir_name_test.go
@@ -17,13 +17,13 @@ package ir_test
 import (
 	"testing"
 
-	"github.com/bufbuild/protocompile/experimental/ir"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/bufbuild/protocompile/experimental/ir"
 )
 
 func TestFullNameAbsolute(t *testing.T) {
 	t.Parallel()
-
 	tests := []struct {
 		fqn, abs ir.FullName
 	}{
@@ -37,6 +37,7 @@ func TestFullNameAbsolute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.fqn), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.fqn == tt.abs, tt.fqn.Absolute())
 			assert.Equal(t, tt.abs, tt.fqn.ToAbsolute())
 		})
@@ -44,6 +45,7 @@ func TestFullNameAbsolute(t *testing.T) {
 }
 
 func TestFullNameParts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fqn, parent ir.FullName
 		name        string
@@ -59,6 +61,7 @@ func TestFullNameParts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.fqn), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.name, tt.fqn.Name())
 			assert.Equal(t, tt.parent, tt.fqn.Parent())
 		})
@@ -66,6 +69,7 @@ func TestFullNameParts(t *testing.T) {
 }
 
 func TestFullNameAppend(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fqn, got ir.FullName
 		names    []string
@@ -121,6 +125,7 @@ func TestFullNameAppend(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.fqn), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.got, tt.fqn.Append(tt.names...))
 		})
 	}

--- a/experimental/ir/ir_type.go
+++ b/experimental/ir/ir_type.go
@@ -52,6 +52,7 @@ var primitiveCtx = func() *Context {
 	ctx := new(Context)
 	ctx.intern = new(intern.Table)
 
+	nextPtr := 1
 	predeclared.All()(func(n predeclared.Name) bool {
 		if n == predeclared.Unknown || !n.IsScalar() {
 			// Skip allocating a pointer for the very first value. This ensures
@@ -61,7 +62,12 @@ var primitiveCtx = func() *Context {
 			return true
 		}
 
+		for nextPtr != int(n) {
+			_ = ctx.arenas.types.NewCompressed(rawType{})
+			nextPtr++
+		}
 		ptr := ctx.arenas.types.NewCompressed(rawType{})
+		nextPtr++
 
 		if int(ptr) != int(n) {
 			panic(fmt.Sprintf("IR initialization error: %d != %d; this is a bug in protocompile", ptr, n))

--- a/internal/ext/stringsx/stringsx.go
+++ b/internal/ext/stringsx/stringsx.go
@@ -135,6 +135,15 @@ func Lines(s string) iter.Seq[string] {
 	return Split(s, '\n')
 }
 
+// CutLast is like [strings.Cut], but searches for the last occurrence of sep.
+// If sep is not present in s, returns "", s, false.
+func CutLast(s, sep string) (before, after string, found bool) {
+	if i := strings.LastIndex(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return "", s, false
+}
+
 // PartitionKey returns an iterator of the largest substrings of s such that
 // key(r) for each rune in each substring is the same value.
 //


### PR DESCRIPTION
Josh pointed out some places where pulling this logic into its own type would be useful. I opted to write my own because it was pretty trivial and also we're trying very hard not to depend on the Protobuf runtime here.