### PR TITLE
Legalize grammar constructs specific to certain syntax/edition modes

### DIFF
--- a/experimental/parser/diagnostics_internal.go
+++ b/experimental/parser/diagnostics_internal.go
@@ -380,8 +380,8 @@ func doJustifyLeft(stream *token.Stream, span report.Span, e *report.Edit) {
 func doJustifyRight(stream *token.Stream, span report.Span, e *report.Edit) {
 	wasDelete := e.IsDeletion()
 
-	// Get the token at the start of the span.
-	_, end := stream.Around(e.Start + span.Start)
+	// Get the token at the end of the span.
+	_, end := stream.Around(e.End + span.Start)
 	if end.IsZero() {
 		// End of the file, so we can't fast-forward beyond this.
 		return

--- a/experimental/parser/legalize_decl.go
+++ b/experimental/parser/legalize_decl.go
@@ -106,7 +106,7 @@ func legalizeRange(p *parser, parent classified, decl ast.DeclRange) {
 
 	want := taxa.NewSet(taxa.Int, taxa.Range)
 	if in == taxa.Reserved {
-		if p.Mode() == taxa.EditionMode {
+		if p.syntax.IsEdition() {
 			want = want.With(taxa.Ident)
 		} else {
 			want = want.With(taxa.String)
@@ -168,13 +168,12 @@ func legalizeRange(p *parser, parent classified, decl ast.DeclRange) {
 
 			names = append(names, expr)
 
-			m := p.Mode()
-			if m == taxa.EditionMode {
+			if p.syntax.IsEdition() {
 				break
 			}
-			p.Errorf("cannot use %vs in %v in %v", taxa.Ident, in, m).Apply(
+			p.Errorf("cannot use %vs in %v in %v", taxa.Ident, in, taxa.SyntaxMode).Apply(
 				report.Snippet(expr),
-				report.Snippetf(p.syntax, "%v is specified here", m),
+				report.Snippetf(p.syntaxNode, "%v is specified here", taxa.SyntaxMode),
 				report.SuggestEdits(
 					expr,
 					fmt.Sprintf("quote it to make it into a %v", taxa.String),
@@ -201,10 +200,10 @@ func legalizeRange(p *parser, parent classified, decl ast.DeclRange) {
 				}
 
 				names = append(names, expr)
-				if m := p.Mode(); m == taxa.EditionMode {
-					err := p.Errorf("cannot use %vs in %v in %v", taxa.String, in, m).Apply(
+				if p.syntax.IsEdition() {
+					err := p.Errorf("cannot use %vs in %v in %v", taxa.String, in, taxa.EditionMode).Apply(
 						report.Snippet(expr),
-						report.Snippetf(p.syntax, "%v is specified here", m),
+						report.Snippetf(p.syntaxNode, "%v is specified here", taxa.EditionMode),
 					)
 
 					// Only suggest unquoting if it's already an identifier.

--- a/experimental/parser/legalize_decl.go
+++ b/experimental/parser/legalize_decl.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ast/predeclared"
+	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal/taxa"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
@@ -94,6 +95,13 @@ func legalizeRange(p *parser, parent classified, decl ast.DeclRange) {
 	if !validParents.Has(parent.what) {
 		p.Error(errBadNest{parent: parent, child: decl, validParents: validParents})
 		return
+	}
+
+	if p.syntax == syntax.Proto3 && in == taxa.Extensions {
+		p.Errorf("%ss are not permitted in %s", in, p.syntax).Apply(
+			report.Snippet(decl),
+			// TODO: suggestions. Can't just suggest Any because Any sucks.
+		)
 	}
 
 	if options := decl.Options(); !options.IsZero() {

--- a/experimental/parser/legalize_def.go
+++ b/experimental/parser/legalize_def.go
@@ -194,7 +194,7 @@ func legalizeFieldLike(p *parser, what taxa.Noun, def ast.DeclDef, parent classi
 	if what == taxa.Field {
 		var oneof ast.DeclDef
 		if parent.what == taxa.Oneof {
-			oneof = parent.Spanner.(ast.DeclDef)
+			oneof, _ = parent.Spanner.(ast.DeclDef)
 		}
 		legalizeFieldType(p, def.Type(), true, oneof)
 	}

--- a/experimental/parser/legalize_def.go
+++ b/experimental/parser/legalize_def.go
@@ -53,7 +53,7 @@ func legalizeDef(p *parser, parent classified, def ast.DeclDef) {
 	case ast.DefKindMessage, ast.DefKindEnum, ast.DefKindService, ast.DefKindOneof, ast.DefKindExtend:
 		legalizeTypeDefLike(p, taxa.Classify(def), def)
 	case ast.DefKindField, ast.DefKindEnumValue, ast.DefKindGroup:
-		legalizeFieldLike(p, taxa.Classify(def), def)
+		legalizeFieldLike(p, taxa.Classify(def), def, parent)
 	case ast.DefKindOption:
 		legalizeOption(p, def)
 	case ast.DefKindMethod:
@@ -136,7 +136,7 @@ func legalizeTypeDefLike(p *parser, what taxa.Noun, def ast.DeclDef) {
 
 // legalizeFieldLike legalizes something that resembles a field definition:
 // namely, fields, groups, and enum values.
-func legalizeFieldLike(p *parser, what taxa.Noun, def ast.DeclDef) {
+func legalizeFieldLike(p *parser, what taxa.Noun, def ast.DeclDef, parent classified) {
 	if def.Name().IsZero() {
 		def.MarkCorrupt()
 		p.Errorf("missing name %v", what.In()).Apply(
@@ -192,7 +192,11 @@ func legalizeFieldLike(p *parser, what taxa.Noun, def ast.DeclDef) {
 	}
 
 	if what == taxa.Field {
-		legalizeFieldType(p, def.Type())
+		var oneof ast.DeclDef
+		if parent.what == taxa.Oneof {
+			oneof = parent.Spanner.(ast.DeclDef)
+		}
+		legalizeFieldType(p, def.Type(), true, oneof)
 	}
 }
 

--- a/experimental/parser/legalize_type.go
+++ b/experimental/parser/legalize_type.go
@@ -78,7 +78,7 @@ func legalizeFieldType(p *parser, ty ast.TypeAny, topLevel bool, oneof ast.DeclD
 
 	switch ty.Kind() {
 	case ast.TypeKindPath:
-		if topLevel && p.syntax == syntax.Proto2 {
+		if topLevel && p.syntax == syntax.Proto2 && oneof.IsZero() {
 			p.Error(errUnexpected{
 				what: ty,
 				want: expected,
@@ -104,7 +104,7 @@ func legalizeFieldType(p *parser, ty ast.TypeAny, topLevel bool, oneof ast.DeclD
 					Edit:    report.Edit{Start: 0, End: ty.PrefixToken().Span().Len()},
 					justify: justifyRight,
 				}),
-				report.Notef("fields within a %s may not have modifiers applied to them", taxa.Oneof),
+				report.Notef("fields defined as part of a %s may not have modifiers applied to them", taxa.Oneof),
 			)
 			if ty.Prefix() == keyword.Repeated {
 				d.Apply(report.Helpf(
@@ -151,9 +151,9 @@ func legalizeFieldType(p *parser, ty ast.TypeAny, topLevel bool, oneof ast.DeclD
 					report.Helpf(
 						"in %s, the presence behavior of a singular field "+
 							"is controlled with `[feature.field_presence = ...]`, with "+
-							"the default being equivalent to %s %s"+
-							"see <https://protobuf.com/docs/language-spec#field-presence>",
+							"the default being equivalent to %s %s",
 						taxa.EditionMode, syntax.Proto2, taxa.KeywordOptional),
+					report.Helpf("see <https://protobuf.com/docs/language-spec#field-presence>"),
 				)
 			}
 		case keyword.Stream:

--- a/experimental/parser/legalize_type.go
+++ b/experimental/parser/legalize_type.go
@@ -17,6 +17,7 @@ package parser
 import (
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ast/predeclared"
+	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal/taxa"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/token/keyword"
@@ -59,22 +60,121 @@ func legalizeMethodParams(p *parser, list ast.TypeList, what taxa.Noun) {
 }
 
 // legalizeFieldType legalizes the type of a message field.
-func legalizeFieldType(p *parser, ty ast.TypeAny) {
+func legalizeFieldType(p *parser, ty ast.TypeAny, topLevel bool, oneof ast.DeclDef) {
+	expected := taxa.TypePath.AsSet()
+	if oneof.IsZero() {
+		switch p.syntax {
+		case syntax.Proto2:
+			expected = taxa.NewSet(
+				taxa.KeywordRequired, taxa.KeywordOptional, taxa.KeywordRepeated)
+		case syntax.Proto3:
+			expected = taxa.NewSet(
+				taxa.TypePath, taxa.KeywordOptional, taxa.KeywordRepeated)
+		default:
+			expected = taxa.NewSet(
+				taxa.TypePath, taxa.KeywordRepeated)
+		}
+	}
+
 	switch ty.Kind() {
 	case ast.TypeKindPath:
+		if topLevel && p.syntax == syntax.Proto2 {
+			p.Error(errUnexpected{
+				what: ty,
+				want: expected,
+			}).Apply(
+				report.SuggestEdits(ty, "use the `optional` modifier", report.Edit{
+					Replace: "optional ",
+				}),
+				report.Notef("modifiers are required in %s", syntax.Proto2),
+			)
+		}
+
 		legalizePath(p, taxa.Field.In(), ty.AsPath().Path, pathOptions{AllowAbsolute: true})
 
 	case ast.TypeKindPrefixed:
 		ty := ty.AsPrefixed()
-		if ty.Prefix() == keyword.Stream {
-			p.Errorf("the %s modifier may only appear in a %s", taxa.KeywordStream, taxa.Signature).Apply(
+		if !oneof.IsZero() {
+			d := p.Error(errUnexpected{
+				what: ty.PrefixToken(),
+				want: expected,
+			}).Apply(
+				report.Snippetf(oneof, "within this %s", taxa.Oneof),
+				justify(p.Stream(), ty.PrefixToken().Span(), "delete it", justified{
+					Edit:    report.Edit{Start: 0, End: ty.PrefixToken().Span().Len()},
+					justify: justifyRight,
+				}),
+				report.Notef("fields within a %s may not have modifiers applied to them", taxa.Oneof),
+			)
+			if ty.Prefix() == keyword.Repeated {
+				d.Apply(report.Helpf(
+					"to emulate a repeated field in a %s, define a local message type with a single repeated field",
+					taxa.Oneof))
+			}
+
+			return
+		}
+
+		switch ty.Prefix() {
+		case keyword.Required:
+			switch p.syntax {
+			case syntax.Proto2:
+				p.Warnf("required fields are deprecated and should not be used").Apply(
+					report.Snippet(ty.PrefixToken()),
+					report.Helpf("do not attempt to change this to %s if the field is already in-use; "+
+						"doing so is a wire protocol break", keyword.Optional),
+				)
+			default:
+				p.Error(errUnexpected{
+					what: ty.PrefixToken(),
+					want: expected,
+				}).Apply(
+					justify(p.Stream(), ty.PrefixToken().Span(), "delete it", justified{
+						Edit:    report.Edit{Start: 0, End: ty.PrefixToken().Span().Len()},
+						justify: justifyRight,
+					}),
+					report.Helpf("required fields are only permitted in %s; even then, their use is strongly discouraged",
+						syntax.Proto2),
+				)
+			}
+
+		case keyword.Optional:
+			if p.syntax.IsEdition() {
+				p.Error(errUnexpected{
+					what: ty.PrefixToken(),
+					want: expected,
+				}).Apply(
+					justify(p.Stream(), ty.PrefixToken().Span(), "delete it", justified{
+						Edit:    report.Edit{Start: 0, End: ty.PrefixToken().Span().Len()},
+						justify: justifyRight,
+					}),
+					report.Helpf(
+						"in %s, the presence behavior of a singular field "+
+							"is controlled with `[feature.field_presence = ...]`, with "+
+							"the default being equivalent to %s %s"+
+							"see <https://protobuf.com/docs/language-spec#field-presence>",
+						taxa.EditionMode, syntax.Proto2, taxa.KeywordOptional),
+				)
+			}
+		case keyword.Stream:
+			p.Error(errUnexpected{
+				what: ty.PrefixToken(),
+				want: expected,
+			}).Apply(
 				report.Snippet(ty.PrefixToken()),
+				justify(p.Stream(), ty.PrefixToken().Span(), "delete it", justified{
+					Edit:    report.Edit{Start: 0, End: ty.PrefixToken().Span().Len()},
+					justify: justifyRight,
+				}),
+				report.Helpf("the %s modifier may only appear in a %s",
+					taxa.KeywordStream, taxa.Signature),
 			)
 		}
+
 		inner := ty.Type()
 		switch inner.Kind() {
 		case ast.TypeKindPath:
-			legalizeFieldType(p, inner)
+			legalizeFieldType(p, inner, false, oneof)
 		case ast.TypeKindPrefixed:
 			p.Error(errMoreThanOne{
 				first:  ty.PrefixToken(),
@@ -93,9 +193,17 @@ func legalizeFieldType(p *parser, ty ast.TypeAny) {
 		ty := ty.AsGeneric()
 		switch {
 		case ty.Path().AsPredeclared() != predeclared.Map:
-			p.Errorf("generic types other than `map` are not supported").Apply(
+			p.Errorf("generic types other than %s are not supported", taxa.PredeclaredMap).Apply(
 				report.Snippet(ty.Path()),
 			)
+		case !oneof.IsZero():
+			p.Errorf("map fields are not allowed inside of a %s", taxa.Oneof).Apply(
+				report.Snippet(ty),
+				report.Helpf(
+					"to emulate a map field in a %s, fine a local message type with a single map field",
+					taxa.Oneof),
+			)
+
 		case ty.Args().Len() != 2:
 			p.Errorf("expected exactly two type arguments, got %d", ty.Args().Len()).Apply(
 				report.Snippet(ty.Args()),
@@ -120,7 +228,7 @@ func legalizeFieldType(p *parser, ty ast.TypeAny) {
 
 			switch v.Kind() {
 			case ast.TypeKindPath:
-				legalizeFieldType(p, v)
+				legalizeFieldType(p, v, false, oneof)
 			case ast.TypeKindPrefixed:
 				p.Error(errUnexpected{
 					what:  v.AsPrefixed().PrefixToken(),

--- a/experimental/parser/parse_state.go
+++ b/experimental/parser/parse_state.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal/taxa"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/token"
@@ -30,45 +31,8 @@ type parser struct {
 
 	parseComplete bool
 
-	syntax     ast.DeclSyntax
-	cachedMode taxa.Noun
-}
-
-// Mode returns whether or not the parser believes it is in editions
-// mode. This function must not be called until AST construction is complete
-// and legalization begins.
-//
-// This function will return the same answer every time it is called. This is to
-// avoid diagnostics depending on where the editions keyword appears. For
-// example, consider:
-//
-//	message Foo {
-//	  reserved foo;
-//	}
-//
-//	edition = "2023";
-//
-//	message Bar {
-//	  reserved "foo";
-//	}
-//
-// If we only referenced p.syntax, we get into a situation where we diagnose
-// *both* reserved ranges, rather than just the one in Foo, which is potentially
-// confusing, and suggests that the order of declarations in Protobuf is
-// semantically meaningful.
-func (p *parser) Mode() taxa.Noun {
-	if !p.parseComplete {
-		panic("called parser.Mode() outside of the legalizer; this is a bug")
-	}
-
-	if p.cachedMode == taxa.Unknown {
-		p.cachedMode = taxa.SyntaxMode
-		if !p.syntax.IsZero() && p.syntax.IsEdition() {
-			p.cachedMode = taxa.EditionMode
-		}
-	}
-
-	return p.cachedMode
+	syntaxNode ast.DeclSyntax
+	syntax     syntax.Syntax
 }
 
 // classified is a spanner that has been classified by taxa.

--- a/experimental/parser/testdata/parser/def/bare_bodies.proto
+++ b/experimental/parser/testdata/parser/def/bare_bodies.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/def/bare_bodies.proto.yaml
+++ b/experimental/parser/testdata/parser/def/bare_bodies.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/def/ordering.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/def/ordering.proto.stderr.txt
@@ -1,3 +1,14 @@
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:20:5
+   |
+20 |     M x (T) (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+20 |     optional M x (T) (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:20:5
    |
@@ -18,6 +29,17 @@ error: encountered more than one method parameter list
    |         |
    |         first one is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:21:5
+   |
+21 |     M x returns (T) (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+21 |     optional M x returns (T) (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:21:5
    |
@@ -37,6 +59,17 @@ error: unexpected method parameter list after method return type
    |         ----------- ^^^
    |         |
    |         previous method return type is here
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:22:5
+   |
+22 |     M x returns T (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+22 |     optional M x returns T (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:22:5
@@ -68,6 +101,17 @@ error: unexpected method parameter list after method return type
    |         |
    |         previous method return type is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:23:5
+   |
+23 |     M x [foo = bar] (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+23 |     optional M x [foo = bar] (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:23:5
    |
@@ -88,6 +132,17 @@ error: unexpected method parameter list after compact options
    |         |
    |         previous compact options is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:24:5
+   |
+24 |     M x { /* ... */ } (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+24 |     optional M x { /* ... */ } (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:24:5
    |
@@ -106,6 +161,17 @@ error: unexpected nested extension path in message field
 24 |     M x { /* ... */ } (T);
    |                       ^^^
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:24:23
+   |
+24 |     M x { /* ... */ } (T);
+   |                       ^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+24 |     M x { /* ... */ } optional (T);
+   |                       +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:24:23
    |
@@ -117,6 +183,17 @@ error: missing name in message field
    |
 24 |     M x { /* ... */ } (T);
    |                       ^^^^
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:26:5
+   |
+26 |     M x returns (T) returns (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+26 |     optional M x returns (T) returns (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:26:5
@@ -138,6 +215,17 @@ error: encountered more than one method return type
    |         |
    |         first one is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:27:5
+   |
+27 |     M x [foo = bar] returns (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+27 |     optional M x [foo = bar] returns (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:27:5
    |
@@ -158,6 +246,17 @@ error: unexpected method return type after compact options
    |         |
    |         previous compact options is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:28:5
+   |
+28 |     M x { /* ... */ } returns (T);
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+28 |     optional M x { /* ... */ } returns (T);
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:28:5
    |
@@ -170,6 +269,17 @@ error: unexpected definition body in message field
 28 |     M x { /* ... */ } returns (T);
    |         ^^^^^^^^^^^^^
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:28:23
+   |
+28 |     M x { /* ... */ } returns (T);
+   |                       ^^^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+28 |     M x { /* ... */ } optional returns (T);
+   |                       +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:28:23
    |
@@ -181,6 +291,17 @@ error: unexpected extension name in message field
    |
 28 |     M x { /* ... */ } returns (T);
    |                               ^^^ expected identifier
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:30:5
+   |
+30 |     M x returns T returns T;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+30 |     optional M x returns T returns T;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:30:5
@@ -211,6 +332,17 @@ error: encountered more than one method return type
    |         --------- ^^^^^^^^^ help: consider removing this
    |         |
    |         first one is here
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:31:5
+   |
+31 |     M x returns T [] returns T;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+31 |     optional M x returns T [] returns T;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:31:5
@@ -248,6 +380,17 @@ error: unexpected method return type after compact options
    |                   |
    |                   previous compact options is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:32:5
+   |
+32 |     M x [foo = bar] returns T;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+32 |     optional M x [foo = bar] returns T;
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:32:5
    |
@@ -278,6 +421,17 @@ error: missing `(...)` around method return type
 32 |     M x [foo = bar] returns (T);
    |                             + +
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:33:5
+   |
+33 |     M x { /* ... */ } returns T;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+33 |     optional M x { /* ... */ } returns T;
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:33:5
    |
@@ -290,11 +444,33 @@ error: unexpected definition body in message field
 33 |     M x { /* ... */ } returns T;
    |         ^^^^^^^^^^^^^
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:33:23
+   |
+33 |     M x { /* ... */ } returns T;
+   |                       ^^^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+33 |     M x { /* ... */ } optional returns T;
+   |                       +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:33:23
    |
 33 |     M x { /* ... */ } returns T;
    |                       ^^^^^^^^^^
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:35:5
+   |
+35 |     M x = 1 = 1;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+35 |     optional M x = 1 = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: encountered more than one message field tag
   --> testdata/parser/def/ordering.proto:35:13
@@ -304,6 +480,17 @@ error: encountered more than one message field tag
    |         |
    |         first one is here
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:36:5
+   |
+36 |     M x [foo = bar] = 1;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+36 |     optional M x [foo = bar] = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: unexpected message field tag after compact options
   --> testdata/parser/def/ordering.proto:36:21
    |
@@ -311,6 +498,17 @@ error: unexpected message field tag after compact options
    |         ----------- ^^^
    |         |
    |         previous compact options is here
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:37:5
+   |
+37 |     M x { /* ... */ } = 1;
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+37 |     optional M x { /* ... */ } = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:37:5
@@ -330,6 +528,17 @@ error: unexpected tokens in message definition
 37 |     M x { /* ... */ } = 1;
    |                       ^^^ expected identifier, `;`, `.`, `(...)`, or `{...}`
 
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:39:5
+   |
+39 |     M x [foo = bar] [foo = bar];
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+39 |     optional M x [foo = bar] [foo = bar];
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:39:5
    |
@@ -343,6 +552,17 @@ error: encountered more than one compact options
    |         ----------- ^^^^^^^^^^^ help: consider removing this
    |         |
    |         first one is here
+
+error: unexpected type name
+  --> testdata/parser/def/ordering.proto:40:5
+   |
+40 |     M x { /* ... */ } [foo = bar];
+   |     ^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+40 |     optional M x { /* ... */ } [foo = bar];
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: missing message field tag in declaration
   --> testdata/parser/def/ordering.proto:40:5
@@ -362,4 +582,4 @@ error: unexpected `[...]` in message definition
 40 |     M x { /* ... */ } [foo = bar];
    |                       ^^^^^^^^^^^ expected identifier, `;`, `.`, `(...)`, or `{...}`
 
-encountered 54 errors
+encountered 74 errors

--- a/experimental/parser/testdata/parser/field/any-tag.proto
+++ b/experimental/parser/testdata/parser/field/any-tag.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/field/any-tag.proto.yaml
+++ b/experimental/parser/testdata/parser/field/any-tag.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_EXTEND

--- a/experimental/parser/testdata/parser/field/bad-path.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/field/bad-path.proto.stderr.txt
@@ -10,17 +10,47 @@ error: unexpected qualified name in message field
 21 |     repeated Type path.name = 1;
    |                   ^^^^^^^^^ expected identifier
 
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/field/bad-path.proto:22:5
+   |
+22 |     required Type path.name = 1;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:22:19
    |
 22 |     required Type path.name = 1;
    |                   ^^^^^^^^^ expected identifier
 
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:23:5
+   |
+23 |     Type path.name = 1;
+   |     ^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+23 |     optional Type path.name = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
+
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:23:10
    |
 23 |     Type path.name = 1;
    |          ^^^^^^^^^ expected identifier
+
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:24:5
+   |
+24 |     Type path/name = 1;
+   |     ^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+24 |     optional Type path/name = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:24:10
@@ -40,11 +70,41 @@ error: unexpected qualified name in message field
 27 |     repeated package.Type path.name = 1;
    |                           ^^^^^^^^^ expected identifier
 
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/field/bad-path.proto:28:5
+   |
+28 |     required package.Type path.name = 1;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:28:27
    |
 28 |     required package.Type path.name = 1;
    |                           ^^^^^^^^^ expected identifier
+
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:29:5
+   |
+29 |     package.Type name = 1;
+   |     ^^^^^^^^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+29 |     optional package.Type name = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
+
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:30:5
+   |
+30 |     package/Type name = 1;
+   |     ^^^^^^^^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+30 |     optional package/Type name = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: unexpected `/` in path in message field
   --> testdata/parser/field/bad-path.proto:30:12
@@ -76,6 +136,14 @@ error: unexpected nested extension path in message field
 34 |     repeated (foo.bar).Type name = 1;
    |              ^^^^^^^^^
 
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/field/bad-path.proto:35:5
+   |
+35 |     required (foo.bar).Type name = 1;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
 error: unexpected nested extension path in message field
   --> testdata/parser/field/bad-path.proto:35:14
    |
@@ -87,6 +155,17 @@ error: unexpected nested extension path in message field
    |
 36 |     (foo.bar).Type name = 1;
    |     ^^^^^^^^^
+
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:36:5
+   |
+36 |     (foo.bar).Type name = 1;
+   |     ^^^^^^^^^^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+36 |     optional (foo.bar).Type name = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:38:27
@@ -100,11 +179,30 @@ error: unexpected qualified name in message field
 39 |     repeated package.Type (foo.bar).name = 1;
    |                           ^^^^^^^^^^^^^^ expected identifier
 
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/field/bad-path.proto:40:5
+   |
+40 |     required package.Type (foo.bar).name = 1;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:40:27
    |
 40 |     required package.Type (foo.bar).name = 1;
    |                           ^^^^^^^^^^^^^^ expected identifier
+
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:41:5
+   |
+41 |     package.Type (foo.bar).name = 1;
+   |     ^^^^^^^^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+41 |     optional package.Type (foo.bar).name = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: unexpected qualified name in message field
   --> testdata/parser/field/bad-path.proto:41:18
@@ -117,6 +215,17 @@ error: unexpected nested extension path in message field
    |
 43 |     (foo) (bar) = 1;
    |     ^^^^^
+
+error: unexpected type name
+  --> testdata/parser/field/bad-path.proto:43:5
+   |
+43 |     (foo) (bar) = 1;
+   |     ^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+43 |     optional (foo) (bar) = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
 
 error: unexpected extension name in message field
   --> testdata/parser/field/bad-path.proto:43:11
@@ -136,4 +245,4 @@ error: unexpected `/` in path in message field
 46 |     map<string, foo/bar> foo = 1;
    |                    ^ help: replace this with a `.`
 
-encountered 23 errors
+encountered 30 errors and 4 warnings

--- a/experimental/parser/testdata/parser/field/group.proto
+++ b/experimental/parser/testdata/parser/field/group.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/field/group.proto.yaml
+++ b/experimental/parser/testdata/parser/field/group.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/field/incomplete.proto
+++ b/experimental/parser/testdata/parser/field/incomplete.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/field/incomplete.proto.yaml
+++ b/experimental/parser/testdata/parser/field/incomplete.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/field/keywords.proto
+++ b/experimental/parser/testdata/parser/field/keywords.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/field/keywords.proto.yaml
+++ b/experimental/parser/testdata/parser/field/keywords.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/field/modifiers/2023.proto
+++ b/experimental/parser/testdata/parser/field/modifiers/2023.proto
@@ -1,0 +1,33 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package test;
+
+message Foo {
+    required int32 a = 1;
+    optional int32 a = 1;
+    repeated int32 a = 1;
+    int32 a = 1;
+    map<int32, int32> a = 1;
+
+    oneof bar {
+        required int32 a = 1;
+        optional int32 a = 1;
+        repeated int32 a = 1;
+        int32 a = 1;
+        map<int32, int32> a = 1;
+    }
+}

--- a/experimental/parser/testdata/parser/field/modifiers/2023.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/field/modifiers/2023.proto.stderr.txt
@@ -1,0 +1,96 @@
+error: unexpected `required`
+  --> testdata/parser/field/modifiers/2023.proto:20:5
+   |
+20 |     required int32 a = 1;
+   |     ^^^^^^^^ expected type name or `repeated`
+  help: delete it
+   |
+20 | -     required int32 a = 1;
+20 | +     int32 a = 1;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+error: unexpected `optional`
+  --> testdata/parser/field/modifiers/2023.proto:21:5
+   |
+21 |     optional int32 a = 1;
+   |     ^^^^^^^^ expected type name or `repeated`
+  help: delete it
+   |
+21 | -     optional int32 a = 1;
+21 | +     int32 a = 1;
+   |
+   = help: in editions mode, the presence behavior of a singular field is
+           controlled with `[feature.field_presence = ...]`, with the default
+           being equivalent to proto2 `optional`
+   = help: see <https://protobuf.com/docs/language-spec#field-presence>
+
+error: unexpected `required`
+  --> testdata/parser/field/modifiers/2023.proto:27:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+28 | |         optional int32 a = 1;
+...  |
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+27 | -         required int32 a = 1;
+27 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+
+error: unexpected `optional`
+  --> testdata/parser/field/modifiers/2023.proto:28:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+28 | |         optional int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+29 | |         repeated int32 a = 1;
+...  |
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+28 | -         optional int32 a = 1;
+28 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+
+error: unexpected `repeated`
+  --> testdata/parser/field/modifiers/2023.proto:29:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+28 | |         optional int32 a = 1;
+29 | |         repeated int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+30 | |         int32 a = 1;
+31 | |         map<int32, int32> a = 1;
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+29 | -         repeated int32 a = 1;
+29 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+   = help: to emulate a repeated field in a oneof definition, define a local
+           message type with a single repeated field
+
+error: map fields are not allowed inside of a oneof definition
+  --> testdata/parser/field/modifiers/2023.proto:31:9
+   |
+31 |         map<int32, int32> a = 1;
+   |         ^^^^^^^^^^^^^^^^^
+   = help: to emulate a map field in a oneof definition, fine a local message
+           type with a single map field
+
+encountered 6 errors

--- a/experimental/parser/testdata/parser/field/modifiers/2023.proto.yaml
+++ b/experimental/parser/testdata/parser/field/modifiers/2023.proto.yaml
@@ -1,0 +1,81 @@
+decls:
+  - syntax: { kind: KIND_EDITION, value.literal.string_value: "2023" }
+  - package.path.components: [{ ident: "test" }]
+  - def:
+      kind: KIND_MESSAGE
+      name.components: [{ ident: "Foo" }]
+      body.decls:
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_REQUIRED
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_OPTIONAL
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_REPEATED
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.generic:
+              path.components: [{ ident: "map" }]
+              args:
+                - path.components: [{ ident: "int32" }]
+                - path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_ONEOF
+            name.components: [{ ident: "bar" }]
+            body.decls:
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_REQUIRED
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_OPTIONAL
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_REPEATED
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.generic:
+                    path.components: [{ ident: "map" }]
+                    args:
+                      - path.components: [{ ident: "int32" }]
+                      - path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1

--- a/experimental/parser/testdata/parser/field/modifiers/proto2.proto
+++ b/experimental/parser/testdata/parser/field/modifiers/proto2.proto
@@ -1,0 +1,33 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package test;
+
+message Foo {
+    required int32 a = 1;
+    optional int32 a = 1;
+    repeated int32 a = 1;
+    int32 a = 1;
+    map<int32, int32> a = 1;
+
+    oneof bar {
+        required int32 a = 1;
+        optional int32 a = 1;
+        repeated int32 a = 1;
+        int32 a = 1;
+        map<int32, int32> a = 1;
+    }
+}

--- a/experimental/parser/testdata/parser/field/modifiers/proto2.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/field/modifiers/proto2.proto.stderr.txt
@@ -1,0 +1,87 @@
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/field/modifiers/proto2.proto:20:5
+   |
+20 |     required int32 a = 1;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
+error: unexpected type name
+  --> testdata/parser/field/modifiers/proto2.proto:23:5
+   |
+23 |     int32 a = 1;
+   |     ^^^^^ expected `optional`, `repeated`, or `required`
+  help: use the `optional` modifier
+   |
+23 |     optional int32 a = 1;
+   |     +++++++++
+   = note: modifiers are required in proto2
+
+error: unexpected `required`
+  --> testdata/parser/field/modifiers/proto2.proto:27:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+28 | |         optional int32 a = 1;
+...  |
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+27 | -         required int32 a = 1;
+27 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+
+error: unexpected `optional`
+  --> testdata/parser/field/modifiers/proto2.proto:28:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+28 | |         optional int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+29 | |         repeated int32 a = 1;
+...  |
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+28 | -         optional int32 a = 1;
+28 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+
+error: unexpected `repeated`
+  --> testdata/parser/field/modifiers/proto2.proto:29:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+28 | |         optional int32 a = 1;
+29 | |         repeated int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+30 | |         int32 a = 1;
+31 | |         map<int32, int32> a = 1;
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+29 | -         repeated int32 a = 1;
+29 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+   = help: to emulate a repeated field in a oneof definition, define a local
+           message type with a single repeated field
+
+error: map fields are not allowed inside of a oneof definition
+  --> testdata/parser/field/modifiers/proto2.proto:31:9
+   |
+31 |         map<int32, int32> a = 1;
+   |         ^^^^^^^^^^^^^^^^^
+   = help: to emulate a map field in a oneof definition, fine a local message
+           type with a single map field
+
+encountered 5 errors and 1 warning

--- a/experimental/parser/testdata/parser/field/modifiers/proto2.proto.yaml
+++ b/experimental/parser/testdata/parser/field/modifiers/proto2.proto.yaml
@@ -1,0 +1,81 @@
+decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - package.path.components: [{ ident: "test" }]
+  - def:
+      kind: KIND_MESSAGE
+      name.components: [{ ident: "Foo" }]
+      body.decls:
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_REQUIRED
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_OPTIONAL
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_REPEATED
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.generic:
+              path.components: [{ ident: "map" }]
+              args:
+                - path.components: [{ ident: "int32" }]
+                - path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_ONEOF
+            name.components: [{ ident: "bar" }]
+            body.decls:
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_REQUIRED
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_OPTIONAL
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_REPEATED
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.generic:
+                    path.components: [{ ident: "map" }]
+                    args:
+                      - path.components: [{ ident: "int32" }]
+                      - path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1

--- a/experimental/parser/testdata/parser/field/modifiers/proto3.proto
+++ b/experimental/parser/testdata/parser/field/modifiers/proto3.proto
@@ -1,0 +1,33 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message Foo {
+    required int32 a = 1;
+    optional int32 a = 1;
+    repeated int32 a = 1;
+    int32 a = 1;
+    map<int32, int32> a = 1;
+
+    oneof bar {
+        required int32 a = 1;
+        optional int32 a = 1;
+        repeated int32 a = 1;
+        int32 a = 1;
+        map<int32, int32> a = 1;
+    }
+}

--- a/experimental/parser/testdata/parser/field/modifiers/proto3.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/field/modifiers/proto3.proto.stderr.txt
@@ -1,0 +1,81 @@
+error: unexpected `required`
+  --> testdata/parser/field/modifiers/proto3.proto:20:5
+   |
+20 |     required int32 a = 1;
+   |     ^^^^^^^^ expected type name, `optional`, or `repeated`
+  help: delete it
+   |
+20 | -     required int32 a = 1;
+20 | +     int32 a = 1;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+error: unexpected `required`
+  --> testdata/parser/field/modifiers/proto3.proto:27:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+28 | |         optional int32 a = 1;
+...  |
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+27 | -         required int32 a = 1;
+27 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+
+error: unexpected `optional`
+  --> testdata/parser/field/modifiers/proto3.proto:28:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+28 | |         optional int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+29 | |         repeated int32 a = 1;
+...  |
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+28 | -         optional int32 a = 1;
+28 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+
+error: unexpected `repeated`
+  --> testdata/parser/field/modifiers/proto3.proto:29:9
+   |
+26 | /     oneof bar {
+27 | |         required int32 a = 1;
+28 | |         optional int32 a = 1;
+29 | |         repeated int32 a = 1;
+   | |         ^^^^^^^^ expected type name
+30 | |         int32 a = 1;
+31 | |         map<int32, int32> a = 1;
+32 | |     }
+   | \_____- within this oneof definition
+  help: delete it
+   |
+29 | -         repeated int32 a = 1;
+29 | +         int32 a = 1;
+   |
+   = note: fields defined as part of a oneof definition may not have modifiers
+           applied to them
+   = help: to emulate a repeated field in a oneof definition, define a local
+           message type with a single repeated field
+
+error: map fields are not allowed inside of a oneof definition
+  --> testdata/parser/field/modifiers/proto3.proto:31:9
+   |
+31 |         map<int32, int32> a = 1;
+   |         ^^^^^^^^^^^^^^^^^
+   = help: to emulate a map field in a oneof definition, fine a local message
+           type with a single map field
+
+encountered 5 errors

--- a/experimental/parser/testdata/parser/field/modifiers/proto3.proto.yaml
+++ b/experimental/parser/testdata/parser/field/modifiers/proto3.proto.yaml
@@ -1,0 +1,81 @@
+decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
+  - package.path.components: [{ ident: "test" }]
+  - def:
+      kind: KIND_MESSAGE
+      name.components: [{ ident: "Foo" }]
+      body.decls:
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_REQUIRED
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_OPTIONAL
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.prefixed:
+              prefix: PREFIX_REPEATED
+              type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_FIELD
+            name.components: [{ ident: "a" }]
+            type.generic:
+              path.components: [{ ident: "map" }]
+              args:
+                - path.components: [{ ident: "int32" }]
+                - path.components: [{ ident: "int32" }]
+            value.literal.int_value: 1
+        - def:
+            kind: KIND_ONEOF
+            name.components: [{ ident: "bar" }]
+            body.decls:
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_REQUIRED
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_OPTIONAL
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.prefixed:
+                    prefix: PREFIX_REPEATED
+                    type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1
+              - def:
+                  kind: KIND_FIELD
+                  name.components: [{ ident: "a" }]
+                  type.generic:
+                    path.components: [{ ident: "map" }]
+                    args:
+                      - path.components: [{ ident: "int32" }]
+                      - path.components: [{ ident: "int32" }]
+                  value.literal.int_value: 1

--- a/experimental/parser/testdata/parser/field/ok.proto
+++ b/experimental/parser/testdata/parser/field/ok.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/field/ok.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/field/ok.proto.stderr.txt
@@ -1,0 +1,53 @@
+error: unexpected `required`
+  --> testdata/parser/field/ok.proto:22:5
+   |
+22 |     required Type name = 1;
+   |     ^^^^^^^^ expected type name, `optional`, or `repeated`
+  help: delete it
+   |
+22 | -     required Type name = 1;
+22 | +     Type name = 1;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+error: unexpected `required`
+  --> testdata/parser/field/ok.proto:27:5
+   |
+27 |     required .Type name = 1;
+   |     ^^^^^^^^ expected type name, `optional`, or `repeated`
+  help: delete it
+   |
+27 | -     required .Type name = 1;
+27 | +     .Type name = 1;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+error: unexpected `required`
+  --> testdata/parser/field/ok.proto:32:5
+   |
+32 |     required package.Type name = 1;
+   |     ^^^^^^^^ expected type name, `optional`, or `repeated`
+  help: delete it
+   |
+32 | -     required package.Type name = 1;
+32 | +     package.Type name = 1;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+error: unexpected `required`
+  --> testdata/parser/field/ok.proto:37:5
+   |
+37 |     required .package.Type name = 1;
+   |     ^^^^^^^^ expected type name, `optional`, or `repeated`
+  help: delete it
+   |
+37 | -     required .package.Type name = 1;
+37 | +     .package.Type name = 1;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+encountered 4 errors

--- a/experimental/parser/testdata/parser/field/ok.proto.yaml
+++ b/experimental/parser/testdata/parser/field/ok.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/field/options.proto
+++ b/experimental/parser/testdata/parser/field/options.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/field/options.proto.yaml
+++ b/experimental/parser/testdata/parser/field/options.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/lists.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/lists.proto.stderr.txt
@@ -3,6 +3,11 @@ warning: missing `package` declaration
    = note: not explicitly specifying a package places the file in the unnamed
            package; using it strongly is discouraged
 
+warning: missing `syntax` declaration
+ --> testdata/parser/lists.proto
+   = note: this defaults to "proto2"; not specifying this  explicitly is
+           discouraged
+
 error: unexpected array expression in option setting value
   --> testdata/parser/lists.proto:17:14
    |
@@ -882,4 +887,4 @@ error: unexpected `message` after reserved range
 76 |     reserved a, b c;
    |                    +
 
-encountered 94 errors and 1 warning
+encountered 94 errors and 2 warnings

--- a/experimental/parser/testdata/parser/option/bad_path.proto
+++ b/experimental/parser/testdata/parser/option/bad_path.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/option/bad_path.proto.yaml
+++ b/experimental/parser/testdata/parser/option/bad_path.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def.kind: KIND_OPTION
   - def:

--- a/experimental/parser/testdata/parser/option/ok.proto
+++ b/experimental/parser/testdata/parser/option/ok.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/option/ok.proto.yaml
+++ b/experimental/parser/testdata/parser/option/ok.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_OPTION

--- a/experimental/parser/testdata/parser/range/proto3.proto
+++ b/experimental/parser/testdata/parser/range/proto3.proto
@@ -1,0 +1,21 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message F {
+    extensions 1;
+}

--- a/experimental/parser/testdata/parser/range/proto3.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/range/proto3.proto.stderr.txt
@@ -1,0 +1,7 @@
+error: extension ranges are not permitted in proto3
+  --> testdata/parser/range/proto3.proto:20:5
+   |
+20 |     extensions 1;
+   |     ^^^^^^^^^^^^^
+
+encountered 1 error

--- a/experimental/parser/testdata/parser/range/proto3.proto.yaml
+++ b/experimental/parser/testdata/parser/range/proto3.proto.yaml
@@ -1,0 +1,8 @@
+decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
+  - package.path.components: [{ ident: "test" }]
+  - def:
+      kind: KIND_MESSAGE
+      name.components: [{ ident: "F" }]
+      body.decls:
+        - range: { kind: KIND_EXTENSIONS, ranges: [{ literal.int_value: 1 }] }

--- a/experimental/parser/testdata/parser/range/reserved_default_syntax.proto
+++ b/experimental/parser/testdata/parser/range/reserved_default_syntax.proto
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+syntax = "proto2";
+
 package test;
 
 message Foo {

--- a/experimental/parser/testdata/parser/range/reserved_default_syntax.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/range/reserved_default_syntax.proto.stderr.txt
@@ -1,11 +1,14 @@
 error: cannot use identifiers in reserved range in syntax mode
-  --> testdata/parser/range/reserved_default_syntax.proto:18:14
+  --> testdata/parser/range/reserved_default_syntax.proto:20:14
    |
-18 |     reserved foo, "foo";
+15 | syntax = "proto2";
+   | ------------------ syntax mode is specified here
+...
+20 |     reserved foo, "foo";
    |              ^^^
   help: quote it to make it into a string literal
    |
-18 |     reserved "foo", "foo";
+20 |     reserved "foo", "foo";
    |              +   +
 
 encountered 1 error

--- a/experimental/parser/testdata/parser/range/reserved_default_syntax.proto.yaml
+++ b/experimental/parser/testdata/parser/range/reserved_default_syntax.proto.yaml
@@ -1,4 +1,5 @@
 decls:
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/syntax/missing.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/syntax/missing.proto.stderr.txt
@@ -1,0 +1,6 @@
+warning: missing `syntax` declaration
+ --> testdata/parser/syntax/missing.proto
+   = note: this defaults to "proto2"; not specifying this  explicitly is
+           discouraged
+
+encountered 1 warning

--- a/experimental/parser/testdata/parser/type/generic.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/type/generic.proto.stderr.txt
@@ -52,6 +52,14 @@ error: unexpected type after `repeated`
 31 |     repeated map<string, string> x9 = 9;
    |              ^^^^^^^^^^^^^^^^^^^ expected type name
 
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/type/generic.proto:32:5
+   |
+32 |     required map<string, string> x10 = 10;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
 error: unexpected type after `required`
   --> testdata/parser/type/generic.proto:32:14
    |
@@ -139,4 +147,4 @@ error: only message types may appear in method return type
 44 |     rpc X3(map<string, repeated string>) returns (stream map<string, string>) {}
    |                                                          ^^^^^^^^^^^^^^^^^^^
 
-encountered 21 errors
+encountered 21 errors and 1 warning

--- a/experimental/parser/testdata/parser/type/ok.proto
+++ b/experimental/parser/testdata/parser/type/ok.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package test;
 

--- a/experimental/parser/testdata/parser/type/ok.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/type/ok.proto.stderr.txt
@@ -1,0 +1,14 @@
+error: unexpected `required`
+  --> testdata/parser/type/ok.proto:22:5
+   |
+22 |     required M x3 = 3;
+   |     ^^^^^^^^ expected type name, `optional`, or `repeated`
+  help: delete it
+   |
+22 | -     required M x3 = 3;
+22 | +     M x3 = 3;
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+encountered 1 error

--- a/experimental/parser/testdata/parser/type/ok.proto.yaml
+++ b/experimental/parser/testdata/parser/type/ok.proto.yaml
@@ -1,5 +1,5 @@
 decls:
-  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+  - syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto3" }
   - package.path.components: [{ ident: "test" }]
   - def:
       kind: KIND_MESSAGE

--- a/experimental/parser/testdata/parser/type/repeated.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/type/repeated.proto.stderr.txt
@@ -14,6 +14,14 @@ error: encountered more than one type modifier
    |     |
    |     first one is here
 
+warning: required fields are deprecated and should not be used
+  --> testdata/parser/type/repeated.proto:22:5
+   |
+22 |     required optional M x3 = 3;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to optional if the field is already
+           in-use; doing so is a wire protocol break
+
 error: encountered more than one type modifier
   --> testdata/parser/type/repeated.proto:22:14
    |
@@ -38,11 +46,17 @@ error: encountered more than one type modifier
    |     |
    |     first one is here
 
-error: the `stream` modifier may only appear in a method signature
+error: unexpected `stream`
   --> testdata/parser/type/repeated.proto:25:5
    |
 25 |     stream stream M x6 = 6;
-   |     ^^^^^^
+   |     ^^^^^^ expected `optional`, `repeated`, or `required`
+  help: delete it
+   |
+25 | -     stream stream M x6 = 6;
+25 | +     stream M x6 = 6;
+   |
+   = help: the `stream` modifier may only appear in a method signature
 
 error: encountered more than one type modifier
   --> testdata/parser/type/repeated.proto:25:12
@@ -190,4 +204,4 @@ error: only message types may appear in method return type
 35 |     rpc X6(stream stream .test.M) returns stream repeated M {}
    |                                                  ^^^^^^^^^^
 
-encountered 28 errors
+encountered 28 errors and 1 warning


### PR DESCRIPTION
This PR adds legalization diagnostics against:

1. Field modifiers not allowed in a particular syntax version.
2. Required fields (as a warning in proto2).
3. Field modifiers (and maps) inside of oneofs.
4. Extension ranges in proto3.

We cannot legalize extension blocks in proto3 in the legalizer, because extension blocks *are* permitted for extendable types defined in `google/protobuf/descriptor.proto`.