### PR TITLE
Fix some bugs in the incremental package

### DIFF
--- a/experimental/incremental/cyclic_test.go
+++ b/experimental/incremental/cyclic_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package incremental_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
+)
+
+type Cyclic struct {
+	Mod, Step int
+}
+
+func (c Cyclic) Key() any {
+	return c
+}
+
+func (c Cyclic) Execute(t *incremental.Task) (int, error) {
+	next, err := incremental.Resolve(t, Cyclic{
+		Mod:  c.Mod,
+		Step: (c.Step + 1) % c.Mod,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// NOTE: This call is a regression check against a case where calling
+	// Report() after a cyclic error would incorrectly treat the cycle point
+	// as having been completed.
+	t.Report().Remarkf("squaring: %d", next[0].Value)
+	return next[0].Value * next[0].Value, next[0].Fatal
+}
+
+func TestCyclic(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	ctx := context.Background()
+	exec := incremental.New(
+		incremental.WithParallelism(4),
+	)
+
+	result, _, err := incremental.Run(ctx, exec, Cyclic{Mod: 5, Step: 3})
+	require.NoError(t, err)
+	assert.Equal(
+		`cycle detected: `+
+			`incremental_test.Cyclic{Mod:5, Step:3} -> `+
+			`incremental_test.Cyclic{Mod:5, Step:4} -> `+
+			`incremental_test.Cyclic{Mod:5, Step:0} -> `+
+			`incremental_test.Cyclic{Mod:5, Step:1} -> `+
+			`incremental_test.Cyclic{Mod:5, Step:2} -> `+
+			`incremental_test.Cyclic{Mod:5, Step:3}`,
+		result[0].Fatal.Error(),
+	)
+}

--- a/experimental/incremental/executor_test.go
+++ b/experimental/incremental/executor_test.go
@@ -30,73 +30,6 @@ import (
 	"github.com/bufbuild/protocompile/experimental/incremental"
 )
 
-type Root struct{}
-
-func (r Root) Key() any {
-	return r
-}
-
-func (Root) Execute(_ *incremental.Task) (struct{}, error) {
-	time.Sleep(100 * time.Millisecond)
-	return struct{}{}, nil
-}
-
-type ParseInt struct {
-	Input string
-}
-
-func (i ParseInt) Key() any {
-	return i
-}
-
-func (i ParseInt) Execute(t *incremental.Task) (int, error) {
-	// This tests that a thundering stampede of queries all waiting on the same
-	// query (as in a diamond-shaped graph) do not cause any issues.
-	_, err := incremental.Resolve(t, Root{})
-	if err != nil {
-		return 0, err
-	}
-
-	v, err := strconv.Atoi(i.Input)
-	if err != nil {
-		t.Report().Errorf("%s", err)
-	}
-	if v < 0 {
-		return 0, fmt.Errorf("negative value: %v", v)
-	}
-	return v, nil
-}
-
-type Sum struct {
-	Input string
-}
-
-func (s Sum) Key() any {
-	return s
-}
-
-func (s Sum) Execute(t *incremental.Task) (int, error) {
-	var queries []incremental.Query[int] //nolint:prealloc
-	for _, s := range strings.Split(s.Input, ",") {
-		queries = append(queries, ParseInt{s})
-	}
-
-	ints, err := incremental.Resolve(t, queries...)
-	if err != nil {
-		return 0, err
-	}
-
-	var v int
-	for _, i := range ints {
-		if i.Fatal != nil {
-			return 0, i.Fatal
-		}
-
-		v += i.Value
-	}
-	return v, nil
-}
-
 func TestSum(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -248,4 +181,74 @@ func TestUnchanged(t *testing.T) {
 			assert.False(r.Changed, "%d", j)
 		}
 	}
+}
+
+// ParseInt is a fallible query that parses an integer.
+type ParseInt struct {
+	Input string
+}
+
+func (i ParseInt) Key() any {
+	return i
+}
+
+func (i ParseInt) Execute(t *incremental.Task) (int, error) {
+	// This tests that a thundering stampede of queries all waiting on the same
+	// query (as in a diamond-shaped graph) do not cause any issues.
+	_, err := incremental.Resolve(t, Root{})
+	if err != nil {
+		return 0, err
+	}
+
+	v, err := strconv.Atoi(i.Input)
+	if err != nil {
+		t.Report().Errorf("%s", err)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("negative value: %v", v)
+	}
+	return v, nil
+}
+
+// Sum is a fallible query that sums the elements of a comma-separated string.
+type Sum struct {
+	Input string
+}
+
+func (s Sum) Key() any {
+	return s
+}
+
+func (s Sum) Execute(t *incremental.Task) (int, error) {
+	var queries []incremental.Query[int] //nolint:prealloc
+	for _, s := range strings.Split(s.Input, ",") {
+		queries = append(queries, ParseInt{s})
+	}
+
+	ints, err := incremental.Resolve(t, queries...)
+	if err != nil {
+		return 0, err
+	}
+
+	var v int
+	for _, i := range ints {
+		if i.Fatal != nil {
+			return 0, i.Fatal
+		}
+
+		v += i.Value
+	}
+	return v, nil
+}
+
+// Root is a query that ParseInt depends on, which is used to test eviction.
+type Root struct{}
+
+func (r Root) Key() any {
+	return r
+}
+
+func (Root) Execute(_ *incremental.Task) (struct{}, error) {
+	time.Sleep(100 * time.Millisecond)
+	return struct{}{}, nil
 }

--- a/experimental/incremental/export_test.go
+++ b/experimental/incremental/export_test.go
@@ -1,0 +1,7 @@
+package incremental
+
+// Exported symbols for test use only. Placing such symbols in a _test.go
+// file avoids them being exported "for real".
+
+// Abort forces an abort on the given task.
+func Abort(t *Task, err error) { t.abort(err) }

--- a/experimental/incremental/export_test.go
+++ b/experimental/incremental/export_test.go
@@ -18,4 +18,4 @@ package incremental
 // file avoids them being exported "for real".
 
 // Abort forces an abort on the given task.
-func Abort(t *Task, err error) { t.abort(err) }
+func (t *Task) Abort(err error) { t.abort(err) }

--- a/experimental/incremental/export_test.go
+++ b/experimental/incremental/export_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package incremental
 
 // Exported symbols for test use only. Placing such symbols in a _test.go

--- a/experimental/incremental/panic_test.go
+++ b/experimental/incremental/panic_test.go
@@ -51,12 +51,12 @@ func TestPanic(t *testing.T) {
 	_, _, err = incremental.Run(ctx, exec, Panic(true), Panic(false))
 	var panicked *incremental.ErrPanic
 	require.ErrorAs(t, err, &panicked)
-	assert.Equal(t, panicked.Query, Panic(true))
+	assert.Equal(t, panicked.Query.Underlying(), Panic(true))
 	assert.Equal(t, "aaa!", panicked.Panic)
 
 	_, _, err = incremental.Run(ctx, exec, Panic(false), Panic(true))
 	require.ErrorAs(t, err, &panicked)
-	assert.Equal(t, panicked.Query, Panic(true))
+	assert.Equal(t, panicked.Query.Underlying(), Panic(true))
 	assert.Equal(t, "aaa!", panicked.Panic)
 }
 
@@ -68,7 +68,7 @@ func (a Abort) Key() any {
 
 func (a Abort) Execute(t *incremental.Task) (bool, error) {
 	if a {
-		incremental.Abort(t, a)
+		t.Abort(a)
 	}
 	return bool(a), nil
 }

--- a/experimental/incremental/panic_test.go
+++ b/experimental/incremental/panic_test.go
@@ -1,0 +1,82 @@
+package incremental_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Panic bool
+
+func (p Panic) Key() any {
+	return p
+}
+
+func (p Panic) Execute(t *incremental.Task) (bool, error) {
+	if p {
+		panic("aaa!")
+	}
+	return bool(p), nil
+}
+
+func TestPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	exec := incremental.New(
+		incremental.WithParallelism(4),
+	)
+
+	_, _, err := incremental.Run(ctx, exec, Panic(false))
+	require.NoError(t, err)
+
+	_, _, err = incremental.Run(ctx, exec, Panic(true), Panic(false))
+	var panicked *incremental.ErrPanic
+	require.True(t, errors.As(err, &panicked))
+	assert.Equal(t, panicked.Query, Panic(true))
+	assert.Equal(t, panicked.Panic, "aaa!")
+
+	_, _, err = incremental.Run(ctx, exec, Panic(false), Panic(true))
+	require.True(t, errors.As(err, &panicked))
+	assert.Equal(t, panicked.Query, Panic(true))
+	assert.Equal(t, panicked.Panic, "aaa!")
+}
+
+type Abort bool
+
+func (a Abort) Key() any {
+	return a
+}
+
+func (a Abort) Execute(t *incremental.Task) (bool, error) {
+	if a {
+		incremental.Abort(t, a)
+	}
+	return bool(a), nil
+}
+
+func (a Abort) Error() string {
+	return "aaa!"
+}
+func TestAbort(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	exec := incremental.New(
+		incremental.WithParallelism(4),
+	)
+
+	_, _, err := incremental.Run(ctx, exec, Abort(false))
+	require.NoError(t, err)
+
+	assert.Panics(t, func() {
+		incremental.Run(ctx, exec, Abort(true), Abort(false))
+	})
+	assert.Panics(t, func() {
+		incremental.Run(ctx, exec, Abort(false), Abort(true))
+	})
+}

--- a/experimental/incremental/queries/ast.go
+++ b/experimental/incremental/queries/ast.go
@@ -44,7 +44,7 @@ func (a AST) Key() any {
 }
 
 // Execute implements [incremental.Query].
-func (a AST) Execute(t incremental.Task) (ast.File, error) {
+func (a AST) Execute(t *incremental.Task) (ast.File, error) {
 	t.Report().Options.Stage += stageAST
 
 	r, err := incremental.Resolve(t, File(a))

--- a/experimental/incremental/queries/file.go
+++ b/experimental/incremental/queries/file.go
@@ -43,7 +43,7 @@ func (f File) Key() any {
 }
 
 // Execute implements [incremental.Query].
-func (f File) Execute(t incremental.Task) (*report.File, error) {
+func (f File) Execute(t *incremental.Task) (*report.File, error) {
 	t.Report().Options.Stage += stageFile
 
 	text, err := f.Open(f.Path)

--- a/experimental/incremental/queries/queries.go
+++ b/experimental/incremental/queries/queries.go
@@ -22,4 +22,5 @@ package queries
 const (
 	stageFile int = iota * 10
 	stageAST
+	stageIR
 )

--- a/experimental/incremental/query.go
+++ b/experimental/incremental/query.go
@@ -24,9 +24,7 @@ import (
 // Types which implement Query can be executed by an [Executor], which
 // automatically caches the results of a query.
 //
-// Nil query values will not panic the executor; instead, they will fail with
-// [ErrNilQuery]. This allows nil queries to be processed in cases where we
-// "don't care" about their result, so they can be used as a placeholder.
+// Nil query values will cause [Run] and [Resolve] to panic.
 type Query[T any] interface {
 	// Returns a unique key representing this query.
 	//

--- a/experimental/incremental/starve_test.go
+++ b/experimental/incremental/starve_test.go
@@ -1,12 +1,27 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package incremental_test
 
 import (
 	"context"
 	"testing"
 
-	"github.com/bufbuild/protocompile/experimental/incremental"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
 )
 
 type Fanout struct {
@@ -44,7 +59,7 @@ func (c Fanout) Execute(t *incremental.Task) (int, error) {
 	return total, nil
 }
 
-func TestFanout(t *testing.T) {
+func TestStarvation(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()

--- a/experimental/incremental/starve_test.go
+++ b/experimental/incremental/starve_test.go
@@ -1,0 +1,72 @@
+package incremental_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Fanout struct {
+	Depth, Level, Index int
+}
+
+func (c Fanout) Key() any {
+	return c
+}
+
+func (c Fanout) Execute(t *incremental.Task) (int, error) {
+	if c.Depth == c.Level {
+		return 1, nil
+	}
+
+	queries := make([]incremental.Query[int], c.Level+1)
+	for i := range queries {
+		queries[i] = Fanout{
+			Depth: c.Depth,
+			Level: c.Level + 1,
+			Index: i,
+		}
+	}
+
+	results, err := incremental.Resolve(t, queries...)
+	if err != nil {
+		return 0, err
+	}
+
+	var total int
+	for _, r := range results {
+		total += r.Value
+	}
+
+	return total, nil
+}
+
+func TestFanout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	exec := incremental.New(
+		// Very low parallelism to ensure we avoid starvation.
+		incremental.WithParallelism(2),
+	)
+
+	result, _, err := incremental.Run(ctx, exec, Fanout{Depth: 4})
+	require.NoError(t, err)
+	assert.Equal(t, 1*2*3*4, result[0].Value)
+	assert.Equal(t, []string{
+		"incremental_test.Fanout{Depth:4, Level:0, Index:0}",
+		"incremental_test.Fanout{Depth:4, Level:1, Index:0}",
+		"incremental_test.Fanout{Depth:4, Level:2, Index:0}",
+		"incremental_test.Fanout{Depth:4, Level:2, Index:1}",
+		"incremental_test.Fanout{Depth:4, Level:3, Index:0}",
+		"incremental_test.Fanout{Depth:4, Level:3, Index:1}",
+		"incremental_test.Fanout{Depth:4, Level:3, Index:2}",
+		"incremental_test.Fanout{Depth:4, Level:4, Index:0}",
+		"incremental_test.Fanout{Depth:4, Level:4, Index:1}",
+		"incremental_test.Fanout{Depth:4, Level:4, Index:2}",
+		"incremental_test.Fanout{Depth:4, Level:4, Index:3}",
+	}, exec.Keys())
+}

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Set this to true to enable debug printing.
-const debugIncremental = true
+const debugIncremental = false
 
 // ErrNilQuery is set as the Fatal error for the result of executing a nil
 // query.

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -34,10 +34,7 @@ import (
 // Set this to true to enable debug printing.
 const debugIncremental = false
 
-// ErrNilQuery is set as the Fatal error for the result of executing a nil
-// query.
 var (
-	ErrNilQuery   = errors.New("incremental: nil query value")
 	errBadAcquire = errors.New("called acquire() while holding the semaphore")
 	errBadRelease = errors.New("called release() without holding the semaphore")
 )
@@ -228,11 +225,6 @@ func Resolve[T any](caller *Task, queries ...Query[T]) (results []Result[T], exp
 	var needWait bool
 	schedule := func(i int, runNow bool) {
 		q := AsAny(queries[i]) // This will also cache the result of q.Key() for us.
-
-		if q == nil {
-			results[i].Fatal = ErrNilQuery
-			return
-		}
 
 		deps[i] = caller.exec.getTask(q.Key())
 		async := deps[i].start(caller, q, runNow, func(r *result) {

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -228,7 +228,7 @@ func Resolve[T any](caller *Task, queries ...Query[T]) (results []Result[T], exp
 	}
 
 	// Schedule all but the first query to run asynchronously.
-	for i := range len(queries) {
+	for i := range queries {
 		if i > 0 {
 			schedule(i, false)
 		}
@@ -465,14 +465,14 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 		}
 
 		return t.waitUntilDone(caller)
-	} else {
-		// Try to become the leader (the task responsible for computing the result).
-		output = &result{done: make(chan struct{})}
-		if !t.result.CompareAndSwap(nil, output) {
-			// We failed to become the executor, so we're gonna go to sleep
-			// until it's done.
-			return t.waitUntilDone(caller)
-		}
+	}
+
+	// Try to become the leader (the task responsible for computing the result).
+	output = &result{done: make(chan struct{})}
+	if !t.result.CompareAndSwap(nil, output) {
+		// We failed to become the executor, so we're gonna go to sleep
+		// until it's done.
+		return t.waitUntilDone(caller)
 	}
 
 	callee := &Task{


### PR DESCRIPTION
This PR improves the tests and robustness of the `incremental` query system, by adding checks to catch potential concurrency bugs, and validation that various error conditions actually do what they're documented to do.

This PR also implements an optimization for reducing the number of goroutines that need to be spawned for a particular batch of tasks.