### PR TITLE
Add IR tests, with a focus on imports

### DIFF
--- a/experimental/ast/decl_file.go
+++ b/experimental/ast/decl_file.go
@@ -59,12 +59,12 @@ func (f File) Package() DeclPackage {
 }
 
 // Imports returns an iterator over this file's import declarations.
-func (f File) Imports() iter.Seq2[int, DeclImport] {
-	return iterx.FilterMap2(seq.All(f.Decls()), func(i int, d DeclAny) (int, DeclImport, bool) {
+func (f File) Imports() iter.Seq[DeclImport] {
+	return iterx.FilterMap(seq.Values(f.Decls()), func(d DeclAny) (DeclImport, bool) {
 		if imp := d.AsImport(); !imp.IsZero() {
-			return i, imp, true
+			return imp, true
 		}
-		return 0, DeclImport{}, false
+		return DeclImport{}, false
 	})
 }
 

--- a/experimental/incremental/queries/ast.go
+++ b/experimental/incremental/queries/ast.go
@@ -47,7 +47,11 @@ func (a AST) Key() any {
 func (a AST) Execute(t *incremental.Task) (ast.File, error) {
 	t.Report().Options.Stage += stageAST
 
-	r, err := incremental.Resolve(t, File(a))
+	r, err := incremental.Resolve(t, File{
+		Opener:      a.Opener,
+		Path:        a.Path,
+		ReportError: true,
+	})
 	if err != nil {
 		return ast.File{}, err
 	}

--- a/experimental/incremental/queries/ast.go
+++ b/experimental/incremental/queries/ast.go
@@ -21,8 +21,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/source"
 )
 
-// AST is an [incremental.Query] for the contents of a file as provided
-// by a [source.Opener].
+// AST is an [incremental.Query] for the AST of a Protobuf file.
 //
 // AST queries with different Openers are considered distinct.
 type AST struct {

--- a/experimental/incremental/queries/ir.go
+++ b/experimental/incremental/queries/ir.go
@@ -64,7 +64,7 @@ func (i IR) Execute(t *incremental.Task) (ir.File, error) {
 
 	// Resolve all of the imports in the AST.
 	var queries []incremental.Query[ir.File]
-	var errors []error
+	var errors []error //nolint:prealloc // False positive.
 	for decl := range file.Imports() {
 		path, ok := decl.ImportPath().AsLiteral().AsString()
 		// Not filepath.ToSlash, since this conversion is file-system independent.

--- a/experimental/incremental/queries/ir.go
+++ b/experimental/incremental/queries/ir.go
@@ -1,0 +1,134 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import (
+	"strings"
+
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/incremental"
+	"github.com/bufbuild/protocompile/experimental/ir"
+	"github.com/bufbuild/protocompile/experimental/source"
+)
+
+// AST is an [incremental.Query] for the contents of a file as provided
+// by a [source.Opener].
+//
+// AST queries with different Openers are considered distinct.
+type IR struct {
+	source.Opener // Must be comparable.
+	*ir.Session
+	Path string
+
+	// Used for tracking if this IR request was triggered by an import, for
+	// constructing a cycle error. This is not part of the query's key.
+	request ast.DeclImport
+}
+
+var _ incremental.Query[ir.File] = IR{}
+
+// Key implements [incremental.Query].
+func (i IR) Key() any {
+	type key struct {
+		o    source.Opener
+		s    *ir.Session
+		path string
+	}
+	return key{i.Opener, i.Session, i.Path}
+}
+
+// Execute implements [incremental.Query].
+func (i IR) Execute(t *incremental.Task) (ir.File, error) {
+	t.Report().Options.Stage += stageIR
+
+	r, err := incremental.Resolve(t, AST{
+		Opener: i.Opener,
+		Path:   i.Path,
+	})
+	if err != nil {
+		return ir.File{}, err
+	}
+	file := r[0].Value
+
+	// Resolve all of the imports in the AST.
+	var queries []incremental.Query[ir.File]
+	var errors []error
+	for decl := range file.Imports() {
+		path, ok := decl.ImportPath().AsLiteral().AsString()
+		// Not filepath.ToSlash, since this conversion is file-system independent.
+		path = strings.ReplaceAll(path, `\`, `/`)
+
+		if !ok { // Already legalized in parser.legalizeImport()
+			continue
+		}
+
+		r, err := incremental.Resolve(t, File{
+			Opener:      i.Opener,
+			Path:        path,
+			ReportError: false,
+		})
+		if err != nil {
+			return ir.File{}, err
+		}
+
+		err = r[0].Fatal
+		errors = append(errors, err)
+		if err == nil {
+			queries = append(queries, IR{
+				Opener:  i.Opener,
+				Session: i.Session,
+				Path:    path,
+				request: decl,
+			})
+		} else {
+			queries = append(queries, incremental.ZeroQuery[ir.File]{})
+		}
+	}
+
+	imports, err := incremental.Resolve(t, queries...)
+	if err != nil {
+		return ir.File{}, err
+	}
+
+	importer := func(n int, _ string, _ ast.DeclImport) (ir.File, error) {
+		result := imports[n]
+		switch err := result.Fatal.(type) {
+		case nil:
+			return result.Value, errors[n]
+
+		case *incremental.ErrCycle[*incremental.AnyQuery]:
+			// We need to walk the cycle and extract which imports are
+			// responsible for the failure.
+			cyc := new(incremental.ErrCycle[ast.DeclImport])
+			for _, q := range err.Cycle {
+				irq, ok := incremental.AsTyped[IR](q)
+				if !ok {
+					continue
+				}
+				if !irq.request.IsZero() {
+					cyc.Cycle = append(cyc.Cycle, irq.request)
+				}
+			}
+
+			return ir.File{}, cyc
+
+		default:
+			return ir.File{}, err
+		}
+	}
+
+	ir, _ := i.Session.Lower(file, t.Report(), importer)
+	return ir, nil
+}

--- a/experimental/incremental/queries/ir.go
+++ b/experimental/incremental/queries/ir.go
@@ -15,8 +15,6 @@
 package queries
 
 import (
-	"strings"
-
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/incremental"
 	"github.com/bufbuild/protocompile/experimental/ir"
@@ -67,8 +65,7 @@ func (i IR) Execute(t *incremental.Task) (ir.File, error) {
 	var errors []error //nolint:prealloc // False positive.
 	for decl := range file.Imports() {
 		path, ok := decl.ImportPath().AsLiteral().AsString()
-		// Not filepath.ToSlash, since this conversion is file-system independent.
-		path = strings.ReplaceAll(path, `\`, `/`)
+		path = ir.CanonicalizeFilePath(path)
 
 		if !ok { // Already legalized in parser.legalizeImport()
 			continue

--- a/experimental/incremental/query.go
+++ b/experimental/incremental/query.go
@@ -88,6 +88,23 @@ func (e *ErrPanic) Error() string {
 	)
 }
 
+// ZeroQuery is a [Query] that produces the zero value of T.
+//
+// This query is useful for cases where you are building a slice of queries out
+// of some input slice, but some of the elements of that slice are invalid. This
+// can be used as a "placeholder" query so that indices of the input slice
+// match the indices of the result slice returned by [Resolve].
+type ZeroQuery[T any] struct{}
+
+// Key implements [Query].
+func (q ZeroQuery[T]) Key() any { return q }
+
+// Execute implements [Query].
+func (q ZeroQuery[T]) Execute(t *Task) (T, error) {
+	var zero T
+	return zero, nil
+}
+
 // AnyQuery is a [Query] that has been type-erased.
 type AnyQuery struct {
 	actual, key any

--- a/experimental/incremental/query.go
+++ b/experimental/incremental/query.go
@@ -16,7 +16,8 @@ package incremental
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/bufbuild/protocompile/experimental/internal/cycle"
 )
 
 // Query represents an incremental compilation query.
@@ -50,25 +51,7 @@ type Query[T any] interface {
 }
 
 // ErrCycle is an error due to cyclic dependencies.
-//
-// When returned by [Resolve] or [Run], this will be *ErrCycle[*AnyQuery].
-type ErrCycle[T any] struct {
-	// The offending cycle. The first and last entries will be equal.
-	Cycle []T
-}
-
-// Error implements [error].
-func (e *ErrCycle[T]) Error() string {
-	var buf strings.Builder
-	buf.WriteString("cycle detected: ")
-	for i, q := range e.Cycle {
-		if i != 0 {
-			buf.WriteString(" -> ")
-		}
-		fmt.Fprintf(&buf, "%#v", q)
-	}
-	return buf.String()
-}
+type ErrCycle = cycle.Error[*AnyQuery]
 
 // ErrPanic is returned by [Run] if any of the queries it executes panic.
 // This error is used to cancel the [context.Context] that governs the call to

--- a/experimental/incremental/query.go
+++ b/experimental/incremental/query.go
@@ -99,7 +99,7 @@ type ZeroQuery[T any] struct{}
 func (q ZeroQuery[T]) Key() any { return q }
 
 // Execute implements [Query].
-func (q ZeroQuery[T]) Execute(t *Task) (T, error) {
+func (q ZeroQuery[T]) Execute(_ *Task) (T, error) {
 	var zero T
 	return zero, nil
 }

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -415,13 +415,13 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 
 		// Check for a potential cycle. This is only possible if output is
 		// pending; if it isn't, it can't be in our history path.
-		var cycle *ErrCycle[*AnyQuery]
+		var cycle *ErrCycle
 		for node := range caller.path.Walk() {
 			if node.Query.Key() != q.Key() {
 				continue
 			}
 
-			cycle = new(ErrCycle[*AnyQuery])
+			cycle = new(ErrCycle)
 
 			// Re-walk the list to collect the cycle itself.
 			for node2 := range caller.path.Walk() {

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -415,13 +415,13 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 
 		// Check for a potential cycle. This is only possible if output is
 		// pending; if it isn't, it can't be in our history path.
-		var cycle *ErrCycle
+		var cycle *ErrCycle[*AnyQuery]
 		for node := range caller.path.Walk() {
 			if node.Query.Key() != q.Key() {
 				continue
 			}
 
-			cycle = new(ErrCycle)
+			cycle = new(ErrCycle[*AnyQuery])
 
 			// Re-walk the list to collect the cycle itself.
 			for node2 := range caller.path.Walk() {

--- a/experimental/internal/cycle/cycle.go
+++ b/experimental/internal/cycle/cycle.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package cycle contains internal helpers for dealing with dependency cycles.
 package cycle
 

--- a/experimental/internal/cycle/cycle.go
+++ b/experimental/internal/cycle/cycle.go
@@ -1,0 +1,26 @@
+// Package cycle contains internal helpers for dealing with dependency cycles.
+package cycle
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrCycle is an error due to cyclic dependencies.
+type Error[T any] struct {
+	// The offending cycle. The first and last entries will be equal.
+	Cycle []T
+}
+
+// Error implements [error].
+func (e *Error[T]) Error() string {
+	var buf strings.Builder
+	buf.WriteString("cycle detected: ")
+	for i, q := range e.Cycle {
+		if i != 0 {
+			buf.WriteString(" -> ")
+		}
+		fmt.Fprintf(&buf, "%#v", q)
+	}
+	return buf.String()
+}

--- a/experimental/ir/ir_imports.go
+++ b/experimental/ir/ir_imports.go
@@ -17,7 +17,9 @@ package ir
 import (
 	"slices"
 
+	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/internal/ext/mapsx"
 	"github.com/bufbuild/protocompile/internal/intern"
 )
 
@@ -105,10 +107,10 @@ func (i *imports) AddDirect(imp Import) {
 
 // Recurse updates the import table to incorporate the transitive imports of
 // each import.
-func (i *imports) Recurse(dedup intern.Set) {
+func (i *imports) Recurse(dedup intern.Map[ast.DeclImport]) {
 	for file := range seq.Values(i.Directs()) {
 		for imp := range seq.Values(file.TransitiveImports()) {
-			if !dedup.AddID(imp.File.InternedPath()) {
+			if !mapsx.AddZero(dedup, imp.InternedPath()) {
 				continue
 			}
 

--- a/experimental/ir/ir_imports_test.go
+++ b/experimental/ir/ir_imports_test.go
@@ -20,8 +20,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ir"
 	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/internal/ext/mapsx"
 	"github.com/bufbuild/protocompile/internal/intern"
 )
 
@@ -110,9 +112,9 @@ func buildFile(
 	file := ir.NewFile(session, path)
 	table := ir.GetImports(file)
 
-	dedup := make(intern.Set)
+	dedup := make(intern.Map[ast.DeclImport])
 	for _, imp := range imports {
-		if !dedup.AddID(imp.File.InternedPath()) {
+		if !mapsx.AddZero(dedup, imp.File.InternedPath()) {
 			continue
 		}
 

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ir_test
 
 import (
@@ -6,6 +20,12 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"gopkg.in/yaml.v3"
 
 	"github.com/bufbuild/protocompile/experimental/incremental"
 	"github.com/bufbuild/protocompile/experimental/incremental/queries"
@@ -16,11 +36,6 @@ import (
 	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 	"github.com/bufbuild/protocompile/internal/golden"
 	"github.com/bufbuild/protocompile/internal/prototest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/descriptorpb"
-	"gopkg.in/yaml.v3"
 )
 
 // Test is the type that a test case for the compiler is deserialized from.

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -1,0 +1,107 @@
+package ir_test
+
+import (
+	"context"
+	"maps"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
+	"github.com/bufbuild/protocompile/experimental/incremental/queries"
+	"github.com/bufbuild/protocompile/experimental/ir"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/source"
+	"github.com/bufbuild/protocompile/internal/ext/iterx"
+	"github.com/bufbuild/protocompile/internal/ext/slicesx"
+	"github.com/bufbuild/protocompile/internal/golden"
+	"github.com/bufbuild/protocompile/internal/prototest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"gopkg.in/yaml.v3"
+)
+
+// Test is the type that a test case for the compiler is deserialized from.
+type Test struct {
+	Files []File `yaml:"files"`
+}
+
+type File struct {
+	Path   string `yaml:"path"`
+	Text   string `yaml:"text"`
+	Import bool   `yaml:"import"`
+}
+
+func TestIR(t *testing.T) {
+	t.Parallel()
+
+	corpus := golden.Corpus{
+		Root:       "testdata",
+		Refresh:    "PROTOCOMPILE_REFRESH",
+		Extensions: []string{"proto", "proto.yaml"},
+		Outputs: []golden.Output{
+			{Extension: "fds.yaml"},
+			{Extension: "stderr.txt"},
+		},
+	}
+
+	corpus.Run(t, func(t *testing.T, path, text string, outputs []string) {
+		var test Test
+		switch filepath.Ext(path) {
+		case ".proto":
+			test.Files = []File{{Path: path, Text: text}}
+		case ".yaml":
+			require.NoError(t, yaml.Unmarshal([]byte(text), &test))
+		}
+
+		files := source.NewMap(maps.Collect(iterx.Map1To2(
+			slices.Values(test.Files),
+			func(f File) (string, string) {
+				return f.Path, f.Text
+			},
+		)))
+
+		exec := incremental.New(
+			incremental.WithParallelism(1),
+			incremental.WithReportOptions(report.Options{Tracing: 10}),
+		)
+
+		session := new(ir.Session)
+		queries := slices.Collect(iterx.FilterMap(
+			slices.Values(test.Files),
+			func(f File) (incremental.Query[ir.File], bool) {
+				if f.Import {
+					return nil, false
+				}
+				return queries.IR{
+					Opener:  files,
+					Session: session,
+					Path:    f.Path,
+				}, true
+			},
+		))
+
+		results, r, err := incremental.Run(context.Background(), exec, queries...)
+		require.NoError(t, err)
+
+		stderr, _, _ := report.Renderer{
+			Colorize:  true,
+			ShowDebug: true,
+		}.RenderString(r)
+		t.Log(stderr)
+		outputs[1], _, _ = report.Renderer{}.RenderString(r)
+		assert.NotContains(t, outputs[1], "internal compiler error")
+
+		irs := slicesx.Transform(results, func(r incremental.Result[ir.File]) ir.File { return r.Value })
+		irs = slices.DeleteFunc(irs, ir.File.IsZero)
+		bytes, err := ir.DescriptorSetBytes(irs)
+		require.NoError(t, err)
+
+		fds := new(descriptorpb.FileDescriptorSet)
+		require.NoError(t, proto.Unmarshal(bytes, fds))
+
+		outputs[0] = prototest.ToYAML(fds, prototest.ToYAMLOptions{})
+	})
+}

--- a/experimental/ir/ir_type.go
+++ b/experimental/ir/ir_type.go
@@ -110,7 +110,7 @@ func (t Type) IsMessage() bool {
 func (t Type) IsEnum() bool {
 	// All of the predeclared types have isEnum set to false, so we don't
 	// need to check for them here.
-	return t.raw.isEnum
+	return !t.IsZero() && t.raw.isEnum
 }
 
 // Predeclared returns the predeclared type that this Type corresponds to, if any.

--- a/experimental/ir/lower_imports.go
+++ b/experimental/ir/lower_imports.go
@@ -15,39 +15,61 @@
 package ir
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"strconv"
+	"strings"
 
 	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/incremental"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
 	"github.com/bufbuild/protocompile/internal/intern"
 )
 
-// Importer is a function that resolves the nth import of an [ast.File] being
+// Importer is a callback to resolve the imports of an [ast.File] being
 // lowered.
 //
-// If a cycle is encountered, returns the cycle of import statements that caused
-// it, starting from decl and ending when the currently lowered file is
-// imported.
+// If a cycle is encountered, should return an *[incremental.ErrCycle][[ast.DeclImport]],
+// starting from decl and ending when the currently lowered file is imported.
 //
 // [Session.Lower] may not call this function on all imports; only those for
 // which it needs the caller to resolve a [File] for it.
-type Importer func(n int, path string, decl ast.DeclImport) (File, ErrCycle[ast.DeclImport])
+type Importer func(n int, path string, decl ast.DeclImport) (File, error)
 
 // buildImports builds the transitive imports table.
 func buildImports(f File, r *report.Report, importer Importer) {
 	c := f.Context()
-	dedup := make(intern.Set, iterx.Count2(f.AST().Imports()))
+	dedup := make(intern.Set, iterx.Count(f.AST().Imports()))
 
-	for i, imp := range f.AST().Imports() {
+	for i, imp := range iterx.Enumerate(f.AST().Imports()) {
 		path, ok := imp.ImportPath().AsLiteral().AsString()
 		if !ok {
 			continue // Already legalized in parser.legalizeImport()
 		}
+		path = caonicalizeImportPath(path, r, imp)
+		if path == "" {
+			continue
+		}
 
-		file, cycle := importer(i, path, imp)
-		if cycle != nil {
-			diagnoseCycle(r, path, cycle)
+		file, err := importer(i, path, imp)
+		switch err := err.(type) {
+		case nil:
+		case *incremental.ErrCycle[ast.DeclImport]:
+			diagnoseCycle(r, err)
+			continue
+		default:
+			if errors.Is(err, fs.ErrNotExist) {
+				r.Errorf("imported file does not exist").Apply(
+					report.Snippetf(imp, "imported here"),
+				)
+			} else {
+
+				r.Errorf("could not open imported file: %v", err).Apply(
+					report.Snippetf(imp, "imported here"),
+				)
+			}
 			continue
 		}
 
@@ -68,29 +90,72 @@ func buildImports(f File, r *report.Report, importer Importer) {
 	c.imports.Recurse(dedup)
 }
 
-// ErrCycle is an error indicating that a cycle has occurred during processing.
-//
-// The first and last elements of this slice should be equal.
-type ErrCycle[T any] []T
-
 // diagnoseCycle generates a diagnostic for an import cycle, showing each
 // import contributing to the cycle in turn.
-func diagnoseCycle(r *report.Report, path string, cycle ErrCycle[ast.DeclImport]) {
-	err := r.Errorf("encountered cycle while importing %q", path)
+func diagnoseCycle(r *report.Report, cycle *incremental.ErrCycle[ast.DeclImport]) {
+	path, _ := cycle.Cycle[0].ImportPath().AsLiteral().AsString()
+	err := r.Errorf("detected cyclic import while importing %q", path)
 
-	for i, imp := range cycle {
+	for i, imp := range cycle.Cycle {
 		var message string
 		path, ok := imp.ImportPath().AsLiteral().AsString()
 		if ok {
 			switch i {
 			case 0:
 				message = "imported here"
-			case len(cycle) - 1:
-				message = fmt.Sprintf("which imports %q, completing the cycle", path)
+			case len(cycle.Cycle) - 1:
+				message = fmt.Sprintf("...which imports %q, completing the cycle", path)
 			default:
-				message = fmt.Sprintf("which imports %q", path)
+				message = fmt.Sprintf("...which imports %q...", path)
 			}
 		}
 		err.Apply(report.Snippetf(imp, "%v", message))
 	}
+}
+
+// caonicalizeImportPath canonicalizes the path of an import declaration.
+//
+// This will generate diagnostics for invalid paths. Returns "" for paths that
+// cannot be made canonical.
+func caonicalizeImportPath(path string, r *report.Report, decl ast.DeclImport) string {
+	if path == "" {
+		r.Errorf("import path cannot be empty").Apply(
+			report.Snippet(decl.ImportPath()),
+		)
+		return ""
+	}
+
+	orig := path
+	// Not filepath.ToSlash, since this conversion is file-system independent.
+	path = strings.ReplaceAll(path, `\`, `/`)
+	if orig != path {
+		r.Errorf("import path cannot use `\\` as a path separator").Apply(
+			report.Snippetf(decl.ImportPath(), "this path begins with a `%c`", path[0]),
+			report.SuggestEdits(decl.ImportPath(), "use `/` as the separator instead", report.Edit{
+				Start: 0, End: decl.ImportPath().Span().Len(),
+				Replace: strconv.Quote(path),
+			}),
+			report.Notef("this restriction also applies when compiling on a non-Windows system"),
+		)
+	}
+
+	isLetter := func(b byte) bool {
+		return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+	}
+
+	if len(path) >= 2 && isLetter(path[0]) && path[1] == ':' {
+		r.Warnf("import path appears to begin with the Windows drive prefix `%s`", path[:2]).Apply(
+			report.Snippet(decl.ImportPath()),
+			report.Notef("this is not an error, because `protoc` accepts it, but may result in unexpected behavior on Windows"),
+		)
+	}
+
+	if strings.HasPrefix(path, "/") {
+		r.Errorf("import path cannot be absolute").Apply(
+			report.Snippetf(decl.ImportPath(), "this path begins with a `%c`", path[0]),
+		)
+		return ""
+	}
+
+	return path
 }

--- a/experimental/ir/lower_imports.go
+++ b/experimental/ir/lower_imports.go
@@ -65,7 +65,6 @@ func buildImports(f File, r *report.Report, importer Importer) {
 					report.Snippetf(imp, "imported here"),
 				)
 			} else {
-
 				r.Errorf("could not open imported file: %v", err).Apply(
 					report.Snippetf(imp, "imported here"),
 				)

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -15,7 +15,6 @@
 package ir
 
 import (
-	"path/filepath"
 	"slices"
 
 	"github.com/bufbuild/protocompile/experimental/ast"
@@ -40,9 +39,8 @@ type walker struct {
 func (w *walker) walk() {
 	c := w.Context()
 
-	path := filepath.Clean(w.AST().Span().File.Path())
-	path = filepath.ToSlash(path)
-	c.path = c.session.intern.Intern(path)
+	path := w.AST().Span().File.Path()
+	c.path = c.session.intern.Intern(CanonicalizeFilePath(path))
 
 	if pkg := w.AST().Package(); !pkg.IsZero() {
 		c.pkg = c.session.intern.Intern(pkg.Path().Canonicalized())

--- a/experimental/ir/testdata/imports/canonical.proto.yaml
+++ b/experimental/ir/testdata/imports/canonical.proto.yaml
@@ -18,10 +18,12 @@ files:
     syntax = "proto2";
     package foo.bar;
 
+    import "nested/path.proto";
     import "nested//path.proto";
     import "./local.proto";
-    import "nested/../local2.proto";
-    import "../up.proto"
+    import "local.proto";
+    import "fake/../local.proto";
+    import "../up.proto";
 
 - path: "nested/path.proto"
   import: true
@@ -30,12 +32,6 @@ files:
     package foo.bar;
 
 - path: "local.proto"
-  import: true
-  text: |
-    syntax = "proto2";
-    package foo.bar;
-
-- path: "local2.proto"
   import: true
   text: |
     syntax = "proto2";

--- a/experimental/ir/testdata/imports/canonical.proto.yaml
+++ b/experimental/ir/testdata/imports/canonical.proto.yaml
@@ -13,25 +13,36 @@
 # limitations under the License.
 
 files:
-- path: "a.proto"
+- path: "main.proto"
   text: |
     syntax = "proto2";
-    package buf.test;
+    package foo.bar;
 
-    import "b.proto";
+    import "nested//path.proto";
+    import "./local.proto";
+    import "nested/../local2.proto";
+    import "../up.proto"
 
-- path: "b.proto"
+- path: "nested/path.proto"
   import: true
   text: |
     syntax = "proto2";
-    package buf.test;
+    package foo.bar;
 
-    import "c.proto";
-
-- path: "c.proto"
+- path: "local.proto"
   import: true
   text: |
     syntax = "proto2";
-    package buf.test;
+    package foo.bar;
 
-    import "a.proto";
+- path: "local2.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package foo.bar;
+
+- path: "../up.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package foo.bar;

--- a/experimental/ir/testdata/imports/canonical.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/canonical.proto.yaml.fds.yaml
@@ -1,9 +1,7 @@
 file:
-  - { name: "../up.proto", package: "foo.bar", syntax: "proto2" }
-  - { name: "local2.proto", package: "foo.bar", syntax: "proto2" }
   - { name: "local.proto", package: "foo.bar", syntax: "proto2" }
   - { name: "nested/path.proto", package: "foo.bar", syntax: "proto2" }
   - name: "main.proto"
     package: "foo.bar"
-    dependency: ["../up.proto", "local.proto", "local2.proto", "nested/path.proto"]
+    dependency: ["local.proto", "nested/path.proto"]
     syntax: "proto2"

--- a/experimental/ir/testdata/imports/canonical.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/canonical.proto.yaml.fds.yaml
@@ -1,0 +1,9 @@
+file:
+  - { name: "../up.proto", package: "foo.bar", syntax: "proto2" }
+  - { name: "local2.proto", package: "foo.bar", syntax: "proto2" }
+  - { name: "local.proto", package: "foo.bar", syntax: "proto2" }
+  - { name: "nested/path.proto", package: "foo.bar", syntax: "proto2" }
+  - name: "main.proto"
+    package: "foo.bar"
+    dependency: ["../up.proto", "local.proto", "local2.proto", "nested/path.proto"]
+    syntax: "proto2"

--- a/experimental/ir/testdata/imports/canonical.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/canonical.proto.yaml.stderr.txt
@@ -1,40 +1,68 @@
-warning: import path should be canonicalized
-  --> main.proto:4:8
+error: file imported multiple times
+  --> main.proto:5:1
    |
- 4 | import "nested//path.proto";
-   |        ^^^^^^^^^^^^^^^^^^^^ imported here
-  help: replace it with its canonical equivalent
-   |
- 4 | - import "nested//path.proto";
- 4 | + import "nested/path.proto";
-   |
+ 4 | import "nested/path.proto";
+   | --------------------------- first imported here
+ 5 | import "nested//path.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: both paths are equivalent to "nested/path.proto"
 
-warning: import path should be canonicalized
+error: import path must not contain `.`, `..`, or repeated separators
   --> main.proto:5:8
    |
- 5 | import "./local.proto";
-   |        ^^^^^^^^^^^^^^^ imported here
-  help: replace it with its canonical equivalent
+ 5 | import "nested//path.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^ imported here
+  help: canonicalize this path
    |
- 5 | - import "./local.proto";
- 5 | + import "local.proto";
+ 5 | - import "nested//path.proto";
+ 5 | + import "nested/path.proto";
    |
 
-warning: import path should be canonicalized
+error: import path must not contain `.`, `..`, or repeated separators
   --> main.proto:6:8
    |
- 6 | import "nested/../local2.proto";
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^ imported here
-  help: replace it with its canonical equivalent
+ 6 | import "./local.proto";
+   |        ^^^^^^^^^^^^^^^ imported here
+  help: canonicalize this path
    |
- 6 | - import "nested/../local2.proto";
- 6 | + import "local2.proto";
+ 6 | - import "./local.proto";
+ 6 | + import "local.proto";
    |
 
-warning: import path should be canonicalized
-  --> main.proto:7:8
+error: file imported multiple times
+  --> main.proto:7:1
    |
- 7 | import "../up.proto"
+ 6 | import "./local.proto";
+   | ----------------------- first imported here
+ 7 | import "local.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^
+   = help: both paths are equivalent to "local.proto"
+
+error: file imported multiple times
+  --> main.proto:8:1
+   |
+ 6 | import "./local.proto";
+   | ----------------------- first imported here
+ 7 | import "local.proto";
+ 8 | import "fake/../local.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: both paths are equivalent to "local.proto"
+
+error: import path must not contain `.`, `..`, or repeated separators
+  --> main.proto:8:8
+   |
+ 8 | import "fake/../local.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^ imported here
+  help: canonicalize this path
+   |
+ 8 | - import "fake/../local.proto";
+ 8 | + import "local.proto";
+   |
+
+error: import path must not refer to parent directory
+  --> main.proto:9:8
+   |
+ 9 | import "../up.proto";
    |        ^^^^^^^^^^^^^ imported here
 
-encountered 4 warnings
+encountered 7 errors

--- a/experimental/ir/testdata/imports/canonical.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/canonical.proto.yaml.stderr.txt
@@ -1,0 +1,40 @@
+warning: import path should be canonicalized
+  --> main.proto:4:8
+   |
+ 4 | import "nested//path.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^ imported here
+  help: replace it with its canonical equivalent
+   |
+ 4 | - import "nested//path.proto";
+ 4 | + import "nested/path.proto";
+   |
+
+warning: import path should be canonicalized
+  --> main.proto:5:8
+   |
+ 5 | import "./local.proto";
+   |        ^^^^^^^^^^^^^^^ imported here
+  help: replace it with its canonical equivalent
+   |
+ 5 | - import "./local.proto";
+ 5 | + import "local.proto";
+   |
+
+warning: import path should be canonicalized
+  --> main.proto:6:8
+   |
+ 6 | import "nested/../local2.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^ imported here
+  help: replace it with its canonical equivalent
+   |
+ 6 | - import "nested/../local2.proto";
+ 6 | + import "local2.proto";
+   |
+
+warning: import path should be canonicalized
+  --> main.proto:7:8
+   |
+ 7 | import "../up.proto"
+   |        ^^^^^^^^^^^^^ imported here
+
+encountered 4 warnings

--- a/experimental/ir/testdata/imports/cycle.proto.yaml
+++ b/experimental/ir/testdata/imports/cycle.proto.yaml
@@ -1,0 +1,23 @@
+files:
+- path: "a.proto"
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "b.proto";
+
+- path: "b.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "c.proto";
+
+- path: "c.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "a.proto";

--- a/experimental/ir/testdata/imports/cycle.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/cycle.proto.yaml.fds.yaml
@@ -1,0 +1,4 @@
+file:
+  - { name: "c.proto", package: "buf.test", syntax: "proto2" }
+  - { name: "b.proto", package: "buf.test", dependency: ["c.proto"], syntax: "proto2" }
+  - { name: "a.proto", package: "buf.test", dependency: ["b.proto"], syntax: "proto2" }

--- a/experimental/ir/testdata/imports/cycle.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/cycle.proto.yaml.stderr.txt
@@ -1,0 +1,15 @@
+error: detected cyclic import while importing "b.proto"
+  --> a.proto:4:1
+   |
+ 4 | import "b.proto";
+   | ^^^^^^^^^^^^^^^^^ imported here
+  ::: b.proto:4:1
+   |
+ 4 | import "c.proto";
+   | ----------------- ...which imports "c.proto"...
+  ::: c.proto:4:1
+   |
+ 4 | import "a.proto";
+   | ----------------- ...which imports "a.proto", completing the cycle
+
+encountered 1 error

--- a/experimental/ir/testdata/imports/invalid.proto
+++ b/experimental/ir/testdata/imports/invalid.proto
@@ -1,0 +1,23 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.test;
+
+import "";
+import "/root.proto";
+import "C:/windows.proto";
+import "does_not_exist.proto";
+import "windows\\path.proto";

--- a/experimental/ir/testdata/imports/invalid.proto
+++ b/experimental/ir/testdata/imports/invalid.proto
@@ -18,6 +18,4 @@ package buf.test;
 
 import "";
 import "/root.proto";
-import "C:/windows.proto";
 import "does_not_exist.proto";
-import "windows\\path.proto";

--- a/experimental/ir/testdata/imports/invalid.proto.fds.yaml
+++ b/experimental/ir/testdata/imports/invalid.proto.fds.yaml
@@ -1,0 +1,1 @@
+file: [{ name: "testdata/imports/invalid.proto", package: "buf.test", syntax: "proto2" }]

--- a/experimental/ir/testdata/imports/invalid.proto.stderr.txt
+++ b/experimental/ir/testdata/imports/invalid.proto.stderr.txt
@@ -13,39 +13,7 @@ error: import path cannot be absolute
 error: imported file does not exist
   --> testdata/imports/invalid.proto:21:1
    |
-21 | import "C:/windows.proto";
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
-
-warning: import path appears to begin with the Windows drive prefix `C:`
-  --> testdata/imports/invalid.proto:21:8
-   |
-21 | import "C:/windows.proto";
-   |        ^^^^^^^^^^^^^^^^^^
-   = note: this is not an error, because `protoc` accepts it, but may result in
-           unexpected behavior on Windows
-
-error: imported file does not exist
-  --> testdata/imports/invalid.proto:22:1
-   |
-22 | import "does_not_exist.proto";
+21 | import "does_not_exist.proto";
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
 
-error: imported file does not exist
-  --> testdata/imports/invalid.proto:23:1
-   |
-23 | import "windows\\path.proto";
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
-
-error: import path cannot use `\` as a path separator
-  --> testdata/imports/invalid.proto:23:8
-   |
-23 | import "windows\\path.proto";
-   |        ^^^^^^^^^^^^^^^^^^^^^ this path begins with a `w`
-  help: use `/` as the separator instead
-   |
-23 | - import "windows\\path.proto";
-23 | + import "windows/path.proto";
-   |
-   = note: this restriction also applies when compiling on a non-Windows system
-
-encountered 6 errors and 1 warning
+encountered 3 errors

--- a/experimental/ir/testdata/imports/invalid.proto.stderr.txt
+++ b/experimental/ir/testdata/imports/invalid.proto.stderr.txt
@@ -4,7 +4,7 @@ error: import path cannot be empty
 19 | import "";
    |        ^^
 
-error: import path cannot be absolute
+error: import path must be relative
   --> testdata/imports/invalid.proto:20:8
    |
 20 | import "/root.proto";

--- a/experimental/ir/testdata/imports/invalid.proto.stderr.txt
+++ b/experimental/ir/testdata/imports/invalid.proto.stderr.txt
@@ -1,0 +1,51 @@
+error: import path cannot be empty
+  --> testdata/imports/invalid.proto:19:8
+   |
+19 | import "";
+   |        ^^
+
+error: import path cannot be absolute
+  --> testdata/imports/invalid.proto:20:8
+   |
+20 | import "/root.proto";
+   |        ^^^^^^^^^^^^^ this path begins with a `/`
+
+error: imported file does not exist
+  --> testdata/imports/invalid.proto:21:1
+   |
+21 | import "C:/windows.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
+
+warning: import path appears to begin with the Windows drive prefix `C:`
+  --> testdata/imports/invalid.proto:21:8
+   |
+21 | import "C:/windows.proto";
+   |        ^^^^^^^^^^^^^^^^^^
+   = note: this is not an error, because `protoc` accepts it, but may result in
+           unexpected behavior on Windows
+
+error: imported file does not exist
+  --> testdata/imports/invalid.proto:22:1
+   |
+22 | import "does_not_exist.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
+
+error: imported file does not exist
+  --> testdata/imports/invalid.proto:23:1
+   |
+23 | import "windows\\path.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
+
+error: import path cannot use `\` as a path separator
+  --> testdata/imports/invalid.proto:23:8
+   |
+23 | import "windows\\path.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^ this path begins with a `w`
+  help: use `/` as the separator instead
+   |
+23 | - import "windows\\path.proto";
+23 | + import "windows/path.proto";
+   |
+   = note: this restriction also applies when compiling on a non-Windows system
+
+encountered 6 errors and 1 warning

--- a/experimental/ir/testdata/imports/ok.proto.yaml
+++ b/experimental/ir/testdata/imports/ok.proto.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020-2025 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 files:
 - path: "main.proto"
   text: |

--- a/experimental/ir/testdata/imports/ok.proto.yaml
+++ b/experimental/ir/testdata/imports/ok.proto.yaml
@@ -1,0 +1,27 @@
+files:
+- path: "main.proto"
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "a.proto";
+    import public "b.proto";
+    import weak "c.proto";
+
+- path: "a.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+- path: "b.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+- path: "c.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;

--- a/experimental/ir/testdata/imports/ok.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/ok.proto.yaml.fds.yaml
@@ -1,0 +1,10 @@
+file:
+  - { name: "a.proto", package: "buf.test", syntax: "proto2" }
+  - { name: "c.proto", package: "buf.test", syntax: "proto2" }
+  - { name: "b.proto", package: "buf.test", syntax: "proto2" }
+  - name: "main.proto"
+    package: "buf.test"
+    dependency: ["a.proto", "b.proto", "c.proto"]
+    public_dependency: [1]
+    weak_dependency: [2]
+    syntax: "proto2"

--- a/experimental/ir/testdata/imports/ok.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/ok.proto.yaml.stderr.txt
@@ -1,0 +1,9 @@
+warning: use of `import weak`
+  --> main.proto:6:1
+   |
+ 6 | import weak "c.proto";
+   | ^^^^^^^^^^^
+   = note: `import weak` is deprecated and not supported correctly in most
+           Protobuf implementations
+
+encountered 1 warning

--- a/experimental/ir/testdata/imports/windows.proto.yaml
+++ b/experimental/ir/testdata/imports/windows.proto.yaml
@@ -13,25 +13,23 @@
 # limitations under the License.
 
 files:
-- path: "a.proto"
+- path: "main.proto"
   text: |
     syntax = "proto2";
-    package buf.test;
+    package foo.bar;
 
-    import "b.proto";
+    import "nested\\path.proto";
+    import "C:/MyFiles/foo.proto";
+    import "C:\\MyFiles\\foo.proto";
 
-- path: "b.proto"
+- path: "nested/path.proto"
   import: true
   text: |
     syntax = "proto2";
-    package buf.test;
+    package foo.bar;
 
-    import "c.proto";
-
-- path: "c.proto"
+- path: "C:/MyFiles/foo.proto"
   import: true
   text: |
     syntax = "proto2";
-    package buf.test;
-
-    import "a.proto";
+    package foo.bar;

--- a/experimental/ir/testdata/imports/windows.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/windows.proto.yaml.fds.yaml
@@ -1,0 +1,7 @@
+file:
+  - { name: "C:/MyFiles/foo.proto", package: "foo.bar", syntax: "proto2" }
+  - { name: "nested/path.proto", package: "foo.bar", syntax: "proto2" }
+  - name: "main.proto"
+    package: "foo.bar"
+    dependency: ["C:/MyFiles/foo.proto", "nested/path.proto"]
+    syntax: "proto2"

--- a/experimental/ir/testdata/imports/windows.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/windows.proto.yaml.stderr.txt
@@ -1,0 +1,63 @@
+error: import path cannot use `\` as a path separator
+  --> main.proto:4:8
+   |
+ 4 | import "nested\\path.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^ this path begins with a `n`
+  help: use `/` as the separator instead
+   |
+ 4 | - import "nested\\path.proto";
+ 4 | + import "nested/path.proto";
+   |
+   = note: this restriction also applies when compiling on a non-Windows system
+
+warning: import path should be canonicalized
+  --> main.proto:4:8
+   |
+ 4 | import "nested\\path.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^ imported here
+  help: replace it with its canonical equivalent
+   |
+ 4 | - import "nested\\path.proto";
+ 4 | + import "nested/path.proto";
+   |
+
+warning: import path appears to begin with the Windows drive prefix `C:`
+  --> main.proto:5:8
+   |
+ 5 | import "C:/MyFiles/foo.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this is not an error, because `protoc` accepts it, but may result in
+           unexpected behavior on Windows
+
+warning: import path appears to begin with the Windows drive prefix `C:`
+  --> main.proto:6:8
+   |
+ 6 | import "C:\\MyFiles\\foo.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this is not an error, because `protoc` accepts it, but may result in
+           unexpected behavior on Windows
+
+error: import path cannot use `\` as a path separator
+  --> main.proto:6:8
+   |
+ 6 | import "C:\\MyFiles\\foo.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^ this path begins with a `C`
+  help: use `/` as the separator instead
+   |
+ 6 | - import "C:\\MyFiles\\foo.proto";
+ 6 | + import "C:/MyFiles/foo.proto";
+   |
+   = note: this restriction also applies when compiling on a non-Windows system
+
+warning: import path should be canonicalized
+  --> main.proto:6:8
+   |
+ 6 | import "C:\\MyFiles\\foo.proto";
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^ imported here
+  help: replace it with its canonical equivalent
+   |
+ 6 | - import "C:\\MyFiles\\foo.proto";
+ 6 | + import "C:/MyFiles/foo.proto";
+   |
+
+encountered 2 errors and 4 warnings

--- a/experimental/ir/testdata/imports/windows.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/windows.proto.yaml.stderr.txt
@@ -10,12 +10,12 @@ error: import path cannot use `\` as a path separator
    |
    = note: this restriction also applies when compiling on a non-Windows system
 
-warning: import path should be canonicalized
+error: import path must not contain `.`, `..`, or repeated separators
   --> main.proto:4:8
    |
  4 | import "nested\\path.proto";
    |        ^^^^^^^^^^^^^^^^^^^^ imported here
-  help: replace it with its canonical equivalent
+  help: canonicalize this path
    |
  4 | - import "nested\\path.proto";
  4 | + import "nested/path.proto";
@@ -28,6 +28,15 @@ warning: import path appears to begin with the Windows drive prefix `C:`
    |        ^^^^^^^^^^^^^^^^^^^^^^
    = note: this is not an error, because `protoc` accepts it, but may result in
            unexpected behavior on Windows
+
+error: file imported multiple times
+  --> main.proto:6:1
+   |
+ 5 | import "C:/MyFiles/foo.proto";
+   | ------------------------------ first imported here
+ 6 | import "C:\\MyFiles\\foo.proto";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: both paths are equivalent to "C:/MyFiles/foo.proto"
 
 warning: import path appears to begin with the Windows drive prefix `C:`
   --> main.proto:6:8
@@ -49,15 +58,15 @@ error: import path cannot use `\` as a path separator
    |
    = note: this restriction also applies when compiling on a non-Windows system
 
-warning: import path should be canonicalized
+error: import path must not contain `.`, `..`, or repeated separators
   --> main.proto:6:8
    |
  6 | import "C:\\MyFiles\\foo.proto";
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ imported here
-  help: replace it with its canonical equivalent
+  help: canonicalize this path
    |
  6 | - import "C:\\MyFiles\\foo.proto";
  6 | + import "C:/MyFiles/foo.proto";
    |
 
-encountered 2 errors and 4 warnings
+encountered 5 errors and 2 warnings

--- a/experimental/ir/testdata/smoke.proto
+++ b/experimental/ir/testdata/smoke.proto
@@ -1,0 +1,29 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.test;
+
+message Foo {
+    int32 a = 1;
+    int32 b = 1;
+    int32 c = 1;
+}
+
+enum BAR {
+    BAR_ZERO = 0;
+    BAR_A = 1;
+    BAR_B = 2;
+}

--- a/experimental/ir/testdata/smoke.proto
+++ b/experimental/ir/testdata/smoke.proto
@@ -17,9 +17,9 @@ syntax = "proto2";
 package buf.test;
 
 message Foo {
-    int32 a = 1;
-    int32 b = 1;
-    int32 c = 1;
+    optional int32 a = 1;
+    optional int32 b = 1;
+    optional int32 c = 1;
 }
 
 enum BAR {

--- a/experimental/ir/testdata/smoke.proto.fds.yaml
+++ b/experimental/ir/testdata/smoke.proto.fds.yaml
@@ -1,0 +1,16 @@
+file:
+  - name: "testdata/smoke.proto"
+    package: "buf.test"
+    message_type:
+      - name: "Foo"
+        field:
+          - { name: "a", number: 0 }
+          - { name: "b", number: 0 }
+          - { name: "c", number: 0 }
+    enum_type:
+      - name: "BAR"
+        value:
+          - { name: "BAR_ZERO", number: 0 }
+          - { name: "BAR_A", number: 0 }
+          - { name: "BAR_B", number: 0 }
+    syntax: "proto2"

--- a/experimental/parser/legalize_decl.go
+++ b/experimental/parser/legalize_decl.go
@@ -44,7 +44,7 @@ func legalizeDecl(p *parser, parent classified, decl ast.DeclAny) {
 	case ast.DeclKindPackage:
 		legalizePackage(p, parent, -1, nil, decl.AsPackage())
 	case ast.DeclKindImport:
-		legalizeImport(p, parent, decl.AsImport(), nil)
+		legalizeImport(p, parent, decl.AsImport())
 
 	case ast.DeclKindRange:
 		legalizeRange(p, parent, decl.AsRange())

--- a/experimental/parser/legalize_file.go
+++ b/experimental/parser/legalize_file.go
@@ -29,7 +29,7 @@ import (
 
 // isOrdinaryFilePath matches a "normal looking" file path, for the purposes
 // of emitting warnings.
-var isOrdinaryFilePath = regexp.MustCompile("[0-9a-zA-Z./_-]*")
+var isOrdinaryFilePath = regexp.MustCompile(`^[0-9a-zA-Z./_-]*$`)
 
 // legalizeFile is the entry-point for legalizing a parsed Protobuf file.
 func legalizeFile(p *parser, file ast.File) {

--- a/experimental/parser/lex_test.go
+++ b/experimental/parser/lex_test.go
@@ -30,9 +30,9 @@ func TestLexer(t *testing.T) {
 	t.Parallel()
 
 	corpus := golden.Corpus{
-		Root:      "testdata/lexer",
-		Refresh:   "PROTOCOMPILE_REFRESH",
-		Extension: "proto",
+		Root:       "testdata/lexer",
+		Refresh:    "PROTOCOMPILE_REFRESH",
+		Extensions: []string{"proto"},
 		Outputs: []golden.Output{
 			{Extension: "tokens.tsv"},
 			{Extension: "stderr.txt"},

--- a/experimental/parser/parse_test.go
+++ b/experimental/parser/parse_test.go
@@ -32,9 +32,9 @@ func TestParse(t *testing.T) {
 	t.Parallel()
 
 	corpus := golden.Corpus{
-		Root:      "testdata/parser",
-		Refresh:   "PROTOCOMPILE_REFRESH",
-		Extension: "proto",
+		Root:       "testdata/parser",
+		Refresh:    "PROTOCOMPILE_REFRESH",
+		Extensions: []string{"proto"},
 		Outputs: []golden.Output{
 			{Extension: "yaml"},
 			{Extension: "stderr.txt"},

--- a/experimental/parser/testdata/parser/import/repeated.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/import/repeated.proto.stderr.txt
@@ -1,9 +1,12 @@
-error: file "foo.proto" imported multiple times
-  --> testdata/parser/import/repeated.proto:20:1
+warning: non-canonical string literal in import
+  --> testdata/parser/import/repeated.proto:20:8
    |
-19 | import "foo.proto";
-   | ------------------- first imported here
 20 | import "foo\x2eproto";
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^
+  help: replace it with a canonical string
+   |
+20 | - import "foo\x2eproto";
+20 | + import "foo.proto";
+   |
 
-encountered 1 error
+encountered 1 warning

--- a/experimental/report/renderer_test.go
+++ b/experimental/report/renderer_test.go
@@ -62,9 +62,9 @@ func TestRender(t *testing.T) {
 	t.Parallel()
 
 	corpus := golden.Corpus{
-		Root:      "testdata",
-		Refresh:   "PROTOCOMPILE_REFRESH",
-		Extension: "yaml",
+		Root:       "testdata",
+		Refresh:    "PROTOCOMPILE_REFRESH",
+		Extensions: []string{"yaml"},
 		Outputs: []golden.Output{
 			{Extension: "simple.txt"},
 			{Extension: "fancy.txt"},

--- a/experimental/report/report.go
+++ b/experimental/report/report.go
@@ -138,8 +138,8 @@ func (r *Report) CatchICE(resume bool, diagnose func(*Diagnostic)) {
 	// Report.CatchICE).
 	stack = stack[5:]
 
-	diagnostic.notes = append(diagnostic.notes, "", "stack trace:")
-	diagnostic.notes = append(diagnostic.notes, stack...)
+	diagnostic.debug = append(diagnostic.debug, "", "stack trace:")
+	diagnostic.debug = append(diagnostic.debug, stack...)
 
 	if resume {
 		panic(panicked)

--- a/experimental/seq/seq.go
+++ b/experimental/seq/seq.go
@@ -98,3 +98,12 @@ func Append[T any](seq Inserter[T], values ...T) {
 		seq.Insert(seq.Len(), v)
 	}
 }
+
+// ToSlice copies an [Indexer] into a slice.
+func ToSlice[T any](seq Indexer[T]) []T {
+	out := make([]T, seq.Len())
+	for i := range out {
+		out[i] = seq.At(i)
+	}
+	return out
+}

--- a/internal/ext/mapsx/mapsx.go
+++ b/internal/ext/mapsx/mapsx.go
@@ -34,13 +34,20 @@ func Contains[M ~map[K]V, K comparable, V any](m M, k K) bool {
 	return ok
 }
 
+// Add inserts k into the map if it is not present. Returns whether insertion
+// occurred, and the value that k maps to in the map.
+func Add[M ~map[K]V, K comparable, V any](m M, k K, v V) (mapped V, inserted bool) {
+	if v, ok := m[k]; ok {
+		return v, false
+	}
+	m[k] = v
+	return v, true
+}
+
 // AddZero inserts k into the map if it is not present, using the zero value of
 // V as the value. Returns whether insertion occurred.
 func AddZero[M ~map[K]V, K comparable, V any](m M, k K) (inserted bool) {
-	if _, ok := m[k]; ok {
-		return false
-	}
 	var z V
-	m[k] = z
-	return true
+	_, inserted = Add(m, k, z)
+	return inserted
 }

--- a/internal/ext/slicesx/iter.go
+++ b/internal/ext/slicesx/iter.go
@@ -32,6 +32,16 @@ func Join[S ~[]E, E any](s S, sep string) string {
 	return iterx.Join(slices.Values(s), sep)
 }
 
+// Transform is like calling [slices.Collect] with [Map], but is able to
+// preallocate.
+func Transform[S ~[]E, E, U any](s S, f func(E) U) []U {
+	out := make([]U, len(s))
+	for i, e := range s {
+		out[i] = f(e)
+	}
+	return out
+}
+
 // PartitionFunc returns an iterator of the largest substrings of s of equal
 // elements.
 //

--- a/internal/golden/golden.go
+++ b/internal/golden/golden.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
@@ -51,9 +50,9 @@ type Corpus struct {
 	// mode or not.
 	Refresh string
 
-	// The file extension (without a dot) of files which define a test case,
+	// The file extensions (without a dot) of files which define a test case,
 	// e.g. "proto".
-	Extension string
+	Extensions []string
 
 	// Possible outputs of the test, which are found using Outputs.Extension.
 	// If the file for a particular output is missing, it is implicitly treated
@@ -78,12 +77,17 @@ func (c Corpus) Run(t *testing.T, test func(t *testing.T, path, text string, out
 	// Enumerate the tests to run by walking the filesystem.
 	var tests []string
 	err := filepath.Walk(root, func(p string, fi fs.FileInfo, err error) error {
-		if err != nil {
+		if err != nil || fi.IsDir() {
 			return err
 		}
-		if !fi.IsDir() && strings.TrimPrefix(path.Ext(p), ".") == c.Extension {
-			tests = append(tests, p)
+
+		for _, extn := range c.Extensions {
+			if strings.HasSuffix(p, "."+extn) {
+				tests = append(tests, p)
+				break
+			}
 		}
+
 		return err
 	})
 	if err != nil {

--- a/internal/intern/intern.go
+++ b/internal/intern/intern.go
@@ -227,3 +227,27 @@ func (s Set) Add(table *Table, key string) (inserted bool) {
 	}
 	return !ok
 }
+
+// Map is a map keyed by intern IDs.
+type Map[T any] map[ID]T
+
+// Get returns the value that key maps to.
+func (m Map[T]) Get(table *Table, key string) (T, bool) {
+	k, ok := table.Query(key)
+	if !ok {
+		var z T
+		return z, false
+	}
+	v, ok := m[k]
+	return v, ok
+}
+
+// AddID adds an ID to m, and returns whether it was added.
+func (m Map[T]) AddID(id ID, v T) (mapped T, inserted bool) {
+	return mapsx.Add(m, id, v)
+}
+
+// Add adds a string to m, and returns whether it was added.
+func (m Map[T]) Add(table *Table, key string, v T) (mapped T, inserted bool) {
+	return m.AddID(table.Intern(key), v)
+}


### PR DESCRIPTION
This PR adds end-to-end tests to the `ir` package. These tests start from either a single proto file or a collection of them (in a `proto.yaml` file) and generates diagnostics and an FDS.

This PR also implements `queries.IR`, which is used in the IR tests. It is not clear to me if coupling this more tightly with the `ir` module makes sense, but it does mighty feel like it. If we decide to move it into the `ir` package as `ir.Query`, one thing I would worry about is that if `Session.Lower` isn't left exposed, there won't be a way to construct an IR module from user-build AST. Kind of a corner-case, but one that seems annoying to close off. At the same time, `Session.Lower` is such a confusing API...

Also, this changes the `ir.Importer` interface to return a general error. It felt "more correct" for the lowering logic to be where all errors become diagnostics. I've also made it so that `queries.File` can be run with or without diagnostics triggering on failure. This is used by `queries.IR` to delay the diagnostic being created until `Session.Lower` gets a chance to.