### PR TITLE
Reorganize `ir.Context` a bit

### DIFF
--- a/experimental/ir/export_test.go
+++ b/experimental/ir/export_test.go
@@ -28,5 +28,5 @@ func NewFile(s *Session, path string) File {
 }
 
 func GetImports(f File) *Imports {
-	return &f.Context().file.imports
+	return &f.Context().imports
 }

--- a/experimental/ir/ir_field.go
+++ b/experimental/ir/ir_field.go
@@ -183,7 +183,7 @@ func wrapField(c *Context, r ref[rawField]) Field {
 
 	file := c.File()
 	if r.file > 0 {
-		file = c.file.imports.files[r.file-1]
+		file = c.imports.files[r.file-1]
 	}
 
 	return Field{

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -30,28 +30,9 @@ import (
 //
 // Unlike [ast.Context], this Context is shared by many files.
 type Context struct {
-	session *Session
 	ast     ast.File
-
-	// The path for this file. This need not be what ast.Span() reports, because
-	// it has been passed through filepath.Clean() and filepath.ToSlash() first,
-	// to normalize it.
-	path intern.ID
-
-	syntax syntax.Syntax
-	pkg    intern.ID
-
-	imports imports
-
-	types            []arena.Pointer[rawType]
-	topLevelTypesEnd int // Index of the last top-level type in types.
-
-	extns            []arena.Pointer[rawField]
-	topLevelExtnsEnd int // Index of the last top-level extension in extns.
-
-	options []arena.Pointer[rawOption]
-
-	arenas struct {
+	session *Session
+	arenas  struct {
 		types    arena.Arena[rawType]
 		fields   arena.Arena[rawField]
 		oneofs   arena.Arena[rawOneof]
@@ -59,6 +40,15 @@ type Context struct {
 		messages arena.Arena[rawMessageValue]
 		arrays   arena.Arena[[]rawValue]
 	}
+	types            []arena.Pointer[rawType]
+	extns            []arena.Pointer[rawField]
+	options          []arena.Pointer[rawOption]
+	imports          imports
+	syntax           syntax.Syntax
+	topLevelTypesEnd int
+	topLevelExtnsEnd int
+	path             intern.ID
+	pkg              intern.ID
 }
 
 type withContext = internal.With[*Context]

--- a/experimental/ir/ir_type.go
+++ b/experimental/ir/ir_type.go
@@ -72,7 +72,7 @@ var primitiveCtx = func() *Context {
 			panic(fmt.Sprintf("IR initialization error: %d != %d; this is a bug in protocompile", ptr, n))
 		}
 
-		ctx.file.types = append(ctx.file.types, ptr)
+		ctx.types = append(ctx.types, ptr)
 		return true
 	})
 	return ctx
@@ -266,7 +266,7 @@ func wrapType(c *Context, r ref[rawType]) Type {
 	case r.file == -1:
 		ctx = primitiveCtx
 	case r.file > 0:
-		ctx = c.file.imports.files[r.file-1].Context()
+		ctx = c.imports.files[r.file-1].Context()
 	default:
 		ctx = c.File().Context()
 	}

--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -37,7 +37,7 @@ type Session struct {
 func (s *Session) Lower(source ast.File, errs *report.Report, importer Importer) (file File, ok bool) {
 	prior := len(errs.Diagnostics)
 	c := &Context{session: s}
-	c.file.ast = source
+	c.ast = source
 
 	lower(c, errs, importer)
 

--- a/experimental/ir/lower_imports.go
+++ b/experimental/ir/lower_imports.go
@@ -56,7 +56,7 @@ func buildImports(f File, r *report.Report, importer Importer) {
 			continue
 		}
 
-		c.file.imports.AddDirect(Import{
+		c.imports.AddDirect(Import{
 			File:   file,
 			Public: imp.IsPublic(),
 			Weak:   imp.IsWeak(),
@@ -65,7 +65,7 @@ func buildImports(f File, r *report.Report, importer Importer) {
 
 	// Having found all of the imports that are not cyclic, we now need to pull
 	// in all of *their* transitive imports.
-	c.file.imports.Recurse(dedup)
+	c.imports.Recurse(dedup)
 }
 
 // ErrCycle is an error indicating that a cycle has occurred during processing.

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -16,13 +16,13 @@ package ir
 
 import (
 	"path/filepath"
+	"slices"
 
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
-	"golang.org/x/exp/slices"
 )
 
 // walker is the state struct for the AST-walking logic.

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/internal"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
+	"golang.org/x/exp/slices"
 )
 
 // walker is the state struct for the AST-walking logic.
@@ -140,40 +141,41 @@ func (w *walker) recurse(decl ast.DeclAny, parent any) {
 }
 
 func (w *walker) newType(def ast.DeclDef, parent any) Type {
+	c := w.Context()
 	parentTy := extractParentType(parent)
 	name := def.Name().AsIdent().Name()
 	fqn := w.fullname(parentTy, name)
 
-	raw := w.Context().arenas.types.New(rawType{
+	raw := c.arenas.types.NewCompressed(rawType{
 		def:  def,
-		name: w.Context().session.intern.Intern(name),
-		fqn:  w.Context().session.intern.Intern(fqn),
+		name: c.session.intern.Intern(name),
+		fqn:  c.session.intern.Intern(fqn),
 	})
 
 	if !parentTy.IsZero() {
-		parentTy.raw.nested = append(parentTy.raw.nested,
-			w.Context().arenas.types.Compress(raw),
-		)
+		parentTy.raw.nested = append(parentTy.raw.nested, raw)
+		c.types = append(c.types, raw)
 	} else {
-		c := w.Context()
-		c.types = append(c.types, c.arenas.types.Compress(raw))
+		c.types = slices.Insert(c.types, c.topLevelTypesEnd, raw)
+		c.topLevelTypesEnd++
 	}
 
-	return Type{internal.NewWith(w.Context()), raw}
+	return Type{internal.NewWith(w.Context()), c.arenas.types.Deref(raw)}
 }
 
 func (w *walker) newField(def ast.DeclDef, parent any) Field {
+	c := w.Context()
 	parentTy := extractParentType(parent)
 	name := def.Name().AsIdent().Name()
 	fqn := w.fullname(parentTy, name)
 
-	id := w.Context().arenas.fields.NewCompressed(rawField{
+	id := c.arenas.fields.NewCompressed(rawField{
 		def:    def,
-		name:   w.Context().session.intern.Intern(name),
-		fqn:    w.Context().session.intern.Intern(fqn),
-		parent: w.Context().arenas.types.Compress(parentTy.raw),
+		name:   c.session.intern.Intern(name),
+		fqn:    c.session.intern.Intern(fqn),
+		parent: c.arenas.types.Compress(parentTy.raw),
 	})
-	raw := w.Context().arenas.fields.Deref(id)
+	raw := c.arenas.fields.Deref(id)
 
 	switch parent := parent.(type) {
 	case oneof:
@@ -187,10 +189,12 @@ func (w *walker) newField(def ast.DeclDef, parent any) Field {
 		parentTy.raw.fields = append(parentTy.raw.fields, id)
 
 		if _, ok := parent.(extend); !ok {
+			c.extns = append(c.extns, id)
 			parentTy.raw.fieldsExtnStart++
 		}
 	} else if _, ok := parent.(extend); !ok {
-		w.Context().extns = append(w.Context().extns, id)
+		c.extns = slices.Insert(c.extns, c.topLevelExtnsEnd, id)
+		c.topLevelExtnsEnd++
 	}
 
 	return Field{internal.NewWith(w.Context()), raw}

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -155,8 +155,8 @@ func (w *walker) newType(def ast.DeclDef, parent any) Type {
 			w.Context().arenas.types.Compress(raw),
 		)
 	} else {
-		file := &w.Context().file
-		file.types = append(file.types, w.Context().arenas.types.Compress(raw))
+		c := w.Context()
+		c.types = append(c.types, c.arenas.types.Compress(raw))
 	}
 
 	return Type{internal.NewWith(w.Context()), raw}
@@ -190,8 +190,7 @@ func (w *walker) newField(def ast.DeclDef, parent any) Field {
 			parentTy.raw.fieldsExtnStart++
 		}
 	} else if _, ok := parent.(extend); !ok {
-		file := &w.Context().file
-		file.extns = append(file.extns, id)
+		w.Context().extns = append(w.Context().extns, id)
 	}
 
 	return Field{internal.NewWith(w.Context()), raw}


### PR DESCRIPTION
This change:

1. Removes the `ir.Context.file` struct. It was providing relatively little organizational value.
2. Makes the type and extension slices contain all types and extensions in the file.