### PR TITLE
Add arena pointers and syntax lookup in IR lowering

### DIFF
--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -41,7 +41,6 @@ type Context struct {
 
 	file struct {
 		ast     ast.File
-		syntax  syntax.Syntax
 		imports imports
 		types   []arena.Pointer[rawType]
 		extns   []arena.Pointer[rawField]
@@ -98,7 +97,7 @@ func (f File) AST() ast.File {
 
 // Syntax returns the syntax pragma that applies to this file.
 func (f File) Syntax() syntax.Syntax {
-	return f.Context().file.syntax
+	return f.Context().syntax
 }
 
 // Path returns the canoniocal path for this file.

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -98,7 +98,7 @@ func (f File) AST() ast.File {
 
 // Syntax returns the syntax pragma that applies to this file.
 func (f File) Syntax() syntax.Syntax {
-	return f.Context().syntax
+	return f.Context().file.syntax
 }
 
 // Path returns the canoniocal path for this file.

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 
 	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
@@ -46,6 +47,11 @@ func (w *walker) walk() {
 		c.pkg = c.session.intern.Intern(pkg.Path().Canonicalized())
 	}
 	w.pkg = w.Package().ToAbsolute()
+
+	if syn := w.AST().Syntax(); !syn.IsZero() {
+		c.syntax = syntax.Lookup(syn.Value().AsLiteral().Text())
+		c.file.syntax = syntax.Lookup(syn.Value().AsLiteral().Text())
+	}
 
 	w.recurse(w.AST().AsAny(), nil)
 }
@@ -149,6 +155,9 @@ func (w *walker) newType(def ast.DeclDef, parent any) Type {
 			w.Context().arenas.types.Compress(raw),
 		)
 	}
+
+	file := &w.Context().file
+	file.types = append(file.types, w.Context().arenas.types.Compress(raw))
 
 	return Type{internal.NewWith(w.Context()), raw}
 }

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -50,7 +50,6 @@ func (w *walker) walk() {
 
 	if syn := w.AST().Syntax(); !syn.IsZero() {
 		c.syntax = syntax.Lookup(syn.Value().AsLiteral().Text())
-		c.file.syntax = syntax.Lookup(syn.Value().AsLiteral().Text())
 	}
 
 	w.recurse(w.AST().AsAny(), nil)

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -49,7 +49,8 @@ func (w *walker) walk() {
 	w.pkg = w.Package().ToAbsolute()
 
 	if syn := w.AST().Syntax(); !syn.IsZero() {
-		c.syntax = syntax.Lookup(syn.Value().AsLiteral().Text())
+		unquoted, _ := syn.Value().AsLiteral().AsString()
+		c.syntax = syntax.Lookup(unquoted)
 	}
 
 	w.recurse(w.AST().AsAny(), nil)
@@ -153,10 +154,10 @@ func (w *walker) newType(def ast.DeclDef, parent any) Type {
 		parentTy.raw.nested = append(parentTy.raw.nested,
 			w.Context().arenas.types.Compress(raw),
 		)
+	} else {
+		file := &w.Context().file
+		file.types = append(file.types, w.Context().arenas.types.Compress(raw))
 	}
-
-	file := &w.Context().file
-	file.types = append(file.types, w.Context().arenas.types.Compress(raw))
 
 	return Type{internal.NewWith(w.Context()), raw}
 }


### PR DESCRIPTION
This PR does the following:
- Add arena pointers for `Context.file.types` when calling `newType`
- Set the syntax on `Context.syntax` and `Context.file.syntax`
