### PR TITLE
Fix semicolons after imports being optional

### DIFF
--- a/experimental/parser/parse_decl.go
+++ b/experimental/parser/parse_decl.go
@@ -242,7 +242,7 @@ func parseDecl(p *parser, c *token.Cursor, in taxa.Noun) ast.DeclAny {
 		} else {
 			semi, err := parseSemi(p, c, in)
 			args.Semicolon = semi
-			if err != nil && args.ImportPath.IsZero() {
+			if err != nil {
 				p.Error(err)
 			}
 		}

--- a/experimental/parser/testdata/parser/import/nosemi.proto
+++ b/experimental/parser/testdata/parser/import/nosemi.proto
@@ -1,0 +1,20 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package test;
+
+import "foo.proto"
+import "bar.proto"

--- a/experimental/parser/testdata/parser/import/nosemi.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/import/nosemi.proto.stderr.txt
@@ -1,0 +1,21 @@
+error: unexpected `import` after import
+  --> testdata/parser/import/nosemi.proto:20:1
+   |
+20 | import "bar.proto"
+   | ^^^^^^ expected `;`
+  help: consider inserting a `;`
+   |
+19 | import "foo.proto";
+   |                   +
+
+error: unexpected end-of-file after import
+  --> testdata/parser/import/nosemi.proto:20:19
+   |
+20 | import "bar.proto"
+   |                   ^ expected `;`
+  help: consider inserting a `;`
+   |
+20 | import "bar.proto";
+   |                   +
+
+encountered 2 errors

--- a/experimental/parser/testdata/parser/import/nosemi.proto.yaml
+++ b/experimental/parser/testdata/parser/import/nosemi.proto.yaml
@@ -1,0 +1,5 @@
+decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - package.path.components: [{ ident: "test" }]
+  - import.import_path.literal.string_value: "foo.proto"
+  - import.import_path.literal.string_value: "bar.proto"

--- a/experimental/parser/testdata/parser/package/nosemi.proto
+++ b/experimental/parser/testdata/parser/package/nosemi.proto
@@ -1,0 +1,17 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package test

--- a/experimental/parser/testdata/parser/package/nosemi.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/package/nosemi.proto.stderr.txt
@@ -1,0 +1,11 @@
+error: unexpected end-of-file after `package` declaration
+  --> testdata/parser/package/nosemi.proto:17:13
+   |
+17 | package test
+   |             ^ expected `;`
+  help: consider inserting a `;`
+   |
+17 | package test;
+   |             +
+
+encountered 1 error

--- a/experimental/parser/testdata/parser/package/nosemi.proto.yaml
+++ b/experimental/parser/testdata/parser/package/nosemi.proto.yaml
@@ -1,0 +1,3 @@
+decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - package.path.components: [{ ident: "test" }]

--- a/experimental/parser/testdata/parser/syntax/nosemi.proto
+++ b/experimental/parser/testdata/parser/syntax/nosemi.proto
@@ -1,0 +1,17 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2"
+
+package test;

--- a/experimental/parser/testdata/parser/syntax/nosemi.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/syntax/nosemi.proto.stderr.txt
@@ -1,0 +1,11 @@
+error: unexpected `package` after `syntax` declaration
+  --> testdata/parser/syntax/nosemi.proto:17:1
+   |
+17 | package test;
+   | ^^^^^^^ expected `;`
+  help: consider inserting a `;`
+   |
+15 | syntax = "proto2";
+   |                  +
+
+encountered 1 error

--- a/experimental/parser/testdata/parser/syntax/nosemi.proto.yaml
+++ b/experimental/parser/testdata/parser/syntax/nosemi.proto.yaml
@@ -1,0 +1,3 @@
+decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - package.path.components: [{ ident: "test" }]


### PR DESCRIPTION
Apparently I completely missed this. Discovered it while writing tests for import lowering.