### PR TITLE
Implement option name resolution

### DIFF
--- a/experimental/ast/path_test.go
+++ b/experimental/ast/path_test.go
@@ -16,6 +16,7 @@ package ast_test
 
 import (
 	"fmt"
+	"iter"
 	"slices"
 	"testing"
 
@@ -77,6 +78,27 @@ func TestNaturalSplit(t *testing.T) {
 	start, end = path.Split(2)
 	pathEq(t, start, components[:2])
 	pathEq(t, end, components[2:])
+
+	start, end = nth(path.Components, 0).SplitBefore()
+	pathEq(t, start, [][2]token.Token{})
+	pathEq(t, end, components)
+	start, end = nth(path.Components, 0).SplitAfter()
+	pathEq(t, start, components[:1])
+	pathEq(t, end, components[1:])
+
+	start, end = nth(path.Components, 1).SplitBefore()
+	pathEq(t, start, components[:1])
+	pathEq(t, end, components[1:])
+	start, end = nth(path.Components, 1).SplitAfter()
+	pathEq(t, start, components[:2])
+	pathEq(t, end, components[2:])
+
+	start, end = nth(path.Components, 3).SplitBefore()
+	pathEq(t, start, components[:3])
+	pathEq(t, end, components[3:])
+	start, end = nth(path.Components, 3).SplitAfter()
+	pathEq(t, start, components)
+	pathEq(t, end, [][2]token.Token{})
 }
 
 func TestSyntheticSplit(t *testing.T) {
@@ -117,6 +139,10 @@ func TestSyntheticSplit(t *testing.T) {
 	pathEq(t, start, [][2]token.Token{})
 	pathEq(t, end, components)
 
+	start, end = path.Split(1)
+	pathEq(t, start, components[:1])
+	pathEq(t, end, components[1:])
+
 	start, end = path.Split(2)
 	pathEq(t, start, components[:2])
 	pathEq(t, end, components[2:])
@@ -143,4 +169,14 @@ func stringEq[T any](t *testing.T, tokens []T, expected []T) {
 		b[i] = fmt.Sprint(t)
 	}
 	assert.Equal(t, b, a)
+}
+
+func nth[T any](seq iter.Seq[T], n int) (x T) {
+	for v := range seq {
+		if n == 0 {
+			return v
+		}
+		n--
+	}
+	return x
 }

--- a/experimental/incremental/queries/file.go
+++ b/experimental/incremental/queries/file.go
@@ -23,9 +23,6 @@ import (
 // File is an [incremental.Query] for the contents of a file as provided
 // by a [source.Opener].
 //
-// Will automatically include [source.WKTs] when performing the lookup of a
-// file, but only as a fallback when File.Opener does not override it.
-//
 // File queries with different Openers are considered distinct.
 type File struct {
 	source.Opener // Must be comparable.
@@ -53,8 +50,7 @@ func (f File) Key() any {
 // Execute implements [incremental.Query].
 func (f File) Execute(t *incremental.Task) (*report.File, error) {
 	if !f.ReportError {
-		src := source.Openers{f.Opener, source.WKTs()}
-		text, err := src.Open(f.Path)
+		text, err := f.Open(f.Path)
 
 		if err != nil {
 			return nil, err

--- a/experimental/incremental/queries/file.go
+++ b/experimental/incremental/queries/file.go
@@ -23,6 +23,9 @@ import (
 // File is an [incremental.Query] for the contents of a file as provided
 // by a [source.Opener].
 //
+// Will automatically include [source.WKTs] when performing the lookup of a
+// file, but only as a fallback when File.Opener does not override it.
+//
 // File queries with different Openers are considered distinct.
 type File struct {
 	source.Opener // Must be comparable.
@@ -50,7 +53,9 @@ func (f File) Key() any {
 // Execute implements [incremental.Query].
 func (f File) Execute(t *incremental.Task) (*report.File, error) {
 	if !f.ReportError {
-		text, err := f.Open(f.Path)
+		src := source.Openers{f.Opener, source.WKTs()}
+		text, err := src.Open(f.Path)
+
 		if err != nil {
 			return nil, err
 		}

--- a/experimental/incremental/queries/ir.go
+++ b/experimental/incremental/queries/ir.go
@@ -93,11 +93,13 @@ func (i IR) Execute(t *incremental.Task) (ir.File, error) {
 			request: decl,
 		}
 	}
+	//nolint:makezero // False positive.
 	queries = append(queries, IR{
 		Opener:  i.Opener,
 		Session: i.Session,
 		Path:    ir.DescriptorProtoPath,
 	})
+	//nolint:makezero // False positive.
 	errors = append(errors, nil)
 
 	imports, err := incremental.Resolve(t, queries...)

--- a/experimental/internal/taxa/noun.go
+++ b/experimental/internal/taxa/noun.go
@@ -52,6 +52,8 @@ const (
 	Group
 	Option
 	CustomOption
+	FieldSelector
+	PseudoOption
 	Field
 	Extension
 	EnumValue
@@ -169,6 +171,8 @@ var _table_Noun_String = [...]string{
 	Group:              "group definition",
 	Option:             "option setting",
 	CustomOption:       "custom option setting",
+	FieldSelector:      "field selector",
+	PseudoOption:       "pseudo-option",
 	Field:              "message field",
 	Extension:          "message extension",
 	EnumValue:          "enum value",
@@ -269,6 +273,8 @@ var _table_Noun_GoString = [...]string{
 	Group:              "Group",
 	Option:             "Option",
 	CustomOption:       "CustomOption",
+	FieldSelector:      "FieldSelector",
+	PseudoOption:       "PseudoOption",
 	Field:              "Field",
 	Extension:          "Extension",
 	EnumValue:          "EnumValue",

--- a/experimental/internal/taxa/noun.yaml
+++ b/experimental/internal/taxa/noun.yaml
@@ -52,6 +52,8 @@
 
   - {name: Option, string: "option setting"}
   - {name: CustomOption, string: "custom option setting"}
+  - {name: FieldSelector, string: "field selector"}
+  - {name: PseudoOption, string: "pseudo-option"}
 
   - {name: Field, string: "message field"}
   - {name: Extension, string: "message extension"}

--- a/experimental/ir/ir_field.go
+++ b/experimental/ir/ir_field.go
@@ -17,6 +17,7 @@ package ir
 import (
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/internal"
+	"github.com/bufbuild/protocompile/experimental/internal/taxa"
 	"github.com/bufbuild/protocompile/experimental/ir/presence"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/internal/arena"
@@ -154,7 +155,6 @@ func (f Field) Parent() Type {
 	if f.IsZero() {
 		return Type{}
 	}
-
 	return wrapType(f.Context(), ref[rawType]{ptr: f.raw.parent})
 }
 
@@ -169,7 +169,6 @@ func (f Field) Element() Type {
 	if f.IsZero() {
 		return Type{}
 	}
-
 	return wrapType(f.Context(), f.raw.elem)
 }
 
@@ -202,6 +201,18 @@ func (f Field) Oneof() Oneof {
 // Options returns the options applied to this field.
 func (f Field) Options() MessageValue {
 	return wrapValue(f.Context(), f.raw.options).AsMessage()
+}
+
+// noun returns a [taxa.Noun] for diagnostics.
+func (f Field) noun() taxa.Noun {
+	switch {
+	case f.IsEnumValue():
+		return taxa.EnumValue
+	case f.IsExtension():
+		return taxa.Extension
+	default:
+		return taxa.Field
+	}
 }
 
 func wrapField(c *Context, r ref[rawField]) Field {

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -69,6 +69,20 @@ type Context struct {
 	// of each direct import.
 	exported, imported symtab
 
+	// Symbols that are built into the language, and which the compiler cannot
+	// handle not being present. This field is only present in the Context
+	// for descriptor.proto.
+	//
+	// See [resolveLangSymbols] for where they are resolved.
+	langSymbols *struct {
+		fileOptions,
+		messageOptions,
+		fieldOptions,
+		oneofOptions,
+		enumOptions,
+		enumValueOptions arena.Pointer[rawField]
+	}
+
 	arenas struct {
 		types     arena.Arena[rawType]
 		fields    arena.Arena[rawField]

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -69,19 +69,7 @@ type Context struct {
 	// of each direct import.
 	exported, imported symtab
 
-	// Symbols that are built into the language, and which the compiler cannot
-	// handle not being present. This field is only present in the Context
-	// for descriptor.proto.
-	//
-	// See [resolveLangSymbols] for where they are resolved.
-	langSymbols *struct {
-		fileOptions,
-		messageOptions,
-		fieldOptions,
-		oneofOptions,
-		enumOptions,
-		enumValueOptions arena.Pointer[rawField]
-	}
+	langSymbols *langSymbols
 
 	arenas struct {
 		types     arena.Arena[rawType]
@@ -94,6 +82,20 @@ type Context struct {
 		messages arena.Arena[rawMessageValue]
 		arrays   arena.Arena[[]rawValueBits]
 	}
+}
+
+// langSymbols contains those symbols that are built into the language, and which the compiler cannot
+// handle not being present. This field is only present in the Context
+// for descriptor.proto.
+//
+// See [resolveLangSymbols] for where they are resolved.
+type langSymbols struct {
+	fileOptions,
+	messageOptions,
+	fieldOptions,
+	oneofOptions,
+	enumOptions,
+	enumValueOptions arena.Pointer[rawField]
 }
 
 type withContext = internal.With[*Context]

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -40,8 +40,9 @@ type Context struct {
 	// to normalize it.
 	path intern.ID
 
-	syntax syntax.Syntax
-	pkg    intern.ID
+	syntax            syntax.Syntax
+	pkg               intern.ID
+	isDescriptorProto bool // This is the magic descriptor.proto file.
 
 	imports imports
 
@@ -128,11 +129,17 @@ type withContext2 struct{ internal.With[*Context] }
 
 // AST returns the AST this file was parsed from.
 func (f File) AST() ast.File {
+	if f.IsZero() {
+		return ast.File{}
+	}
 	return f.Context().ast
 }
 
 // Syntax returns the syntax pragma that applies to this file.
 func (f File) Syntax() syntax.Syntax {
+	if f.IsZero() {
+		return syntax.Unknown
+	}
 	return f.Context().syntax
 }
 
@@ -140,12 +147,18 @@ func (f File) Syntax() syntax.Syntax {
 //
 // This need not be the same as [File.AST]().Span().Path().
 func (f File) Path() string {
+	if f.IsZero() {
+		return ""
+	}
 	c := f.Context()
 	return c.session.intern.Value(c.path)
 }
 
 // InternedPackage returns the intern ID for the value of [File.Path].
 func (f File) InternedPath() intern.ID {
+	if f.IsZero() {
+		return 0
+	}
 	return f.Context().path
 }
 
@@ -154,12 +167,18 @@ func (f File) InternedPath() intern.ID {
 // The name will not include a leading dot. It will be empty for the empty
 // package.
 func (f File) Package() FullName {
+	if f.IsZero() {
+		return ""
+	}
 	c := f.Context()
 	return FullName(c.session.intern.Value(c.pkg))
 }
 
 // InternedPackage returns the intern ID for the value of [File.Package].
 func (f File) InternedPackage() intern.ID {
+	if f.IsZero() {
+		return 0
+	}
 	return f.Context().pkg
 }
 

--- a/experimental/ir/ir_imports_test.go
+++ b/experimental/ir/ir_imports_test.go
@@ -121,6 +121,7 @@ func buildFile(
 		table.AddDirect(imp)
 	}
 	table.Recurse(dedup)
+	table.Insert(ir.File{}, -1, false) // Dummy descriptor.proto.
 
 	return file
 }

--- a/experimental/ir/ir_symbol.go
+++ b/experimental/ir/ir_symbol.go
@@ -177,6 +177,16 @@ func (k SymbolKind) IsField() bool {
 	}
 }
 
+// IsType returns whether this is a *message* field's symbol kind.
+func (k SymbolKind) IsMessageField() bool {
+	switch k {
+	case SymbolKindField, SymbolKindExtension:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsScope returns whether this is a symbol that defines a scope, for the
 // purposes of name lookup.
 func (k SymbolKind) IsScope() bool {

--- a/experimental/ir/ir_symbol.go
+++ b/experimental/ir/ir_symbol.go
@@ -166,7 +166,7 @@ func (k SymbolKind) IsType() bool {
 	}
 }
 
-// IsType returns whether this is a field's symbol kind. This includes
+// IsField returns whether this is a field's symbol kind. This includes
 // enum values, which the ir package treats as fields of enum types.
 func (k SymbolKind) IsField() bool {
 	switch k {
@@ -177,7 +177,7 @@ func (k SymbolKind) IsField() bool {
 	}
 }
 
-// IsType returns whether this is a *message* field's symbol kind.
+// IsMessageField returns whether this is a field's symbol kind.
 func (k SymbolKind) IsMessageField() bool {
 	switch k {
 	case SymbolKindField, SymbolKindExtension:

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -46,7 +46,7 @@ import (
 // Test is the type that a test case for the compiler is deserialized from.
 type Test struct {
 	Files       []File `yaml:"files"`
-	IncludeWKTs bool   `yaml:"include_wkts"`
+	IncludeWKTs bool   `yaml:"include_wkts"` //nolint:tagliatelle
 }
 
 type File struct {

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -19,6 +19,7 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/incremental"
 	"github.com/bufbuild/protocompile/experimental/incremental/queries"
 	"github.com/bufbuild/protocompile/experimental/ir"
+	"github.com/bufbuild/protocompile/experimental/ir/presence"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/experimental/source"
@@ -43,7 +45,8 @@ import (
 
 // Test is the type that a test case for the compiler is deserialized from.
 type Test struct {
-	Files []File `yaml:"files"`
+	Files       []File `yaml:"files"`
+	IncludeWKTs bool   `yaml:"include_wkts"`
 }
 
 type File struct {
@@ -121,23 +124,31 @@ func TestIR(t *testing.T) {
 		fds := new(descriptorpb.FileDescriptorSet)
 		require.NoError(t, proto.Unmarshal(bytes, fds))
 
+		if !test.IncludeWKTs {
+			fds.File = slices.DeleteFunc(fds.File, func(fdp *descriptorpb.FileDescriptorProto) bool {
+				return strings.HasPrefix(*fdp.Name, "google/protobuf/")
+			})
+		}
+
 		outputs[0] = prototest.ToYAML(fds, prototest.ToYAMLOptions{})
-		outputs[1] = prototest.ToYAML(symtabProto(irs), prototest.ToYAMLOptions{})
+		outputs[1] = prototest.ToYAML(symtabProto(irs, &test), prototest.ToYAMLOptions{})
 	})
 }
 
-func symtabProto(files []ir.File) *compilerpb.SymbolSet {
+func symtabProto(files []ir.File, t *Test) *compilerpb.SymbolSet {
 	set := new(compilerpb.SymbolSet)
 	set.Tables = make(map[string]*compilerpb.SymbolTable)
 
 	for _, file := range files {
-		if file.Symbols().Len() <= 1 {
+		if file.Symbols().Len() <= 1 && file.Options().IsZero() {
 			// Don't bother if the file only has a single symbol for its
 			// package.
 			continue
 		}
 
-		symtab := new(compilerpb.SymbolTable)
+		symtab := &compilerpb.SymbolTable{
+			Options: messageProto(file.Options()),
+		}
 
 		for imp := range seq.Values(file.TransitiveImports()) {
 			symtab.Imports = append(symtab.Imports, &compilerpb.Import{
@@ -151,12 +162,27 @@ func symtabProto(files []ir.File) *compilerpb.SymbolSet {
 		slices.SortFunc(symtab.Imports, cmpx.Key(func(x *compilerpb.Import) string { return x.Path }))
 
 		for sym := range seq.Values(file.Symbols()) {
+			if !t.IncludeWKTs && strings.HasPrefix(sym.File().Path(), "google/protobuf/") {
+				continue
+			}
+
+			var options ir.MessageValue
+			switch sym.Kind() {
+			case ir.SymbolKindMessage, ir.SymbolKindEnum:
+				options = sym.AsType().Options()
+			case ir.SymbolKindField, ir.SymbolKindExtension, ir.SymbolKindEnumValue:
+				options = sym.AsField().Options()
+			case ir.SymbolKindOneof:
+				options = sym.AsOneof().Options()
+			}
+
 			symtab.Symbols = append(symtab.Symbols, &compilerpb.Symbol{
 				Fqn:     string(sym.FullName()),
 				Kind:    compilerpb.Symbol_Kind(sym.Kind()),
 				File:    sym.File().Path(),
 				Index:   uint32(sym.RawData()),
 				Visible: sym.Kind() != ir.SymbolKindPackage && sym.Visible(),
+				Options: messageProto(options),
 			})
 		}
 		slices.SortFunc(symtab.Symbols,
@@ -171,4 +197,67 @@ func symtabProto(files []ir.File) *compilerpb.SymbolSet {
 	}
 
 	return set
+}
+
+func messageProto(v ir.MessageValue) *compilerpb.Value {
+	if v.IsZero() {
+		return nil
+	}
+
+	m := new(compilerpb.Value_Message)
+	for elem := range seq.Values(v.Fields()) {
+		if elem.Field().IsExtension() {
+			if m.Extns == nil {
+				m.Extns = make(map[string]*compilerpb.Value)
+			}
+			m.Extns[string(elem.Field().FullName())] = valueProto(elem)
+		} else {
+			if m.Fields == nil {
+				m.Fields = make(map[string]*compilerpb.Value)
+			}
+			m.Fields[elem.Field().Name()] = valueProto(elem)
+		}
+	}
+
+	return &compilerpb.Value{Value: &compilerpb.Value_Message_{Message: m}}
+}
+
+func valueProto(v ir.Value) *compilerpb.Value {
+	if v.IsZero() {
+		return nil
+	}
+
+	element := func(v ir.Element) *compilerpb.Value {
+		if x, ok := v.AsBool(); ok {
+			return &compilerpb.Value{Value: &compilerpb.Value_Bool{Bool: x}}
+		}
+
+		if x, ok := v.AsInt(); ok {
+			return &compilerpb.Value{Value: &compilerpb.Value_Int{Int: x}}
+		}
+
+		if x, ok := v.AsUInt(); ok {
+			return &compilerpb.Value{Value: &compilerpb.Value_Uint{Uint: x}}
+		}
+
+		if x, ok := v.AsFloat(); ok {
+			return &compilerpb.Value{Value: &compilerpb.Value_Float{Float: x}}
+		}
+
+		if x, ok := v.AsString(); ok {
+			return &compilerpb.Value{Value: &compilerpb.Value_String_{String_: []byte(x)}}
+		}
+
+		return messageProto(v.AsMessage())
+	}
+
+	if v.Field().Presence() == presence.Repeated {
+		r := new(compilerpb.Value_Repeated)
+		for elem := range seq.Values(v.Elements()) {
+			r.Values = append(r.Values, element(elem))
+		}
+		return &compilerpb.Value{Value: &compilerpb.Value_Repeated_{Repeated: r}}
+	}
+
+	return element(v.Elements().At(0))
 }

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -47,9 +47,9 @@ import (
 //
 //nolint:tagliatelle
 type Test struct {
-	Files          []File `yaml:"files"`
-	DisableSysroot bool   `yaml:"disable_sysroot"`
-	OutputWKTs     bool   `yaml:"output_wkts"`
+	Files             []File `yaml:"files"`
+	ExcludeWKTSources bool   `yaml:"exclude_wkt_sources"`
+	OutputWKTs        bool   `yaml:"output_wkts"`
 }
 
 type File struct {
@@ -88,7 +88,7 @@ func TestIR(t *testing.T) {
 			},
 		)))
 
-		if !test.DisableSysroot {
+		if !test.ExcludeWKTSources {
 			files = &source.Openers{files, source.WKTs()}
 		}
 

--- a/experimental/ir/ir_type.go
+++ b/experimental/ir/ir_type.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ast/predeclared"
 	"github.com/bufbuild/protocompile/experimental/internal"
+	"github.com/bufbuild/protocompile/experimental/internal/taxa"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/internal/arena"
 	"github.com/bufbuild/protocompile/internal/intern"
@@ -36,6 +37,7 @@ type rawType struct {
 	def             ast.DeclDef
 	nested          []arena.Pointer[rawType]
 	fields          []arena.Pointer[rawField]
+	fieldByName     func() intern.Map[arena.Pointer[rawField]]
 	ranges          []rawRange
 	reservedNames   []rawReservedName
 	oneofs          []arena.Pointer[rawOneof]
@@ -109,7 +111,7 @@ func (t Type) IsPredeclared() bool {
 
 // IsMessage returns whether this is a message type.
 func (t Type) IsMessage() bool {
-	return !t.IsPredeclared() && !t.raw.isEnum
+	return !t.IsZero() && !t.IsPredeclared() && !t.raw.isEnum
 }
 
 // IsMessage returns whether this is an enum type.
@@ -234,6 +236,30 @@ func (t Type) Fields() seq.Indexer[Field] {
 	)
 }
 
+// FieldByName looks up a field with the given name.
+//
+// Returns a zero field if there is no such field.
+func (t Type) FieldByName(name string) Field {
+	id, ok := t.Context().session.intern.Query(name)
+	if !ok {
+		return Field{}
+	}
+
+	ptr := t.raw.fieldByName()[id]
+	return wrapField(t.Context(), ref[rawField]{ptr: ptr})
+}
+
+// makeFieldsByName creates the FieldByName map. This is used to keep
+// construction of this map lazy.
+func (t Type) makeFieldByName() intern.Map[arena.Pointer[rawField]] {
+	table := make(intern.Map[arena.Pointer[rawField]], t.Fields().Len())
+	for _, ptr := range t.raw.fields {
+		field := wrapField(t.Context(), ref[rawField]{ptr: ptr})
+		table[field.InternedName()] = ptr
+	}
+	return table
+}
+
 // Extensions returns any extensions nested within this type.
 func (t Type) Extensions() seq.Indexer[Field] {
 	return seq.NewFixedSlice(
@@ -285,6 +311,18 @@ func (t Type) Oneofs() seq.Indexer[Oneof] {
 // Options returns the options applied to this type.
 func (t Type) Options() MessageValue {
 	return wrapValue(t.Context(), t.raw.options).AsMessage()
+}
+
+// noun returns a [taxa.Noun] for diagnostics.
+func (t Type) noun() taxa.Noun {
+	switch {
+	case t.IsPredeclared():
+		return taxa.ScalarType
+	case t.IsEnum():
+		return taxa.EnumType
+	default:
+		return taxa.MessageType
+	}
 }
 
 func wrapType(c *Context, r ref[rawType]) Type {

--- a/experimental/ir/ir_type.go
+++ b/experimental/ir/ir_type.go
@@ -42,7 +42,7 @@ type rawType struct {
 	options         arena.Pointer[rawValue]
 	fqn, name       intern.ID // 0 for predeclared types.
 	parent          arena.Pointer[rawType]
-	fieldsExtnStart uint32
+	fieldsEnd       uint32
 	rangesExtnStart uint32
 	isEnum          bool
 }
@@ -227,7 +227,7 @@ func (t Type) Nested() seq.Indexer[Type] {
 // type.
 func (t Type) Fields() seq.Indexer[Field] {
 	return seq.NewFixedSlice(
-		t.raw.fields[:t.raw.fieldsExtnStart],
+		t.raw.fields[:t.raw.fieldsEnd],
 		func(_ int, p arena.Pointer[rawField]) Field {
 			return wrapField(t.Context(), ref[rawField]{ptr: p})
 		},
@@ -237,7 +237,7 @@ func (t Type) Fields() seq.Indexer[Field] {
 // Extensions returns any extensions nested within this type.
 func (t Type) Extensions() seq.Indexer[Field] {
 	return seq.NewFixedSlice(
-		t.raw.fields[t.raw.fieldsExtnStart:],
+		t.raw.fields[t.raw.fieldsEnd:],
 		func(_ int, p arena.Pointer[rawField]) Field {
 			return wrapField(t.Context(), ref[rawField]{ptr: p})
 		},

--- a/experimental/ir/ir_value.go
+++ b/experimental/ir/ir_value.go
@@ -345,8 +345,6 @@ type rawMessageValue struct {
 	// Which entries are already inserted. These are by field number, except for
 	// elements of oneofs, which are by negative oneof index. This makes it
 	// easy to check if any element of a oneof is already set.
-	//
-	//nolint:unused // Will be used by options lowering.
 	byName intern.Map[uint32]
 }
 
@@ -377,7 +375,7 @@ func (v MessageValue) Fields() seq.Indexer[Value] {
 // whereas if the value is being inserted for the first time, the returned arena
 // pointer will be nil and can be initialized by the caller.
 //
-//nolint:unused // Will be used by options lowering.
+
 func (v MessageValue) insert(field Field) *arena.Pointer[rawValue] {
 	id := field.InternedFullName()
 	if o := field.Oneof(); !o.IsZero() {
@@ -395,7 +393,7 @@ func (v MessageValue) insert(field Field) *arena.Pointer[rawValue] {
 
 // scalar is a type that can be converted into a [rawValueBits].
 //
-//nolint:unused // Will be used by options lowering.
+
 type scalar interface {
 	bool |
 		int32 | uint32 | int64 | uint64 |
@@ -405,7 +403,7 @@ type scalar interface {
 
 // newScalar constructs a new scalar value.
 //
-//nolint:unused // Will be used by options lowering.
+
 func newScalar[T scalar](c *Context, field ref[rawField], v T) Value {
 	return Value{
 		internal.NewWith(c),
@@ -448,7 +446,7 @@ func appendMessage(array Value, anyType ref[rawType]) MessageValue {
 
 // newMessage constructs a new message value.
 //
-//nolint:unused // Will be used by options lowering.
+
 func newMessage(c *Context, field ref[rawField], anyType ref[rawType]) Value {
 	if anyType.ptr.Nil() {
 		anyType = wrapField(c, field).raw.elem
@@ -468,7 +466,7 @@ func newMessage(c *Context, field ref[rawField], anyType ref[rawType]) Value {
 
 // newScalarBits converts a scalar into raw bits for storing in a [Value].
 //
-//nolint:unused // Will be used by options lowering.
+
 func newScalarBits[T scalar](c *Context, v T) rawValueBits {
 	switch v := any(v).(type) {
 	case bool:

--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -74,6 +74,9 @@ func lower(c *Context, r *report.Report, importer Importer) {
 
 	// Perform "early" name resolution, i.e. field names and extension types.
 	resolveNames(c.File(), r)
+
+	// Perform "late" name resolution, that is, options.
+	resolveOptions(c.File(), r)
 }
 
 // sorry panics with an NYI error, which turns into an ICE inside of the

--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -38,8 +38,12 @@ func (s *Session) Lower(source ast.File, errs *report.Report, importer Importer)
 	prior := len(errs.Diagnostics)
 	c := &Context{session: s}
 	c.ast = source
+	c.isDescriptorProto = c.ast.Span().File.Path() == DescriptorProtoPath
 
-	lower(c, errs, importer)
+	errs.SaveOptions(func() {
+		errs.SuppressWarnings = errs.SuppressWarnings || c.isDescriptorProto
+		lower(c, errs, importer)
+	})
 
 	ok = true
 	for _, d := range errs.Diagnostics[prior:] {

--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ir
 
 import (

--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -1,0 +1,351 @@
+package ir
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/internal/taxa"
+	"github.com/bufbuild/protocompile/experimental/ir/presence"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/internal/arena"
+	"github.com/bufbuild/protocompile/internal/ext/iterx"
+)
+
+// resolveOptions resolves all of the options in a file.
+func resolveOptions(f File, r *report.Report) {
+	dpIdx := int32(len(f.Context().imports.files))
+	dp := f.Context().imports.DescriptorProto().Context()
+	fileOptions := ref[rawField]{dpIdx, dp.langSymbols.fileOptions}
+	messageOptions := ref[rawField]{dpIdx, dp.langSymbols.messageOptions}
+	fieldOptions := ref[rawField]{dpIdx, dp.langSymbols.fieldOptions}
+	oneofOptions := ref[rawField]{dpIdx, dp.langSymbols.oneofOptions}
+	enumOptions := ref[rawField]{dpIdx, dp.langSymbols.enumOptions}
+	enumValueOptions := ref[rawField]{dpIdx, dp.langSymbols.enumValueOptions}
+
+	bodyOptions := func(b ast.DeclBody) iter.Seq[ast.Option] {
+		return iterx.FilterMap(seq.Values(b.Decls()), func(d ast.DeclAny) (ast.Option, bool) {
+			def := d.AsDef()
+			if def.IsZero() || def.Classify() != ast.DefKindOption {
+				return ast.Option{}, false
+			}
+			return def.AsOption().Option, true
+		})
+	}
+
+	for def := range bodyOptions(f.AST().DeclBody) {
+		optionRef{
+			Context: f.Context(),
+			Report:  r,
+
+			scope: f.Package(),
+			def:   def,
+
+			field: fileOptions,
+			raw:   &f.Context().options,
+		}.resolve()
+	}
+
+	for ty := range seq.Values(f.AllTypes()) {
+		for ast := range bodyOptions(ty.AST().Body()) {
+			options := messageOptions
+			if ty.IsEnum() {
+				options = enumOptions
+			}
+			optionRef{
+				Context: f.Context(),
+				Report:  r,
+
+				scope: ty.Scope(),
+				def:   ast,
+
+				field: options,
+				raw:   &ty.raw.options,
+			}.resolve()
+		}
+		for field := range seq.Values(ty.Fields()) {
+			for ast := range seq.Values(field.AST().Options().Entries()) {
+				options := fieldOptions
+				if ty.IsEnum() {
+					options = enumValueOptions
+				}
+				optionRef{
+					Context: f.Context(),
+					Report:  r,
+
+					scope: field.Scope(),
+					def:   ast,
+
+					field: options,
+					raw:   &field.raw.options,
+				}.resolve()
+			}
+		}
+		for oneof := range seq.Values(ty.Oneofs()) {
+			for ast := range bodyOptions(oneof.AST().Body()) {
+				optionRef{
+					Context: f.Context(),
+					Report:  r,
+
+					scope: ty.Scope(),
+					def:   ast,
+
+					field: oneofOptions,
+					raw:   &oneof.raw.options,
+				}.resolve()
+			}
+		}
+	}
+	for field := range seq.Values(f.AllExtensions()) {
+		for ast := range seq.Values(field.AST().Options().Entries()) {
+			optionRef{
+				Context: f.Context(),
+				Report:  r,
+
+				scope: field.Scope(),
+				def:   ast,
+
+				field: fieldOptions,
+				raw:   &field.raw.options,
+			}.resolve()
+		}
+	}
+}
+
+// symbolRef is all of the information necessary to resolve an option reference.
+type optionRef struct {
+	*Context
+	*report.Report
+
+	scope FullName
+	def   ast.Option
+
+	field ref[rawField]
+	raw   *arena.Pointer[rawValue]
+}
+
+// resolve performs symbol resolution.
+func (r optionRef) resolve() {
+	root := wrapField(r.Context, r.field).Element()
+
+	// Check if this is a pseudo-option, and diagnose if it has multiple
+	// components. The values of pseudo-options are calculated elsewhere; this
+	// is only for diagnostics.
+	dp := r.imports.DescriptorProto().Context()
+	if r.field.ptr == dp.langSymbols.fieldOptions {
+		var buf [2]ast.PathComponent
+		prefix := slices.AppendSeq(buf[:0], iterx.Take(r.def.Path.Components, 2))
+
+		if kw := buf[0].AsIdent().Keyword(); kw.IsPseudoOption() {
+			if len(prefix) > 1 {
+				r.Error(errOptionMustBeMessage{
+					selector: buf[1],
+					got:      taxa.PseudoOption,
+					gotName:  kw,
+				}).Apply(report.Notef(
+					"`%s` is a %s and does not correspond to a field in `%s`",
+					kw, taxa.PseudoOption, root.FullName(),
+				))
+			}
+
+			return
+		}
+	}
+
+	if r.raw.Nil() {
+		v := newMessage(r.Context, r.field, ref[rawType]{})
+		*r.raw = r.arenas.values.Compress(v.raw)
+	}
+
+	current := wrapValue(r.Context, *r.raw)
+	for pc := range r.def.Path.Components {
+		field := current.Field()
+		message := field.Element()
+		if !message.IsZero() && !message.IsMessage() {
+			r.Error(errOptionMustBeMessage{
+				selector: pc,
+				got:      message.noun(),
+				gotName:  message.FullName(),
+				spec:     field.AST().Type(),
+			})
+			return
+		}
+		if field.Presence() == presence.Repeated {
+			r.Error(errOptionMustBeMessage{
+				selector: pc,
+				got:      "repeated",
+				gotName:  message.FullName(),
+				spec:     field.AST().Type(),
+			})
+			return
+		}
+
+		if message.IsZero() {
+			message = root
+		}
+
+		var next Field
+		if extn := pc.AsExtension(); !extn.IsZero() {
+			sym := symbolRef{
+				Context: r.Context,
+				Report:  r.Report,
+
+				span:  extn,
+				scope: r.scope,
+				name:  FullName(extn.Canonicalized()),
+
+				accept: SymbolKind.IsMessageField,
+				want:   taxa.Extension,
+
+				allowScalars:  false,
+				suggestImport: true,
+			}.resolve()
+
+			if !sym.Kind().IsMessageField() {
+				// Already diagnosed by resolve().
+				return
+			}
+
+			next = sym.AsField()
+			if next.Container() != message {
+				d := r.Errorf("expected `%s` extension, found %s in `%s`",
+					message.FullName(), next.noun(), next.Container().FullName(),
+				).Apply(
+					report.Snippetf(pc, "because of this %s", taxa.FieldSelector),
+					report.Snippetf(next.AST().Name(), "`%s` defined here", next.FullName()),
+				)
+				if next.IsExtension() {
+					extendee := r.arenas.extendees.Deref(next.raw.extendee)
+					d.Apply(report.Snippetf(extendee.def, "... within this %s", taxa.Extend))
+				} else {
+					d.Apply(report.Snippetf(next.Container().AST(), "... within this %s", taxa.Message))
+				}
+
+				return
+			}
+
+			if !next.IsExtension() {
+				// Protoc accepts this! The horror!
+				r.Warnf("redundant %s syntax", taxa.CustomOption).Apply(
+					report.Snippetf(pc, "this field is not a %s", taxa.Extension),
+					report.Snippetf(next.AST().Name(), "field declared inside of `%s` here", next.Parent().FullName()),
+					report.Helpf("%s syntax should only be used with %ss", taxa.CustomOption, taxa.Extension),
+					report.SuggestEdits(pc.Name(), fmt.Sprintf("replace %s with a field name", taxa.Parens), report.Edit{
+						Start: 0, End: pc.Name().Span().Len(),
+						Replace: next.Name(),
+					}),
+				)
+			}
+		} else if ident := pc.AsIdent(); !ident.IsZero() {
+			next = message.FieldByName(ident.Text())
+			if next.IsZero() {
+				d := r.Errorf("cannot find %s `%s` in `%s`", taxa.Field, ident.Text(), message.FullName()).Apply(
+					report.Snippetf(pc, "because of this %s", taxa.FieldSelector),
+				)
+				if !pc.IsFirst() {
+					d.Apply(report.Snippetf(field.AST().Type(), "`%s` specified here", message.FullName()))
+				}
+				return
+			}
+		}
+
+		path, _ := pc.SplitAfter()
+
+		// Check to see if this value has already been set in the parent message.
+		// We have already validated current as a singular message by this point.
+		parent := current.AsMessage()
+
+		// Check if this field is already set. The only cases where this is
+		// allowed is if:
+		//
+		// 1. The current field is repeated and this is the last component.
+		// 2. The current field is of message type and this is not the last
+		//    component.
+		raw := parent.insert(next)
+		if !raw.Nil() {
+			value := wrapValue(r.Context, *raw)
+			switch {
+			case next.Presence() == presence.Repeated:
+				// TODO: Implement expression evaluation.
+			case value.Field() != next:
+				// A different member of a oneof was set.
+				r.Errorf("oneof `%s` set multiple times", next.Oneof().FullName()).Apply(
+					report.Snippetf(path, "... also set here"),
+					report.Snippetf(value.OptionPath(), "first set here..."),
+					report.Notef("at most one member of a oneof may be set by an option"),
+				)
+				return
+
+			case field.Element().IsMessage():
+				if !pc.IsLast() {
+					current = value
+					continue
+				}
+				fallthrough
+
+			default:
+				name := next.FullName()
+				what := any(next.noun())
+				if !next.IsExtension() && pc.IsFirst() {
+					// For non-custom options, use the short name and call it
+					// an "option".
+					name = FullName(next.Name())
+					what = "option"
+				}
+
+				r.Errorf("%v `%v` set multiple times", what, name).Apply(
+					report.Snippetf(path, "... also set here"),
+					report.Snippetf(value.OptionPath(), "first set here..."),
+					report.Notef("an option may be set at most once"),
+				)
+				return
+			}
+		}
+
+		// Construct a new value for this option.
+		var fieldRef ref[rawField]
+		if next.Context() != r.Context {
+			fieldRef.file = int32(r.imports.byPath[next.Context().File().InternedPath()] + 1)
+		}
+		fieldRef.ptr = next.Context().arenas.fields.Compress(next.raw)
+
+		// TODO: Implement expression evaluation.
+		var value Value
+		if next.Element().IsMessage() {
+			value = newMessage(r.Context, fieldRef, ref[rawType]{})
+		} else {
+			// Just set the zero value; all scalars with a value of zero
+			// are well-defined.
+			value = newScalar[int32](r.Context, fieldRef, 0)
+		}
+		if value.raw.optionPath.IsZero() {
+			value.raw.optionPath = path
+		}
+
+		*raw = r.arenas.values.Compress(value.raw)
+		current = value
+	}
+}
+
+type errOptionMustBeMessage struct {
+	selector, spec report.Spanner
+	got, gotName   any
+}
+
+func (e errOptionMustBeMessage) Diagnose(d *report.Diagnostic) {
+	got := e.got
+	if e.gotName != nil {
+		got = fmt.Sprintf("%v `%v`", got, e.gotName)
+	}
+
+	d.Apply(
+		report.Message("expected singular message, found %s", got),
+		report.Snippetf(e.selector, "%s requires singular message", taxa.FieldSelector),
+	)
+
+	if e.spec != nil {
+		d.Apply(report.Snippetf(e.spec, "type specified here"))
+	}
+}

--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -63,7 +63,7 @@ func resolveOptions(f File, r *report.Report) {
 	}
 
 	for ty := range seq.Values(f.AllTypes()) {
-		for ast := range bodyOptions(ty.AST().Body()) {
+		for def := range bodyOptions(ty.AST().Body()) {
 			options := messageOptions
 			if ty.IsEnum() {
 				options = enumOptions
@@ -73,14 +73,14 @@ func resolveOptions(f File, r *report.Report) {
 				Report:  r,
 
 				scope: ty.Scope(),
-				def:   ast,
+				def:   def,
 
 				field: options,
 				raw:   &ty.raw.options,
 			}.resolve()
 		}
 		for field := range seq.Values(ty.Fields()) {
-			for ast := range seq.Values(field.AST().Options().Entries()) {
+			for def := range seq.Values(field.AST().Options().Entries()) {
 				options := fieldOptions
 				if ty.IsEnum() {
 					options = enumValueOptions
@@ -90,7 +90,7 @@ func resolveOptions(f File, r *report.Report) {
 					Report:  r,
 
 					scope: field.Scope(),
-					def:   ast,
+					def:   def,
 
 					field: options,
 					raw:   &field.raw.options,
@@ -98,13 +98,13 @@ func resolveOptions(f File, r *report.Report) {
 			}
 		}
 		for oneof := range seq.Values(ty.Oneofs()) {
-			for ast := range bodyOptions(oneof.AST().Body()) {
+			for def := range bodyOptions(oneof.AST().Body()) {
 				optionRef{
 					Context: f.Context(),
 					Report:  r,
 
 					scope: ty.Scope(),
-					def:   ast,
+					def:   def,
 
 					field: oneofOptions,
 					raw:   &oneof.raw.options,
@@ -113,13 +113,13 @@ func resolveOptions(f File, r *report.Report) {
 		}
 	}
 	for field := range seq.Values(f.AllExtensions()) {
-		for ast := range seq.Values(field.AST().Options().Entries()) {
+		for def := range seq.Values(field.AST().Options().Entries()) {
 			optionRef{
 				Context: f.Context(),
 				Report:  r,
 
 				scope: field.Scope(),
-				def:   ast,
+				def:   def,
 
 				field: fieldOptions,
 				raw:   &field.raw.options,

--- a/experimental/ir/lower_resolve.go
+++ b/experimental/ir/lower_resolve.go
@@ -157,23 +157,16 @@ func resolveLangSymbols(c *Context) {
 		return mustResolve[rawField](c, "google.protobuf."+name, SymbolKindField)
 	}
 
-	l := inferNew(&c.langSymbols)
+	c.langSymbols = &langSymbols{
+		fileOptions: field("FileDescriptorProto.options"),
 
-	l.fileOptions = field("FileDescriptorProto.options")
+		messageOptions: field("DescriptorProto.options"),
+		fieldOptions:   field("FieldDescriptorProto.options"),
+		oneofOptions:   field("OneofDescriptorProto.options"),
 
-	l.messageOptions = field("DescriptorProto.options")
-	l.fieldOptions = field("FieldDescriptorProto.options")
-	l.oneofOptions = field("OneofDescriptorProto.options")
-
-	l.enumOptions = field("EnumDescriptorProto.options")
-	l.enumValueOptions = field("EnumValueDescriptorProto.options")
-}
-
-// inferNew is a helper for allocating a value of a large, complicated type.
-// Specifically, it's used with Context.langSymbols.
-func inferNew[T any](p **T) *T {
-	*p = new(T)
-	return *p
+		enumOptions:      field("EnumDescriptorProto.options"),
+		enumValueOptions: field("EnumValueDescriptorProto.options"),
+	}
 }
 
 // mustResolve resolves a descriptor.proto name, and panics if it's not found.

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -89,6 +89,9 @@ func (w *walker) recurse(decl ast.DeclAny, parent any) {
 		}
 
 	case ast.DeclKindRange:
+		if w.Context().File().Path() == DescriptorProtoPath {
+			return
+		}
 		sorry("ranges")
 
 	case ast.DeclKindDef:

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -195,7 +195,6 @@ func (w *walker) newField(def ast.DeclDef, parent any) Field {
 	}
 
 	if !parentTy.IsZero() {
-
 		if _, ok := parent.(extend); ok {
 			parentTy.raw.fields = append(parentTy.raw.fields, id)
 			c.extns = append(c.extns, id)

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -191,11 +191,13 @@ func (w *walker) newField(def ast.DeclDef, parent any) Field {
 	}
 
 	if !parentTy.IsZero() {
-		parentTy.raw.fields = append(parentTy.raw.fields, id)
 
 		if _, ok := parent.(extend); ok {
+			parentTy.raw.fields = append(parentTy.raw.fields, id)
 			c.extns = append(c.extns, id)
-			parentTy.raw.fieldsExtnStart++
+		} else {
+			parentTy.raw.fields = slices.Insert(parentTy.raw.fields, int(parentTy.raw.fieldsEnd), id)
+			parentTy.raw.fieldsEnd++
 		}
 	} else if _, ok := parent.(extend); ok {
 		c.extns = slices.Insert(c.extns, c.topLevelExtnsEnd, id)

--- a/experimental/ir/testdata/extend/invalid_partial.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/invalid_partial.proto.fds.yaml
@@ -6,7 +6,7 @@ file:
         nested_type:
           - name: "N"
           - name: "M"
-            field:
+            extension:
               - name: "x"
                 number: 0
                 label: LABEL_OPTIONAL

--- a/experimental/ir/testdata/extend/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/ok.proto.fds.yaml
@@ -3,7 +3,7 @@ file:
     package: "test"
     message_type:
       - name: "Foo"
-        field:
+        extension:
           - name: "x1"
             number: 0
             label: LABEL_OPTIONAL

--- a/experimental/ir/testdata/extend/skip_wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/skip_wrong_kind.proto.fds.yaml
@@ -6,14 +6,14 @@ file:
         nested_type:
           - name: "N"
           - name: "P"
-            field: [{ name: "n", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
-            enum_type: [{ name: "X" }]
+            extension: [{ name: "n", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+            enum_type: [{ name: "X", value: [{ name: "N", number: 0 }] }]
           - name: "Q"
-            field:
+            extension:
               - name: "n"
                 number: 0
                 label: LABEL_OPTIONAL
                 type: TYPE_INT32
                 extendee: ".test.M.Q.N"
-            enum_type: [{ name: "N" }]
+            enum_type: [{ name: "N", value: [{ name: "Q", number: 0 }] }]
     syntax: "proto2"

--- a/experimental/ir/testdata/extend/wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/wrong_kind.proto.fds.yaml
@@ -4,6 +4,12 @@ file:
     message_type:
       - name: "Foo"
         field:
+          - name: "a"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+            oneof_index: 0
+        extension:
           - { name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
           - { name: "y", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
           - name: "z"
@@ -12,18 +18,12 @@ file:
             type: TYPE_INT32
             extendee: ".test.Foo.Bar"
           - { name: "w", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-          - name: "a"
-            number: 0
-            label: LABEL_OPTIONAL
-            type: TYPE_INT32
-            oneof_index: 0
           - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-        extension:
           - name: "capacity"
             number: 0
             label: LABEL_OPTIONAL
             type: TYPE_INT32
             extendee: ".string"
-        enum_type: [{ name: "Bar" }]
+        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 0 }] }]
         oneof_decl: [{ name: "self" }]
     syntax: "proto2"

--- a/experimental/ir/testdata/fields/import_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/fields/import_private.proto.yaml.fds.yaml
@@ -6,8 +6,8 @@ file:
     dependency: ["b.proto"]
     message_type:
       - name: "N"
-        extension:
-          - { name: "m1", number: 0 }
-          - { name: "m2", number: 0 }
-          - { name: "m3", number: 0 }
+        field:
+          - { name: "m1", number: 0, label: LABEL_OPTIONAL }
+          - { name: "m2", number: 0, label: LABEL_OPTIONAL }
+          - { name: "m3", number: 0, label: LABEL_OPTIONAL }
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/import_private.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/fields/import_private.proto.yaml.stderr.txt
@@ -1,0 +1,25 @@
+error: cannot find `M` in this scope
+  --> c.proto:7:3
+   |
+ 7 |   M m1 = 1;
+   |   ^ not found in this scope
+   = help: the full name of this scope is `test.N`
+
+error: expected type, found `package` declaration `test`
+  --> c.proto:8:3
+   |
+ 8 |   test.M m2 = 2;
+   |   ^^^^^^ expected type
+  ::: b.proto:2:1
+   |
+ 2 | package test;
+   | ------------- defined here
+
+error: cannot find `.test.M` in this scope
+  --> c.proto:9:3
+   |
+ 9 |   .test.M m3 = 3;
+   |   ^^^^^^^ not found in this scope
+   = help: the full name of this scope is `test.N`
+
+encountered 3 errors

--- a/experimental/ir/testdata/fields/invalid_partial.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/invalid_partial.proto.fds.yaml
@@ -3,5 +3,13 @@ file:
     package: "test"
     message_type:
       - name: "M"
-        nested_type: [{ name: "N" }, { name: "M", extension: [{ name: "n", number: 0 }] }]
+        nested_type:
+          - name: "N"
+          - name: "M"
+            field:
+              - name: "n"
+                number: 0
+                label: LABEL_OPTIONAL
+                type: TYPE_MESSAGE
+                type_name: ".test.M.N"
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/invalid_partial.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/invalid_partial.proto.stderr.txt
@@ -1,0 +1,12 @@
+error: cannot find `M.N` in this scope
+  --> testdata/fields/invalid_partial.proto:22:9
+   |
+20 |     message N {}
+   |             - found possibly related symbol `test.M.N`
+21 |     message M {
+22 |         M.N n = 1;
+   |         ^^^ not found in this scope
+   = note: Protobuf's name lookup rules expected a symbol `test.M.M.N`, rather
+           than the one we found
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/ok.proto.fds.yaml
@@ -3,13 +3,41 @@ file:
     package: "test"
     message_type:
       - name: "Foo"
-        extension:
-          - { name: "foo", number: 0 }
-          - { name: "bar", number: 0 }
-          - { name: "bars", number: 0 }
-          - { name: "foos", number: 0 }
-          - { name: "foo0", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
-          - { name: "bar0", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
+        field:
+          - name: "foo"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo"
+            oneof_index: 1
+            proto3_optional: true
+          - name: "bar"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo.Bar"
+          - name: "bars"
+            number: 0
+            label: LABEL_REPEATED
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo.Bar"
+          - name: "foos"
+            number: 0
+            label: LABEL_REPEATED
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo"
+          - name: "foo0"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo"
+            oneof_index: 0
+          - name: "bar0"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo.Bar"
+            oneof_index: 0
         nested_type: [{ name: "Bar" }]
-        oneof_decl: [{ name: "baz" }]
+        oneof_decl: [{ name: "baz" }, { name: "_foo" }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/skip_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/fields/skip_private.proto.yaml.fds.yaml
@@ -11,5 +11,12 @@ file:
   - name: "c.proto"
     package: "foo.bar.baz"
     dependency: ["b.proto"]
-    message_type: [{ name: "N", extension: [{ name: "m", number: 0 }] }]
+    message_type:
+      - name: "N"
+        field:
+          - name: "m"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".foo.M"
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/skip_wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/skip_wrong_kind.proto.fds.yaml
@@ -6,6 +6,11 @@ file:
         nested_type:
           - name: "N"
           - name: "P"
-            extension: [{ name: "n", number: 0 }]
-            enum_type: [{ name: "X" }]
+            field:
+              - name: "n"
+                number: 0
+                label: LABEL_OPTIONAL
+                type: TYPE_MESSAGE
+                type_name: ".test.M.N"
+            enum_type: [{ name: "X", value: [{ name: "N", number: 0 }] }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/wrong_kind.proto.fds.yaml
@@ -3,11 +3,11 @@ file:
     package: "test"
     message_type:
       - name: "Foo"
-        extension:
-          - { name: "x", number: 0 }
-          - { name: "y", number: 0 }
-          - { name: "z", number: 0 }
+        field:
+          - { name: "x", number: 0, label: LABEL_OPTIONAL }
+          - { name: "y", number: 0, label: LABEL_OPTIONAL }
+          - { name: "z", number: 0, label: LABEL_OPTIONAL }
           - { name: "a", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
-        enum_type: [{ name: "Bar" }]
+        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 0 }] }]
         oneof_decl: [{ name: "self" }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/wrong_kind.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/wrong_kind.proto.stderr.txt
@@ -1,0 +1,37 @@
+error: expected type, found message field `test.Foo.x`
+  --> testdata/fields/wrong_kind.proto:22:5
+   |
+22 |     x x = 1;
+   |     ^ - defined here
+   |     |
+   |     expected type
+
+error: expected type, found enum value `test.Foo.BAZ`
+  --> testdata/fields/wrong_kind.proto:23:5
+   |
+20 |     enum Bar { BAZ = 1; }
+   |                --- defined here
+21 |
+22 |     x x = 1;
+23 |     BAZ y = 2;
+   |     ^^^ expected type
+
+error: expected type, found `package` declaration `test`
+  --> testdata/fields/wrong_kind.proto:24:5
+   |
+17 | package test;
+   | ------------- defined here
+...
+23 |     BAZ y = 2;
+24 |     test z = 3;
+   |     ^^^^ expected type
+
+error: expected type, found oneof definition `test.Foo.self`
+  --> testdata/fields/wrong_kind.proto:27:9
+   |
+26 |     oneof self {
+   |           ---- defined here
+27 |         self a = 3;
+   |         ^^^^ expected type
+
+encountered 4 errors

--- a/experimental/ir/testdata/missing_wkts.proto.yaml
+++ b/experimental/ir/testdata/missing_wkts.proto.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020-2025 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+disable_sysroot: true
+files:
+- path: "a.proto"
+  text: |
+    syntax = "proto3";
+    package test;

--- a/experimental/ir/testdata/missing_wkts.proto.yaml
+++ b/experimental/ir/testdata/missing_wkts.proto.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-disable_sysroot: true
+exclude_wkt_sources: true
 files:
 - path: "a.proto"
   text: |

--- a/experimental/ir/testdata/missing_wkts.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/missing_wkts.proto.yaml.stderr.txt
@@ -1,0 +1,8 @@
+internal compiler error: could not import `google/protobuf/descriptor.proto`
+   = note: protocompile is not configured correctly
+   = help: `descriptor.proto` must always be available, since it is required for
+           correctly implementing Protobuf's semantics. If you are using
+           protocompile as a library, you may be missing a source.WKTs() in your
+           source.Opener setup.
+
+encountered 1 error

--- a/experimental/ir/testdata/options/builtin.proto
+++ b/experimental/ir/testdata/options/builtin.proto
@@ -12,15 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package keyword provides [Keyword], an enum of all special "grammar particles"
-// (i.e., literal tokens with special meaning in the grammar such as identifier
-// keywords and punctuation) recognized by Protocompile.
-package keyword
+syntax = "proto2";
 
-//go:generate go run github.com/bufbuild/protocompile/internal/enum keyword.yaml
+package buf.test;
 
-// IsPseudoOption returns whether or not this keyword is one of the special
-// pseudo option names ([default = "..."] and [json_name = "..."])
-func (k Keyword) IsPseudoOption() bool {
-	return k == Default || k == JsonName
+option java_package = "build.buf.protocompile";
+option java_multiple_files = true;
+
+message Foo {
+    option deprecated = true;
+    option deprecated = true;
+    optional Foo foo = 1 [lazy = true];
+    optional int32 bar = 2 [default = 42];
+}
+
+enum Bar {
+    option deprecated = true;
+    BAR_ZERO = 0 [deprecated = true];
 }

--- a/experimental/ir/testdata/options/builtin.proto.fds.yaml
+++ b/experimental/ir/testdata/options/builtin.proto.fds.yaml
@@ -1,0 +1,20 @@
+file:
+  - name: "testdata/options/builtin.proto"
+    package: "buf.test"
+    message_type:
+      - name: "Foo"
+        field:
+          - name: "foo"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".buf.test.Foo"
+            options: {}
+          - { name: "bar", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+        options: {}
+    enum_type:
+      - name: "Bar"
+        value: [{ name: "BAR_ZERO", number: 0, options: {} }]
+        options: {}
+    options: {}
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/builtin.proto.stderr.txt
+++ b/experimental/ir/testdata/options/builtin.proto.stderr.txt
@@ -1,0 +1,10 @@
+error: option `deprecated` set multiple times
+  --> testdata/options/builtin.proto:24:12
+   |
+23 |     option deprecated = true;
+   |            ---------- first set here...
+24 |     option deprecated = true;
+   |            ^^^^^^^^^^ ... also set here
+   = note: an option may be set at most once
+
+encountered 1 error

--- a/experimental/ir/testdata/options/builtin.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/builtin.proto.symtab.yaml
@@ -1,0 +1,36 @@
+tables:
+  "testdata/options/builtin.proto":
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/builtin.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/builtin.proto"
+        index: 1
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }
+      - fqn: "buf.test.Bar"
+        kind: KIND_ENUM
+        file: "testdata/options/builtin.proto"
+        index: 2
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }
+      - fqn: "buf.test.Foo.foo"
+        kind: KIND_FIELD
+        file: "testdata/options/builtin.proto"
+        index: 1
+        visible: true
+        options.message.fields: { "lazy": { bool: false } }
+      - fqn: "buf.test.Foo.bar"
+        kind: KIND_FIELD
+        file: "testdata/options/builtin.proto"
+        index: 2
+        visible: true
+      - fqn: "buf.test.BAR_ZERO"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/options/builtin.proto"
+        index: 3
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }
+    options.message.fields: { "java_multiple_files": { bool: false }, "java_package": { string: "" } }

--- a/experimental/ir/testdata/options/custom.proto
+++ b/experimental/ir/testdata/options/custom.proto
@@ -1,0 +1,61 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.test;
+
+import "google/protobuf/descriptor.proto";
+
+option (a) = 42;
+
+message Foo {
+    option (b) = 42;
+
+    optional int32 x = 1 [(c) = 42];
+
+    oneof y {
+        option (d) = 42;
+        int32 z = 2 [(c) = 42];
+    }
+}
+
+enum Bar {
+    option (e) = 42;
+    X = 0 [(f) = 42];
+}
+
+extend google.protobuf.FileOptions {
+    repeated int32 a = 1000;
+}
+
+extend google.protobuf.MessageOptions {
+    repeated int32 b = 1000;
+}
+
+extend google.protobuf.FieldOptions {
+    repeated int32 c = 1000;
+}
+
+extend google.protobuf.OneofOptions {
+    repeated int32 d = 1000;
+}
+
+extend google.protobuf.EnumOptions {
+    repeated int32 e = 1000;
+}
+
+extend google.protobuf.EnumValueOptions {
+    repeated int32 f = 1000;
+}

--- a/experimental/ir/testdata/options/custom.proto.fds.yaml
+++ b/experimental/ir/testdata/options/custom.proto.fds.yaml
@@ -1,0 +1,54 @@
+file:
+  - name: "testdata/options/custom.proto"
+    package: "buf.test"
+    dependency: ["google/protobuf/descriptor.proto"]
+    message_type:
+      - name: "Foo"
+        field:
+          - name: "x"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+            options: {}
+          - name: "z"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+            oneof_index: 0
+            options: {}
+        oneof_decl: [{ name: "y", options: {} }]
+        options: {}
+    enum_type: [{ name: "Bar", value: [{ name: "X", number: 0, options: {} }], options: {} }]
+    extension:
+      - name: "a"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.FileOptions"
+      - name: "b"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.MessageOptions"
+      - name: "c"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.FieldOptions"
+      - name: "d"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.OneofOptions"
+      - name: "e"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.EnumOptions"
+      - name: "f"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.EnumValueOptions"
+    options: {}
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/custom.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/custom.proto.symtab.yaml
@@ -1,0 +1,74 @@
+tables:
+  "testdata/options/custom.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: true }]
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/custom.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/custom.proto"
+        index: 1
+        visible: true
+        options.message.extns: { "buf.test.b": { repeated.values: [{ int: 0 }] } }
+      - fqn: "buf.test.Bar"
+        kind: KIND_ENUM
+        file: "testdata/options/custom.proto"
+        index: 2
+        visible: true
+        options.message.extns: { "buf.test.e": { repeated.values: [{ int: 0 }] } }
+      - fqn: "buf.test.Foo.x"
+        kind: KIND_FIELD
+        file: "testdata/options/custom.proto"
+        index: 1
+        visible: true
+        options.message.extns: { "buf.test.c": { repeated.values: [{ int: 0 }] } }
+      - fqn: "buf.test.Foo.z"
+        kind: KIND_FIELD
+        file: "testdata/options/custom.proto"
+        index: 2
+        visible: true
+        options.message.extns: { "buf.test.c": { repeated.values: [{ int: 0 }] } }
+      - fqn: "buf.test.X"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/options/custom.proto"
+        index: 3
+        visible: true
+        options.message.extns: { "buf.test.f": { repeated.values: [{ int: 0 }] } }
+      - fqn: "buf.test.a"
+        kind: KIND_EXTENSION
+        file: "testdata/options/custom.proto"
+        index: 4
+        visible: true
+      - fqn: "buf.test.b"
+        kind: KIND_EXTENSION
+        file: "testdata/options/custom.proto"
+        index: 5
+        visible: true
+      - fqn: "buf.test.c"
+        kind: KIND_EXTENSION
+        file: "testdata/options/custom.proto"
+        index: 6
+        visible: true
+      - fqn: "buf.test.d"
+        kind: KIND_EXTENSION
+        file: "testdata/options/custom.proto"
+        index: 7
+        visible: true
+      - fqn: "buf.test.e"
+        kind: KIND_EXTENSION
+        file: "testdata/options/custom.proto"
+        index: 8
+        visible: true
+      - fqn: "buf.test.f"
+        kind: KIND_EXTENSION
+        file: "testdata/options/custom.proto"
+        index: 9
+        visible: true
+      - fqn: "buf.test.Foo.y"
+        kind: KIND_ONEOF
+        file: "testdata/options/custom.proto"
+        index: 1
+        visible: true
+        options.message.extns: { "buf.test.d": { repeated.values: [{ int: 0 }] } }
+    options.message.extns: { "buf.test.a": { repeated.values: [{ int: 0 }] } }

--- a/experimental/ir/testdata/options/missing.proto
+++ b/experimental/ir/testdata/options/missing.proto
@@ -12,15 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package keyword provides [Keyword], an enum of all special "grammar particles"
-// (i.e., literal tokens with special meaning in the grammar such as identifier
-// keywords and punctuation) recognized by Protocompile.
-package keyword
+syntax = "proto2";
 
-//go:generate go run github.com/bufbuild/protocompile/internal/enum keyword.yaml
+package buf.test;
 
-// IsPseudoOption returns whether or not this keyword is one of the special
-// pseudo option names ([default = "..."] and [json_name = "..."])
-func (k Keyword) IsPseudoOption() bool {
-	return k == Default || k == JsonName
+option unknown = 42;
+option go_package.x = 42;
+
+message Foo {
+    option unknown = 42;
+    option deprecated.x = 42;
+    optional Foo foo = 1 [unknown = 42, lazy.x = 42];
+    optional int32 bar = 2 [default.x = 42];
+
+    oneof x {
+        option unknown = 42;
+        int32 baz = 3;
+    }
+}
+
+enum Bar {
+    option unknown = 42;
+    option deprecated.x = 42;
+    BAR_ZERO = 0 [unknown = 42, deprecated.x = 42];
 }

--- a/experimental/ir/testdata/options/missing.proto.fds.yaml
+++ b/experimental/ir/testdata/options/missing.proto.fds.yaml
@@ -1,0 +1,26 @@
+file:
+  - name: "testdata/options/missing.proto"
+    package: "buf.test"
+    message_type:
+      - name: "Foo"
+        field:
+          - name: "foo"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".buf.test.Foo"
+            options: {}
+          - { name: "bar", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - name: "baz"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+            oneof_index: 0
+        oneof_decl: [{ name: "x", options: {} }]
+        options: {}
+    enum_type:
+      - name: "Bar"
+        value: [{ name: "BAR_ZERO", number: 0, options: {} }]
+        options: {}
+    options: {}
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/missing.proto.stderr.txt
+++ b/experimental/ir/testdata/options/missing.proto.stderr.txt
@@ -1,0 +1,95 @@
+error: cannot find message field `unknown` in `google.protobuf.FileOptions`
+  --> testdata/options/missing.proto:19:8
+   |
+19 | option unknown = 42;
+   |        ^^^^^^^ because of this field selector
+
+error: expected singular message, found scalar type `string`
+   --> testdata/options/missing.proto:20:18
+    |
+ 20 | option go_package.x = 42;
+    |                  ^^ field selector requires singular message
+   ::: google/protobuf/descriptor.proto:494:3
+    |
+494 |   optional string go_package = 11;
+    |   --------------- type specified here
+
+error: cannot find message field `unknown` in `google.protobuf.MessageOptions`
+  --> testdata/options/missing.proto:23:12
+   |
+23 |     option unknown = 42;
+   |            ^^^^^^^ because of this field selector
+
+error: expected singular message, found scalar type `bool`
+   --> testdata/options/missing.proto:24:22
+    |
+ 24 |     option deprecated.x = 42;
+    |                      ^^ field selector requires singular message
+   ::: google/protobuf/descriptor.proto:601:3
+    |
+601 |   optional bool deprecated = 3 [default = false];
+    |   ------------- type specified here
+
+error: cannot find message field `unknown` in `google.protobuf.FieldOptions`
+  --> testdata/options/missing.proto:25:27
+   |
+25 |     optional Foo foo = 1 [unknown = 42, lazy.x = 42];
+   |                           ^^^^^^^ because of this field selector
+
+error: expected singular message, found scalar type `bool`
+   --> testdata/options/missing.proto:25:45
+    |
+ 25 |     optional Foo foo = 1 [unknown = 42, lazy.x = 42];
+    |                                             ^^ field selector requires singular message
+   ::: google/protobuf/descriptor.proto:733:3
+    |
+733 |   optional bool lazy = 5 [default = false];
+    |   ------------- type specified here
+
+error: expected singular message, found pseudo-option `default`
+  --> testdata/options/missing.proto:26:36
+   |
+26 |     optional int32 bar = 2 [default.x = 42];
+   |                                    ^^ field selector requires singular message
+   = note: `default` is a pseudo-option and does not correspond to a field in
+           `google.protobuf.FieldOptions`
+
+error: cannot find message field `unknown` in `google.protobuf.OneofOptions`
+  --> testdata/options/missing.proto:29:16
+   |
+29 |         option unknown = 42;
+   |                ^^^^^^^ because of this field selector
+
+error: cannot find message field `unknown` in `google.protobuf.EnumOptions`
+  --> testdata/options/missing.proto:35:12
+   |
+35 |     option unknown = 42;
+   |            ^^^^^^^ because of this field selector
+
+error: expected singular message, found scalar type `bool`
+   --> testdata/options/missing.proto:36:22
+    |
+ 36 |     option deprecated.x = 42;
+    |                      ^^ field selector requires singular message
+   ::: google/protobuf/descriptor.proto:848:3
+    |
+848 |   optional bool deprecated = 3 [default = false];
+    |   ------------- type specified here
+
+error: cannot find message field `unknown` in `google.protobuf.EnumValueOptions`
+  --> testdata/options/missing.proto:37:19
+   |
+37 |     BAR_ZERO = 0 [unknown = 42, deprecated.x = 42];
+   |                   ^^^^^^^ because of this field selector
+
+error: expected singular message, found scalar type `bool`
+   --> testdata/options/missing.proto:37:43
+    |
+ 37 |     BAR_ZERO = 0 [unknown = 42, deprecated.x = 42];
+    |                                           ^^ field selector requires singular message
+   ::: google/protobuf/descriptor.proto:878:3
+    |
+878 |   optional bool deprecated = 1 [default = false];
+    |   ------------- type specified here
+
+encountered 12 errors

--- a/experimental/ir/testdata/options/missing.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/missing.proto.symtab.yaml
@@ -1,0 +1,47 @@
+tables:
+  "testdata/options/missing.proto":
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/missing.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/missing.proto"
+        index: 1
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }
+      - fqn: "buf.test.Bar"
+        kind: KIND_ENUM
+        file: "testdata/options/missing.proto"
+        index: 2
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }
+      - fqn: "buf.test.Foo.foo"
+        kind: KIND_FIELD
+        file: "testdata/options/missing.proto"
+        index: 1
+        visible: true
+        options.message.fields: { "lazy": { bool: false } }
+      - fqn: "buf.test.Foo.bar"
+        kind: KIND_FIELD
+        file: "testdata/options/missing.proto"
+        index: 2
+        visible: true
+      - fqn: "buf.test.Foo.baz"
+        kind: KIND_FIELD
+        file: "testdata/options/missing.proto"
+        index: 3
+        visible: true
+      - fqn: "buf.test.BAR_ZERO"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/options/missing.proto"
+        index: 4
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }
+      - fqn: "buf.test.Foo.x"
+        kind: KIND_ONEOF
+        file: "testdata/options/missing.proto"
+        index: 1
+        visible: true
+        options.message: {}
+    options.message.fields: { "go_package": { string: "" } }

--- a/experimental/ir/testdata/options/nested.proto
+++ b/experimental/ir/testdata/options/nested.proto
@@ -1,0 +1,64 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.test;
+
+import "google/protobuf/descriptor.proto";
+
+option (x).b = {};
+option (x).b = {};
+
+option (x).b.a = {};
+
+option (x).a.a = {};
+option (x).a = {};
+option (x).a.a.a = {};
+
+option (x).(y).a = {};
+option (x).(y) = {};
+option (x).(y).a.(y) = {};
+
+option (x).a.a.x = {};
+option (x).a.a.y = {};
+
+option (x).a.x.a = {};
+option (x).a.y.a = {};
+
+option (x).a.a.b = {};
+option (x).a.a.b = {};
+
+option (x).a.(z).a = {};
+option (x).a.(z) = {};
+option (x).a.(z) = {};
+
+message Foo {
+    optional Foo a = 1;
+    repeated Foo b = 2;
+
+    oneof k {
+        Foo x = 3;
+        Foo y = 4;
+    }
+}
+
+extend google.protobuf.FileOptions {
+    optional Foo x = 1000;
+}
+
+extend Foo {
+    optional Foo y = 1000;
+    repeated Foo z = 1000;
+}

--- a/experimental/ir/testdata/options/nested.proto.fds.yaml
+++ b/experimental/ir/testdata/options/nested.proto.fds.yaml
@@ -1,0 +1,51 @@
+file:
+  - name: "testdata/options/nested.proto"
+    package: "buf.test"
+    dependency: ["google/protobuf/descriptor.proto"]
+    message_type:
+      - name: "Foo"
+        field:
+          - name: "a"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".buf.test.Foo"
+          - name: "b"
+            number: 0
+            label: LABEL_REPEATED
+            type: TYPE_MESSAGE
+            type_name: ".buf.test.Foo"
+          - name: "x"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".buf.test.Foo"
+            oneof_index: 0
+          - name: "y"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".buf.test.Foo"
+            oneof_index: 0
+        oneof_decl: [{ name: "k" }]
+    extension:
+      - name: "x"
+        number: 0
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".buf.test.Foo"
+        extendee: ".google.protobuf.FileOptions"
+      - name: "y"
+        number: 0
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".buf.test.Foo"
+        extendee: ".buf.test.Foo"
+      - name: "z"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".buf.test.Foo"
+        extendee: ".buf.test.Foo"
+    options: {}
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/nested.proto.stderr.txt
+++ b/experimental/ir/testdata/options/nested.proto.stderr.txt
@@ -1,0 +1,58 @@
+error: expected singular message, found repeated `buf.test.Foo`
+  --> testdata/options/nested.proto:24:13
+   |
+24 | option (x).b.a = {};
+   |             ^^ field selector requires singular message
+...
+48 |     optional Foo a = 1;
+49 |     repeated Foo b = 2;
+   |     ------------ type specified here
+
+error: message field `buf.test.Foo.a` set multiple times
+  --> testdata/options/nested.proto:27:8
+   |
+26 | option (x).a.a = {};
+   |        ----- first set here...
+27 | option (x).a = {};
+   |        ^^^^^ ... also set here
+   = note: an option may be set at most once
+
+error: message extension `buf.test.y` set multiple times
+  --> testdata/options/nested.proto:31:8
+   |
+30 | option (x).(y).a = {};
+   |        ------- first set here...
+31 | option (x).(y) = {};
+   |        ^^^^^^^ ... also set here
+   = note: an option may be set at most once
+
+error: oneof `buf.test.Foo.k` set multiple times
+  --> testdata/options/nested.proto:35:8
+   |
+34 | option (x).a.a.x = {};
+   |        --------- first set here...
+35 | option (x).a.a.y = {};
+   |        ^^^^^^^^^ ... also set here
+   = note: at most one member of a oneof may be set by an option
+
+error: oneof `buf.test.Foo.k` set multiple times
+  --> testdata/options/nested.proto:38:8
+   |
+37 | option (x).a.x.a = {};
+   |        ------- first set here...
+38 | option (x).a.y.a = {};
+   |        ^^^^^^^ ... also set here
+   = note: at most one member of a oneof may be set by an option
+
+error: expected singular message, found repeated `buf.test.Foo`
+  --> testdata/options/nested.proto:43:17
+   |
+43 | option (x).a.(z).a = {};
+   |                 ^^ field selector requires singular message
+44 | option (x).a.(z) = {};
+...
+62 |     optional Foo y = 1000;
+63 |     repeated Foo z = 1000;
+   |     ------------ type specified here
+
+encountered 6 errors

--- a/experimental/ir/testdata/options/nested.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/nested.proto.symtab.yaml
@@ -1,0 +1,70 @@
+tables:
+  "testdata/options/nested.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: true }]
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/nested.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/nested.proto"
+        index: 1
+        visible: true
+      - fqn: "buf.test.Foo.a"
+        kind: KIND_FIELD
+        file: "testdata/options/nested.proto"
+        index: 1
+        visible: true
+      - fqn: "buf.test.Foo.b"
+        kind: KIND_FIELD
+        file: "testdata/options/nested.proto"
+        index: 2
+        visible: true
+      - fqn: "buf.test.Foo.x"
+        kind: KIND_FIELD
+        file: "testdata/options/nested.proto"
+        index: 3
+        visible: true
+      - fqn: "buf.test.Foo.y"
+        kind: KIND_FIELD
+        file: "testdata/options/nested.proto"
+        index: 4
+        visible: true
+      - fqn: "buf.test.x"
+        kind: KIND_EXTENSION
+        file: "testdata/options/nested.proto"
+        index: 5
+        visible: true
+      - fqn: "buf.test.y"
+        kind: KIND_EXTENSION
+        file: "testdata/options/nested.proto"
+        index: 6
+        visible: true
+      - fqn: "buf.test.z"
+        kind: KIND_EXTENSION
+        file: "testdata/options/nested.proto"
+        index: 7
+        visible: true
+      - fqn: "buf.test.Foo.k"
+        kind: KIND_ONEOF
+        file: "testdata/options/nested.proto"
+        index: 1
+        visible: true
+    options.message.extns:
+      "buf.test.x":
+        message:
+          fields:
+            "a":
+              message:
+                fields:
+                  "a":
+                    message.fields:
+                      "a": { message: {} }
+                      "b": { repeated.values: [{ message: {} }] }
+                      "x": { message: {} }
+                  "x": { message.fields: { "a": { message: {} } } }
+                extns: { "buf.test.z": { repeated.values: [{ message: {} }] } }
+            "b": { repeated.values: [{ message: {} }] }
+          extns:
+            "buf.test.y":
+              message.fields: { "a": { message.extns: { "buf.test.y": { message: {} } } } }

--- a/experimental/ir/testdata/options/redundant_fqn.proto
+++ b/experimental/ir/testdata/options/redundant_fqn.proto
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package keyword provides [Keyword], an enum of all special "grammar particles"
-// (i.e., literal tokens with special meaning in the grammar such as identifier
-// keywords and punctuation) recognized by Protocompile.
-package keyword
+syntax = "proto2";
 
-//go:generate go run github.com/bufbuild/protocompile/internal/enum keyword.yaml
+package buf.test;
 
-// IsPseudoOption returns whether or not this keyword is one of the special
-// pseudo option names ([default = "..."] and [json_name = "..."])
-func (k Keyword) IsPseudoOption() bool {
-	return k == Default || k == JsonName
+import "google/protobuf/descriptor.proto";
+
+message Foo {
+    option (google.protobuf.MessageOptions.deprecated) = true;
 }

--- a/experimental/ir/testdata/options/redundant_fqn.proto.fds.yaml
+++ b/experimental/ir/testdata/options/redundant_fqn.proto.fds.yaml
@@ -1,0 +1,6 @@
+file:
+  - name: "testdata/options/redundant_fqn.proto"
+    package: "buf.test"
+    dependency: ["google/protobuf/descriptor.proto"]
+    message_type: [{ name: "Foo", options: {} }]
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/redundant_fqn.proto.stderr.txt
+++ b/experimental/ir/testdata/options/redundant_fqn.proto.stderr.txt
@@ -1,0 +1,19 @@
+warning: redundant custom option setting syntax
+   --> testdata/options/redundant_fqn.proto:22:12
+    |
+ 22 |     option (google.protobuf.MessageOptions.deprecated) = true;
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this field is not a message extension
+   ::: google/protobuf/descriptor.proto:601:17
+    |
+601 |   optional bool deprecated = 3 [default = false];
+    |                 ---------- field declared inside of `google.protobuf.MessageOptions` here
+   ::: testdata/options/redundant_fqn.proto:22:12
+   help: replace `(...)` with a field name
+    |
+ 22 | -     option (google.protobuf.MessageOptions.deprecated) = true;
+ 22 | +     option deprecated = true;
+    |
+    = help: custom option setting syntax should only be used with message
+            extensions
+
+encountered 1 warning

--- a/experimental/ir/testdata/options/redundant_fqn.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/redundant_fqn.proto.symtab.yaml
@@ -1,0 +1,13 @@
+tables:
+  "testdata/options/redundant_fqn.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: true }]
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/redundant_fqn.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/redundant_fqn.proto"
+        index: 1
+        visible: true
+        options.message.fields: { "deprecated": { bool: false } }

--- a/experimental/ir/testdata/options/repeated_selector.proto
+++ b/experimental/ir/testdata/options/repeated_selector.proto
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package keyword provides [Keyword], an enum of all special "grammar particles"
-// (i.e., literal tokens with special meaning in the grammar such as identifier
-// keywords and punctuation) recognized by Protocompile.
-package keyword
+syntax = "proto2";
 
-//go:generate go run github.com/bufbuild/protocompile/internal/enum keyword.yaml
+package buf.test;
 
-// IsPseudoOption returns whether or not this keyword is one of the special
-// pseudo option names ([default = "..."] and [json_name = "..."])
-func (k Keyword) IsPseudoOption() bool {
-	return k == Default || k == JsonName
+import "google/protobuf/descriptor.proto";
+
+message Foo {
+    option (x).z = 42;
+    option (y).z = 42;
+    option (z).z = 42;
+
+    optional int32 z = 1;
+}
+
+extend google.protobuf.MessageOptions {
+    repeated int32 x = 1000;
+    repeated Foo y = 1001;
+    optional Foo z = 1002;
 }

--- a/experimental/ir/testdata/options/repeated_selector.proto.fds.yaml
+++ b/experimental/ir/testdata/options/repeated_selector.proto.fds.yaml
@@ -1,0 +1,27 @@
+file:
+  - name: "testdata/options/repeated_selector.proto"
+    package: "buf.test"
+    dependency: ["google/protobuf/descriptor.proto"]
+    message_type:
+      - name: "Foo"
+        field: [{ name: "z", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+        options: {}
+    extension:
+      - name: "x"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        extendee: ".google.protobuf.MessageOptions"
+      - name: "y"
+        number: 0
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".buf.test.Foo"
+        extendee: ".google.protobuf.MessageOptions"
+      - name: "z"
+        number: 0
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".buf.test.Foo"
+        extendee: ".google.protobuf.MessageOptions"
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/repeated_selector.proto.stderr.txt
+++ b/experimental/ir/testdata/options/repeated_selector.proto.stderr.txt
@@ -1,0 +1,22 @@
+error: expected singular message, found scalar type `int32`
+  --> testdata/options/repeated_selector.proto:22:15
+   |
+22 |     option (x).z = 42;
+   |               ^^ field selector requires singular message
+23 |     option (y).z = 42;
+...
+30 |     repeated int32 x = 1000;
+   |     -------------- type specified here
+
+error: expected singular message, found repeated `buf.test.Foo`
+  --> testdata/options/repeated_selector.proto:23:15
+   |
+23 |     option (y).z = 42;
+   |               ^^ field selector requires singular message
+24 |     option (z).z = 42;
+...
+30 |     repeated int32 x = 1000;
+31 |     repeated Foo y = 1001;
+   |     ------------ type specified here
+
+encountered 2 errors

--- a/experimental/ir/testdata/options/repeated_selector.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/repeated_selector.proto.symtab.yaml
@@ -1,0 +1,36 @@
+tables:
+  "testdata/options/repeated_selector.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: true }]
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/repeated_selector.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/repeated_selector.proto"
+        index: 1
+        visible: true
+        options.message.extns:
+          "buf.test.x": { repeated.values: [{ int: 0 }] }
+          "buf.test.y": { repeated.values: [{ message: {} }] }
+          "buf.test.z": { message.fields: { "z": { int: 0 } } }
+      - fqn: "buf.test.Foo.z"
+        kind: KIND_FIELD
+        file: "testdata/options/repeated_selector.proto"
+        index: 1
+        visible: true
+      - fqn: "buf.test.x"
+        kind: KIND_EXTENSION
+        file: "testdata/options/repeated_selector.proto"
+        index: 2
+        visible: true
+      - fqn: "buf.test.y"
+        kind: KIND_EXTENSION
+        file: "testdata/options/repeated_selector.proto"
+        index: 3
+        visible: true
+      - fqn: "buf.test.z"
+        kind: KIND_EXTENSION
+        file: "testdata/options/repeated_selector.proto"
+        index: 4
+        visible: true

--- a/experimental/ir/testdata/options/wrong_symbol.proto
+++ b/experimental/ir/testdata/options/wrong_symbol.proto
@@ -12,15 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package keyword provides [Keyword], an enum of all special "grammar particles"
-// (i.e., literal tokens with special meaning in the grammar such as identifier
-// keywords and punctuation) recognized by Protocompile.
-package keyword
+syntax = "proto2";
 
-//go:generate go run github.com/bufbuild/protocompile/internal/enum keyword.yaml
+package buf.test;
 
-// IsPseudoOption returns whether or not this keyword is one of the special
-// pseudo option names ([default = "..."] and [json_name = "..."])
-func (k Keyword) IsPseudoOption() bool {
-	return k == Default || k == JsonName
+import "google/protobuf/descriptor.proto";
+
+message Foo {
+    optional int32 z = 1 [
+        (x) = 42,
+        (z) = 42,
+        (Foo) = 42,
+        (buf.test) = 42
+    ];
+}
+
+extend google.protobuf.MessageOptions {
+    optional int32 x = 1000;
 }

--- a/experimental/ir/testdata/options/wrong_symbol.proto.fds.yaml
+++ b/experimental/ir/testdata/options/wrong_symbol.proto.fds.yaml
@@ -1,0 +1,19 @@
+file:
+  - name: "testdata/options/wrong_symbol.proto"
+    package: "buf.test"
+    dependency: ["google/protobuf/descriptor.proto"]
+    message_type:
+      - name: "Foo"
+        field:
+          - name: "z"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+            options: {}
+    extension:
+      - name: "x"
+        number: 0
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        extendee: ".google.protobuf.MessageOptions"
+    syntax: "proto2"

--- a/experimental/ir/testdata/options/wrong_symbol.proto.stderr.txt
+++ b/experimental/ir/testdata/options/wrong_symbol.proto.stderr.txt
@@ -1,0 +1,50 @@
+error: expected `google.protobuf.FieldOptions` extension, found message
+       extension in `google.protobuf.MessageOptions`
+  --> testdata/options/wrong_symbol.proto:23:9
+   |
+23 |           (x) = 42,
+   |           ^^^ because of this field selector
+24 |           (z) = 42,
+...
+30 | / extend google.protobuf.MessageOptions {
+31 | |     optional int32 x = 1000;
+   | |                    - `buf.test.x` defined here
+32 | | }
+   | \_- ... within this message extension block
+
+error: expected `google.protobuf.FieldOptions` extension, found message field in
+       `buf.test.Foo`
+  --> testdata/options/wrong_symbol.proto:24:9
+   |
+21 | / message Foo {
+22 | |     optional int32 z = 1 [
+   | |                    - `buf.test.Foo.z` defined here
+23 | |         (x) = 42,
+24 | |         (z) = 42,
+   | |         ^^^ because of this field selector
+25 | |         (Foo) = 42,
+...  |
+28 | | }
+   | \_- ... within this message definition
+
+error: expected message extension, found message type `buf.test.Foo`
+  --> testdata/options/wrong_symbol.proto:25:10
+   |
+21 | message Foo {
+   |         --- defined here
+...
+24 |         (z) = 42,
+25 |         (Foo) = 42,
+   |          ^^^ expected message extension
+
+error: expected message extension, found `package` declaration `buf.test`
+  --> testdata/options/wrong_symbol.proto:26:10
+   |
+17 | package buf.test;
+   | ----------------- defined here
+...
+25 |         (Foo) = 42,
+26 |         (buf.test) = 42
+   |          ^^^^^^^^ expected message extension
+
+encountered 4 errors

--- a/experimental/ir/testdata/options/wrong_symbol.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/wrong_symbol.proto.symtab.yaml
@@ -1,0 +1,23 @@
+tables:
+  "testdata/options/wrong_symbol.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: true }]
+    symbols:
+      - fqn: "buf.test"
+        kind: KIND_PACKAGE
+        file: "testdata/options/wrong_symbol.proto"
+      - fqn: "buf.test.Foo"
+        kind: KIND_MESSAGE
+        file: "testdata/options/wrong_symbol.proto"
+        index: 1
+        visible: true
+      - fqn: "buf.test.Foo.z"
+        kind: KIND_FIELD
+        file: "testdata/options/wrong_symbol.proto"
+        index: 1
+        visible: true
+        options.message: {}
+      - fqn: "buf.test.x"
+        kind: KIND_EXTENSION
+        file: "testdata/options/wrong_symbol.proto"
+        index: 2
+        visible: true

--- a/experimental/ir/testdata/smoke.proto.fds.yaml
+++ b/experimental/ir/testdata/smoke.proto.fds.yaml
@@ -3,9 +3,14 @@ file:
     package: "buf.test"
     message_type:
       - name: "Foo"
-        extension:
-          - { name: "a", number: 0 }
-          - { name: "b", number: 0 }
-          - { name: "c", number: 0 }
-    enum_type: [{ name: "BAR" }]
+        field:
+          - { name: "a", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "c", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+    enum_type:
+      - name: "BAR"
+        value:
+          - { name: "BAR_ZERO", number: 0 }
+          - { name: "BAR_A", number: 0 }
+          - { name: "BAR_B", number: 0 }
     syntax: "proto2"

--- a/experimental/ir/testdata/symtab/double_def.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/symtab/double_def.proto.yaml.fds.yaml
@@ -13,9 +13,12 @@ file:
     dependency: ["dep/foo.proto"]
     message_type:
       - name: "Main"
-      - { name: "Main", extension: [{ name: "x", number: 0 }] }
-      - { name: "Foo", enum_type: [{ name: "BAR" }] }
-      - { name: "Main", extension: [{ name: "x", number: 0 }] }
+      - name: "Main"
+        field: [{ name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+      - name: "Foo"
+        enum_type: [{ name: "BAR", value: [{ name: "BAR", number: 0 }] }]
+      - name: "Main"
+        field: [{ name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_STRING }]
     syntax: "proto2"
   - name: "main2.proto"
     package: "dep.foo.Foo"

--- a/experimental/parser/parse.go
+++ b/experimental/parser/parse.go
@@ -32,8 +32,13 @@ func Parse(source *report.File, errs *report.Report) (file ast.File, ok bool) {
 	prior := len(errs.Diagnostics)
 	ctx := ast.NewContext(source)
 
-	lex(ctx, errs)
-	parse(ctx, errs)
+	errs.SaveOptions(func() {
+		if source.Path() == "google/protobuf/descriptor.proto" {
+			errs.SuppressWarnings = true
+		}
+		lex(ctx, errs)
+		parse(ctx, errs)
+	})
 
 	ok = true
 	for _, d := range errs.Diagnostics[prior:] {

--- a/experimental/parser/parse.go
+++ b/experimental/parser/parse.go
@@ -34,8 +34,13 @@ func Parse(source *report.File, errs *report.Report) (file ast.File, ok bool) {
 
 	errs.SaveOptions(func() {
 		if source.Path() == "google/protobuf/descriptor.proto" {
+			// descriptor.proto contains required fields, which we warn against.
+			// However, that would cause literally every project ever to have
+			// warnings, and in general, any warnings we add should not ding
+			// the worst WKT file of them all.
 			errs.SuppressWarnings = true
 		}
+
 		lex(ctx, errs)
 		parse(ctx, errs)
 	})

--- a/experimental/report/renderer.go
+++ b/experimental/report/renderer.go
@@ -249,6 +249,7 @@ func (r *renderer) diagnostic(report *Report, d Diagnostic) {
 		// Add a blank line after the file. This gives the diagnostic window some
 		// visual breathing room.
 		r.WriteSpaces(r.margin)
+		r.WriteString(r.ss.nAccent)
 		r.WriteString(" | ")
 
 		window := buildWindow(d.level, locations[i:i+len(snippets)], snippets)
@@ -916,6 +917,7 @@ func (r *renderer) suggestion(snip snippet) {
 	// visual breathing room.
 	r.WriteString("\n")
 	r.WriteSpaces(r.margin)
+	r.WriteString(r.ss.nAccent)
 	r.WriteString(" | ")
 
 	// When the suggestion spans multiple lines, we don't bother doing a by-the-rune

--- a/experimental/report/testdata/i18n.yaml.color.txt
+++ b/experimental/report/testdata/i18n.yaml.color.txt
@@ -1,18 +1,18 @@
 ⟨b.red⟩error: emoji, CJK, bidi
 ⟨blu⟩  --> foo.proto:5:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨reset⟩message 🐈<U+200D>⬛ {
 ⟨blu⟩   | ⟨reset⟩        ⟨b.red⟩^^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩
 ⟨blu⟩ 6 | ⟨reset⟩  string 黑猫 = 1;
 ⟨blu⟩   | ⟨reset⟩         ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩note: some surfaces render CJK as sub-two-column
 ⟨blu⟩  ::: bar.proto:1:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 1 | ⟨reset⟩import "חתול שחור.proto";
 ⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩---------------⟨reset⟩ ⟨b.blu⟩bidi works if it's quoted, at least⟨reset⟩
 
 ⟨b.red⟩error: bidi (Arabic, Hebrew, Farsi, etc) is broken in some contexts
 ⟨blu⟩  --> foo.proto:7:10
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 7 | ⟨reset⟩  string القطة السوداء = 2;
 ⟨blu⟩   | ⟨reset⟩         ⟨b.red⟩^^^^^^^^⟨reset⟩ ⟨b.red⟩⟨reset⟩
 

--- a/experimental/report/testdata/multi-file.yaml.color.txt
+++ b/experimental/report/testdata/multi-file.yaml.color.txt
@@ -1,27 +1,27 @@
 ⟨b.red⟩error: two files
 ⟨blu⟩  --> foo.proto:3:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨reset⟩        ⟨b.red⟩^^^^^^^⟨reset⟩ ⟨b.red⟩foo
 ⟨blu⟩ 4 | ⟨reset⟩
 ⟨blu⟩ 5 | ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩bar
 ⟨blu⟩  ::: bar.proto:3:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz2;
 ⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩-------⟨reset⟩ ⟨b.blu⟩baz⟨reset⟩
 
 ⟨b.red⟩error: three files
 ⟨blu⟩  --> foo.proto:3:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨reset⟩        ⟨b.red⟩^^^^^^^⟨reset⟩ ⟨b.red⟩foo
 ⟨blu⟩  ::: bar.proto:3:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz2;
 ⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩-------⟨reset⟩ ⟨b.blu⟩baz
 ⟨blu⟩  ::: foo.proto:5:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨reset⟩        ⟨b.blu⟩----⟨reset⟩ ⟨b.blu⟩bar⟨reset⟩
 

--- a/experimental/report/testdata/multi-underline.yaml.color.txt
+++ b/experimental/report/testdata/multi-underline.yaml.color.txt
@@ -1,6 +1,6 @@
 ⟨b.red⟩error: `size_t` is not a built-in Protobuf type
 ⟨blu⟩  --> foo.proto:6:12
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
 ⟨blu⟩   | ⟨reset⟩         ⟨b.blu⟩--------⟨reset⟩ ⟨b.blu⟩syntax version specified here
 ⟨blu⟩...
@@ -9,7 +9,7 @@
 
 ⟨b.ylw⟩warning: these are pretty bad names
 ⟨blu⟩  --> foo.proto:3:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨reset⟩        ⟨b.ylw⟩^^^^^^^⟨reset⟩ ⟨b.ylw⟩could be better
 ⟨blu⟩ 4 | ⟨reset⟩

--- a/experimental/report/testdata/multiline.yaml.color.txt
+++ b/experimental/report/testdata/multiline.yaml.color.txt
@@ -1,6 +1,6 @@
 ⟨b.ylw⟩warning: whole block
 ⟨blu⟩  --> foo.proto:5:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩...  ⟨b.ylw⟩|
 ⟨blu⟩12 | ⟨b.ylw⟩| ⟨reset⟩}
@@ -8,7 +8,7 @@
 
 ⟨b.ylw⟩warning: nested blocks
 ⟨blu⟩  --> foo.proto:5:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩  message Bonk {
@@ -20,7 +20,7 @@
 
 ⟨b.ylw⟩warning: parallel blocks
 ⟨blu⟩  --> foo.proto:5:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨reset⟩  message Bonk {
@@ -33,7 +33,7 @@
 
 ⟨b.ylw⟩warning: nested blocks same start
 ⟨blu⟩  --> foo.proto:5:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨b.blu⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩...  ⟨b.ylw⟩| ⟨b.blu⟩|
 ⟨blu⟩11 | ⟨b.ylw⟩| ⟨b.blu⟩| ⟨reset⟩  }
@@ -43,7 +43,7 @@
 
 ⟨b.ylw⟩warning: nested blocks same end
 ⟨blu⟩  --> foo.proto:5:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩  message Bonk {
@@ -54,7 +54,7 @@
 
 ⟨b.ylw⟩warning: nested overlap
 ⟨blu⟩  --> foo.proto:5:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩/ ⟨reset⟩message Blah {
 ⟨blu⟩ 6 | ⟨b.ylw⟩| ⟨reset⟩  required size_t x = 0;
 ⟨blu⟩ 7 | ⟨b.ylw⟩| ⟨b.blu⟩/ ⟨reset⟩  message Bonk {
@@ -66,7 +66,7 @@
 
 ⟨b.ylw⟩warning: nesting just the braces
 ⟨blu⟩  --> foo.proto:5:15
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩  ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨b.ylw⟩ ________________^
 ⟨blu⟩ 6 | ⟨b.ylw⟩/ ⟨reset⟩  required size_t x = 0;
@@ -80,7 +80,7 @@
 
 ⟨b.ylw⟩warning: nesting just the braces same start
 ⟨blu⟩  --> foo.proto:5:15
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩  ⟨b.blu⟩  ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨b.ylw⟩ ________________^
 ⟨blu⟩   | ⟨b.ylw⟩/ ⟨b.blu⟩ ______________-
@@ -92,7 +92,7 @@
 
 ⟨b.ylw⟩warning: nesting just the braces same start (2)
 ⟨blu⟩  --> foo.proto:5:15
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.blu⟩  ⟨b.ylw⟩  ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨b.blu⟩ ________________-
 ⟨blu⟩   | ⟨b.blu⟩/ ⟨b.ylw⟩ ______________^
@@ -104,7 +104,7 @@
 
 ⟨b.ylw⟩warning: braces nesting overlap
 ⟨blu⟩  --> foo.proto:5:15
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.ylw⟩  ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨b.ylw⟩ ________________^
 ⟨blu⟩ 6 | ⟨b.ylw⟩/ ⟨reset⟩  required size_t x = 0;
@@ -118,7 +118,7 @@
 
 ⟨b.ylw⟩warning: braces nesting overlap (2)
 ⟨blu⟩  --> foo.proto:7:17
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.blu⟩  ⟨reset⟩message Blah {
 ⟨blu⟩   | ⟨b.blu⟩ ________________-
 ⟨blu⟩ 6 | ⟨b.blu⟩/ ⟨reset⟩  required size_t x = 0;

--- a/experimental/report/testdata/single-line.yaml.color.txt
+++ b/experimental/report/testdata/single-line.yaml.color.txt
@@ -1,24 +1,24 @@
 ⟨b.cyn⟩remark: "proto4" isn't real, it can't hurt you
 ⟨blu⟩  --> foo.proto:1:10
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
 ⟨blu⟩   | ⟨reset⟩         ⟨b.cyn⟩^^^^^^^^^⟨reset⟩ ⟨b.cyn⟩help: change this to "proto5"⟨reset⟩
 
 ⟨b.red⟩error: missing `;`
 ⟨blu⟩  --> foo.proto:1:18
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 1 | ⟨reset⟩syntax = "proto4"
 ⟨blu⟩   | ⟨reset⟩                 ⟨b.red⟩^⟨reset⟩ ⟨b.red⟩here⟨reset⟩
 
 ⟨b.cyn⟩remark: EOF
 ⟨blu⟩  --> foo.proto:7:2
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 7 | ⟨reset⟩}
 ⟨blu⟩   | ⟨reset⟩ ⟨b.cyn⟩^⟨reset⟩ ⟨b.cyn⟩here⟨reset⟩
 
 ⟨b.red⟩error: package
 ⟨blu⟩  --> foo.proto:3:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨b.red⟩^^^^^^^⟨reset⟩        ⟨b.blu⟩-⟨reset⟩ ⟨b.blu⟩semicolon
 ⟨blu⟩   | ⟨b.red⟩|
@@ -26,7 +26,7 @@
 
 ⟨b.red⟩error: this is an overlapping error
 ⟨blu⟩  --> foo.proto:3:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨b.red⟩^^^^^^^⟨b.blu⟩---------⟨reset⟩ ⟨b.blu⟩package decl
 ⟨blu⟩   | ⟨b.red⟩|
@@ -34,7 +34,7 @@
 
 ⟨b.red⟩error: P A C K A G E
 ⟨blu⟩  --> foo.proto:3:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨b.red⟩^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩help: ge
 ⟨blu⟩   | ⟨b.red⟩| ⟨b.blu⟩|
@@ -44,7 +44,7 @@
 
 ⟨b.red⟩error: P A C K A G E (different order)
 ⟨blu⟩  --> foo.proto:3:3
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨b.blu⟩-⟨reset⟩ ⟨b.red⟩^^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩help: ge
 ⟨blu⟩   | ⟨b.blu⟩| ⟨b.red⟩|
@@ -54,7 +54,7 @@
 
 ⟨b.red⟩error: P A C K A G E (single letters)
 ⟨blu⟩  --> foo.proto:3:1
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 3 | ⟨reset⟩package abc.xyz;
 ⟨blu⟩   | ⟨b.red⟩^⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩--⟨reset⟩ ⟨b.blu⟩g
 ⟨blu⟩   | ⟨b.red⟩| ⟨b.blu⟩|

--- a/experimental/report/testdata/suggestions.yaml.color.txt
+++ b/experimental/report/testdata/suggestions.yaml.color.txt
@@ -1,45 +1,45 @@
 ⟨b.cyn⟩remark: let protocompile pick a syntax for you
 ⟨blu⟩  --> foo.proto:1:1
 ⟨blu⟩  help: delete this
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 1 | ⟨b.red⟩-⟨red⟩ syntax = "proto3";
 ⟨blu⟩   | ⟨reset⟩
 
 ⟨b.cyn⟩remark: let protocompile pick a syntax for you
 ⟨blu⟩  --> foo.proto:1:10
 ⟨blu⟩  help: delete this
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 1 | ⟨b.red⟩-⟨red⟩ syntax = "proto3";
 ⟨blu⟩ 1 | ⟨b.grn⟩+⟨grn⟩ syntax = ;
 ⟨blu⟩   | ⟨reset⟩
 
 ⟨b.ylw⟩warning: services should have a `Service` suffix
 ⟨blu⟩  --> foo.proto:5:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨reset⟩service Foo {
 ⟨blu⟩   | ⟨reset⟩        ⟨b.ylw⟩^^^⟨reset⟩ ⟨b.ylw⟩
 ⟨blu⟩  help: change the name to `FooService`
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨reset⟩service Foo⟨grn⟩Service⟨reset⟩ {
 ⟨blu⟩   | ⟨reset⟩           ⟨b.grn⟩+++++++⟨reset⟩  ⟨reset⟩
 
 ⟨b.red⟩error: missing (...) around return type
 ⟨blu⟩  --> foo.proto:6:31
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 6 | ⟨reset⟩  rpc Get(GetRequest) returns GetResponse
 ⟨blu⟩   | ⟨reset⟩                              ⟨b.red⟩^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩
 ⟨blu⟩  help: add `(...)` around the type
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 6 | ⟨reset⟩  rpc Get(GetRequest) returns ⟨grn⟩(⟨reset⟩GetResponse⟨grn⟩)
 ⟨blu⟩   | ⟨reset⟩                              ⟨b.grn⟩+⟨reset⟩           ⟨b.grn⟩+⟨reset⟩
 
 ⟨b.red⟩error: method options must go in a block
 ⟨blu⟩  --> foo.proto:7:45
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 7 | ⟨reset⟩  rpc Put(PutRequest) returns (PutResponse) [foo = bar];
 ⟨blu⟩   | ⟨reset⟩                                            ⟨b.red⟩^^^^^^^^^^^⟨reset⟩ ⟨b.red⟩compact options not allowed here
 ⟨blu⟩  help: use `option` settings inside of the method body
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 7 | ⟨b.red⟩-⟨red⟩   rpc Put(PutRequest) returns (PutResponse) [foo = bar];
 ⟨blu⟩ 7 | ⟨b.grn⟩+⟨grn⟩   rpc Put(PutRequest) returns (PutResponse) {
 ⟨blu⟩ 8 | ⟨b.grn⟩+⟨grn⟩     option foo = bar;
@@ -49,7 +49,7 @@
 ⟨b.red⟩error: delete some stuff
 ⟨blu⟩  --> foo.proto:5:1
 ⟨blu⟩  help:
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 5 | ⟨b.red⟩-⟨red⟩ service Foo {
 ⟨blu⟩ 6 | ⟨reset⟩ ⟨reset⟩   rpc Get(GetRequest) returns GetResponse
 ⟨blu⟩ 7 | ⟨reset⟩ ⟨reset⟩   rpc Put(PutRequest) returns (PutResponse) [foo = bar];
@@ -61,7 +61,7 @@
 ⟨b.red⟩error: delete this method
 ⟨blu⟩  --> foo.proto:5:1
 ⟨blu⟩  help:
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 7 | ⟨b.red⟩-⟨red⟩   rpc Put(PutRequest) returns (PutResponse) [foo = bar];
 ⟨blu⟩ 8 | ⟨b.red⟩-⟨red⟩ }
 ⟨blu⟩ 7 | ⟨b.grn⟩+⟨grn⟩   r}

--- a/experimental/report/testdata/tabstops.yaml.color.txt
+++ b/experimental/report/testdata/tabstops.yaml.color.txt
@@ -1,6 +1,6 @@
 ⟨b.ylw⟩warning: tabstop
 ⟨blu⟩  --> foo.proto:6:9
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 6 | ⟨reset⟩        field
 ⟨blu⟩   | ⟨b.blu⟩--------⟨b.ylw⟩^^^^^⟨reset⟩ ⟨b.ylw⟩this is in front of some tabstops
 ⟨blu⟩   | ⟨b.blu⟩|
@@ -8,7 +8,7 @@
 
 ⟨b.ylw⟩warning: partial tabstop
 ⟨blu⟩  --> foo.proto:7:2
-   |
+  ⟨blu⟩ |
 ⟨blu⟩ 7 | ⟨reset⟩    field
 ⟨blu⟩   | ⟨b.blu⟩-⟨b.ylw⟩^^^⟨reset⟩ ⟨b.ylw⟩tabstop
 ⟨blu⟩   | ⟨b.blu⟩|

--- a/experimental/source/source.go
+++ b/experimental/source/source.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"io/fs"
 	"strings"
+
+	"github.com/bufbuild/protocompile/wellknownimports"
 )
 
 // Opener is a mechanism for opening files.
@@ -112,4 +114,9 @@ func (o *Openers) Open(path string) (string, error) {
 		return text, err
 	}
 	return "", fs.ErrNotExist
+}
+
+// WKTs returns an opener that yields protocompile's built-in WKT sources.
+func WKTs() Opener {
+	return &FS{FS: wellknownimports.FS()}
 }

--- a/experimental/source/source.go
+++ b/experimental/source/source.go
@@ -118,5 +118,8 @@ func (o *Openers) Open(path string) (string, error) {
 
 // WKTs returns an opener that yields protocompile's built-in WKT sources.
 func WKTs() Opener {
-	return &FS{FS: wellknownimports.FS()}
+	// Ensure that all openers returned by this function compare equal.
+	return &wkts
 }
+
+var wkts = FS{FS: wellknownimports.FS()}

--- a/experimental/token/keyword/doc.go
+++ b/experimental/token/keyword/doc.go
@@ -19,8 +19,7 @@ package keyword
 
 //go:generate go run github.com/bufbuild/protocompile/internal/enum keyword.yaml
 
-// IsPseudoOption returns whether or not this keyword is one of the special
-// pseudo option names ([default = "..."] and [json_name = "..."])
+// pseudo option names ([default = "..."] and [json_name = "..."]).
 func (k Keyword) IsPseudoOption() bool {
 	return k == Default || k == JsonName
 }

--- a/internal/gen/buf/compiler/v1alpha1/symtab.pb.go
+++ b/internal/gen/buf/compiler/v1alpha1/symtab.pb.go
@@ -153,6 +153,7 @@ type SymbolTable struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Imports       []*Import              `protobuf:"bytes,1,rep,name=imports,proto3" json:"imports,omitempty"`
 	Symbols       []*Symbol              `protobuf:"bytes,2,rep,name=symbols,proto3" json:"symbols,omitempty"`
+	Options       *Value                 `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -197,6 +198,13 @@ func (x *SymbolTable) GetImports() []*Import {
 func (x *SymbolTable) GetSymbols() []*Symbol {
 	if x != nil {
 		return x.Symbols
+	}
+	return nil
+}
+
+func (x *SymbolTable) GetOptions() *Value {
+	if x != nil {
+		return x.Options
 	}
 	return nil
 }
@@ -288,7 +296,8 @@ type Symbol struct {
 	// The index of this kind of entity in that file.
 	Index uint32 `protobuf:"varint,4,opt,name=index,proto3" json:"index,omitempty"`
 	// Whether this symbol can be validly referenced in the current file.
-	Visible       bool `protobuf:"varint,5,opt,name=visible,proto3" json:"visible,omitempty"`
+	Visible       bool   `protobuf:"varint,5,opt,name=visible,proto3" json:"visible,omitempty"`
+	Options       *Value `protobuf:"bytes,6,opt,name=options,proto3" json:"options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -358,6 +367,272 @@ func (x *Symbol) GetVisible() bool {
 	return false
 }
 
+func (x *Symbol) GetOptions() *Value {
+	if x != nil {
+		return x.Options
+	}
+	return nil
+}
+
+// An option value attached to a symbol.
+type Value struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Value:
+	//
+	//	*Value_Bool
+	//	*Value_Int
+	//	*Value_Uint
+	//	*Value_Float
+	//	*Value_String_
+	//	*Value_Repeated_
+	//	*Value_Message_
+	Value         isValue_Value `protobuf_oneof:"value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Value) Reset() {
+	*x = Value{}
+	mi := &file_buf_compiler_v1alpha1_symtab_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Value) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Value) ProtoMessage() {}
+
+func (x *Value) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_compiler_v1alpha1_symtab_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Value.ProtoReflect.Descriptor instead.
+func (*Value) Descriptor() ([]byte, []int) {
+	return file_buf_compiler_v1alpha1_symtab_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *Value) GetValue() isValue_Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *Value) GetBool() bool {
+	if x != nil {
+		if x, ok := x.Value.(*Value_Bool); ok {
+			return x.Bool
+		}
+	}
+	return false
+}
+
+func (x *Value) GetInt() int64 {
+	if x != nil {
+		if x, ok := x.Value.(*Value_Int); ok {
+			return x.Int
+		}
+	}
+	return 0
+}
+
+func (x *Value) GetUint() uint64 {
+	if x != nil {
+		if x, ok := x.Value.(*Value_Uint); ok {
+			return x.Uint
+		}
+	}
+	return 0
+}
+
+func (x *Value) GetFloat() float64 {
+	if x != nil {
+		if x, ok := x.Value.(*Value_Float); ok {
+			return x.Float
+		}
+	}
+	return 0
+}
+
+func (x *Value) GetString_() []byte {
+	if x != nil {
+		if x, ok := x.Value.(*Value_String_); ok {
+			return x.String_
+		}
+	}
+	return nil
+}
+
+func (x *Value) GetRepeated() *Value_Repeated {
+	if x != nil {
+		if x, ok := x.Value.(*Value_Repeated_); ok {
+			return x.Repeated
+		}
+	}
+	return nil
+}
+
+func (x *Value) GetMessage() *Value_Message {
+	if x != nil {
+		if x, ok := x.Value.(*Value_Message_); ok {
+			return x.Message
+		}
+	}
+	return nil
+}
+
+type isValue_Value interface {
+	isValue_Value()
+}
+
+type Value_Bool struct {
+	Bool bool `protobuf:"varint,1,opt,name=bool,proto3,oneof"`
+}
+
+type Value_Int struct {
+	Int int64 `protobuf:"varint,2,opt,name=int,proto3,oneof"`
+}
+
+type Value_Uint struct {
+	Uint uint64 `protobuf:"varint,3,opt,name=uint,proto3,oneof"`
+}
+
+type Value_Float struct {
+	Float float64 `protobuf:"fixed64,4,opt,name=float,proto3,oneof"`
+}
+
+type Value_String_ struct {
+	String_ []byte `protobuf:"bytes,5,opt,name=string,proto3,oneof"`
+}
+
+type Value_Repeated_ struct {
+	Repeated *Value_Repeated `protobuf:"bytes,6,opt,name=repeated,proto3,oneof"`
+}
+
+type Value_Message_ struct {
+	Message *Value_Message `protobuf:"bytes,7,opt,name=message,proto3,oneof"`
+}
+
+func (*Value_Bool) isValue_Value() {}
+
+func (*Value_Int) isValue_Value() {}
+
+func (*Value_Uint) isValue_Value() {}
+
+func (*Value_Float) isValue_Value() {}
+
+func (*Value_String_) isValue_Value() {}
+
+func (*Value_Repeated_) isValue_Value() {}
+
+func (*Value_Message_) isValue_Value() {}
+
+type Value_Message struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Fields        map[string]*Value      `protobuf:"bytes,1,rep,name=fields,proto3" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Extns         map[string]*Value      `protobuf:"bytes,2,rep,name=extns,proto3" json:"extns,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Value_Message) Reset() {
+	*x = Value_Message{}
+	mi := &file_buf_compiler_v1alpha1_symtab_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Value_Message) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Value_Message) ProtoMessage() {}
+
+func (x *Value_Message) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_compiler_v1alpha1_symtab_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Value_Message.ProtoReflect.Descriptor instead.
+func (*Value_Message) Descriptor() ([]byte, []int) {
+	return file_buf_compiler_v1alpha1_symtab_proto_rawDescGZIP(), []int{4, 0}
+}
+
+func (x *Value_Message) GetFields() map[string]*Value {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
+func (x *Value_Message) GetExtns() map[string]*Value {
+	if x != nil {
+		return x.Extns
+	}
+	return nil
+}
+
+type Value_Repeated struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Values        []*Value               `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Value_Repeated) Reset() {
+	*x = Value_Repeated{}
+	mi := &file_buf_compiler_v1alpha1_symtab_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Value_Repeated) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Value_Repeated) ProtoMessage() {}
+
+func (x *Value_Repeated) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_compiler_v1alpha1_symtab_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Value_Repeated.ProtoReflect.Descriptor instead.
+func (*Value_Repeated) Descriptor() ([]byte, []int) {
+	return file_buf_compiler_v1alpha1_symtab_proto_rawDescGZIP(), []int{4, 1}
+}
+
+func (x *Value_Repeated) GetValues() []*Value {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
 var File_buf_compiler_v1alpha1_symtab_proto protoreflect.FileDescriptor
 
 const file_buf_compiler_v1alpha1_symtab_proto_rawDesc = "" +
@@ -367,10 +642,11 @@ const file_buf_compiler_v1alpha1_symtab_proto_rawDesc = "" +
 	"\x06tables\x18\x01 \x03(\v2,.buf.compiler.v1alpha1.SymbolSet.TablesEntryR\x06tables\x1a]\n" +
 	"\vTablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x128\n" +
-	"\x05value\x18\x02 \x01(\v2\".buf.compiler.v1alpha1.SymbolTableR\x05value:\x028\x01\"\x7f\n" +
+	"\x05value\x18\x02 \x01(\v2\".buf.compiler.v1alpha1.SymbolTableR\x05value:\x028\x01\"\xb7\x01\n" +
 	"\vSymbolTable\x127\n" +
 	"\aimports\x18\x01 \x03(\v2\x1d.buf.compiler.v1alpha1.ImportR\aimports\x127\n" +
-	"\asymbols\x18\x02 \x03(\v2\x1d.buf.compiler.v1alpha1.SymbolR\asymbols\"\x82\x01\n" +
+	"\asymbols\x18\x02 \x03(\v2\x1d.buf.compiler.v1alpha1.SymbolR\asymbols\x126\n" +
+	"\aoptions\x18\x03 \x01(\v2\x1c.buf.compiler.v1alpha1.ValueR\aoptions\"\x82\x01\n" +
 	"\x06Import\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x16\n" +
 	"\x06public\x18\x02 \x01(\bR\x06public\x12\x12\n" +
@@ -378,13 +654,14 @@ const file_buf_compiler_v1alpha1_symtab_proto_rawDesc = "" +
 	"\n" +
 	"transitive\x18\x04 \x01(\bR\n" +
 	"transitive\x12\x18\n" +
-	"\avisible\x18\x05 \x01(\bR\avisible\"\xc2\x02\n" +
+	"\avisible\x18\x05 \x01(\bR\avisible\"\xfa\x02\n" +
 	"\x06Symbol\x12\x10\n" +
 	"\x03fqn\x18\x01 \x01(\tR\x03fqn\x126\n" +
 	"\x04kind\x18\x02 \x01(\x0e2\".buf.compiler.v1alpha1.Symbol.KindR\x04kind\x12\x12\n" +
 	"\x04file\x18\x03 \x01(\tR\x04file\x12\x14\n" +
 	"\x05index\x18\x04 \x01(\rR\x05index\x12\x18\n" +
-	"\avisible\x18\x05 \x01(\bR\avisible\"\xa9\x01\n" +
+	"\avisible\x18\x05 \x01(\bR\avisible\x126\n" +
+	"\aoptions\x18\x06 \x01(\v2\x1c.buf.compiler.v1alpha1.ValueR\aoptions\"\xa9\x01\n" +
 	"\x04Kind\x12\x14\n" +
 	"\x10KIND_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fKIND_PACKAGE\x10\x01\x12\x0f\n" +
@@ -396,7 +673,28 @@ const file_buf_compiler_v1alpha1_symtab_proto_rawDesc = "" +
 	"\x0fKIND_ENUM_VALUE\x10\x06\x12\x12\n" +
 	"\x0eKIND_EXTENSION\x10\a\x12\x0e\n" +
 	"\n" +
-	"KIND_ONEOF\x10\bB\xf4\x01\n" +
+	"KIND_ONEOF\x10\b\"\x99\x05\n" +
+	"\x05Value\x12\x14\n" +
+	"\x04bool\x18\x01 \x01(\bH\x00R\x04bool\x12\x12\n" +
+	"\x03int\x18\x02 \x01(\x03H\x00R\x03int\x12\x14\n" +
+	"\x04uint\x18\x03 \x01(\x04H\x00R\x04uint\x12\x16\n" +
+	"\x05float\x18\x04 \x01(\x01H\x00R\x05float\x12\x18\n" +
+	"\x06string\x18\x05 \x01(\fH\x00R\x06string\x12C\n" +
+	"\brepeated\x18\x06 \x01(\v2%.buf.compiler.v1alpha1.Value.RepeatedH\x00R\brepeated\x12@\n" +
+	"\amessage\x18\a \x01(\v2$.buf.compiler.v1alpha1.Value.MessageH\x00R\amessage\x1a\xcb\x02\n" +
+	"\aMessage\x12H\n" +
+	"\x06fields\x18\x01 \x03(\v20.buf.compiler.v1alpha1.Value.Message.FieldsEntryR\x06fields\x12E\n" +
+	"\x05extns\x18\x02 \x03(\v2/.buf.compiler.v1alpha1.Value.Message.ExtnsEntryR\x05extns\x1aW\n" +
+	"\vFieldsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x122\n" +
+	"\x05value\x18\x02 \x01(\v2\x1c.buf.compiler.v1alpha1.ValueR\x05value:\x028\x01\x1aV\n" +
+	"\n" +
+	"ExtnsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x122\n" +
+	"\x05value\x18\x02 \x01(\v2\x1c.buf.compiler.v1alpha1.ValueR\x05value:\x028\x01\x1a@\n" +
+	"\bRepeated\x124\n" +
+	"\x06values\x18\x01 \x03(\v2\x1c.buf.compiler.v1alpha1.ValueR\x06valuesB\a\n" +
+	"\x05valueB\xf4\x01\n" +
 	"\x19com.buf.compiler.v1alpha1B\vSymtabProtoP\x01ZTgithub.com/bufbuild/protocompile/internal/gen/buf/compiler/v1alpha1;compilerv1alpha1\xa2\x02\x03BCX\xaa\x02\x15Buf.Compiler.V1alpha1\xca\x02\x15Buf\\Compiler\\V1alpha1\xe2\x02!Buf\\Compiler\\V1alpha1\\GPBMetadata\xea\x02\x17Buf::Compiler::V1alpha1b\x06proto3"
 
 var (
@@ -412,26 +710,40 @@ func file_buf_compiler_v1alpha1_symtab_proto_rawDescGZIP() []byte {
 }
 
 var file_buf_compiler_v1alpha1_symtab_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_buf_compiler_v1alpha1_symtab_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_buf_compiler_v1alpha1_symtab_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_buf_compiler_v1alpha1_symtab_proto_goTypes = []any{
-	(Symbol_Kind)(0),    // 0: buf.compiler.v1alpha1.Symbol.Kind
-	(*SymbolSet)(nil),   // 1: buf.compiler.v1alpha1.SymbolSet
-	(*SymbolTable)(nil), // 2: buf.compiler.v1alpha1.SymbolTable
-	(*Import)(nil),      // 3: buf.compiler.v1alpha1.Import
-	(*Symbol)(nil),      // 4: buf.compiler.v1alpha1.Symbol
-	nil,                 // 5: buf.compiler.v1alpha1.SymbolSet.TablesEntry
+	(Symbol_Kind)(0),       // 0: buf.compiler.v1alpha1.Symbol.Kind
+	(*SymbolSet)(nil),      // 1: buf.compiler.v1alpha1.SymbolSet
+	(*SymbolTable)(nil),    // 2: buf.compiler.v1alpha1.SymbolTable
+	(*Import)(nil),         // 3: buf.compiler.v1alpha1.Import
+	(*Symbol)(nil),         // 4: buf.compiler.v1alpha1.Symbol
+	(*Value)(nil),          // 5: buf.compiler.v1alpha1.Value
+	nil,                    // 6: buf.compiler.v1alpha1.SymbolSet.TablesEntry
+	(*Value_Message)(nil),  // 7: buf.compiler.v1alpha1.Value.Message
+	(*Value_Repeated)(nil), // 8: buf.compiler.v1alpha1.Value.Repeated
+	nil,                    // 9: buf.compiler.v1alpha1.Value.Message.FieldsEntry
+	nil,                    // 10: buf.compiler.v1alpha1.Value.Message.ExtnsEntry
 }
 var file_buf_compiler_v1alpha1_symtab_proto_depIdxs = []int32{
-	5, // 0: buf.compiler.v1alpha1.SymbolSet.tables:type_name -> buf.compiler.v1alpha1.SymbolSet.TablesEntry
-	3, // 1: buf.compiler.v1alpha1.SymbolTable.imports:type_name -> buf.compiler.v1alpha1.Import
-	4, // 2: buf.compiler.v1alpha1.SymbolTable.symbols:type_name -> buf.compiler.v1alpha1.Symbol
-	0, // 3: buf.compiler.v1alpha1.Symbol.kind:type_name -> buf.compiler.v1alpha1.Symbol.Kind
-	2, // 4: buf.compiler.v1alpha1.SymbolSet.TablesEntry.value:type_name -> buf.compiler.v1alpha1.SymbolTable
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	6,  // 0: buf.compiler.v1alpha1.SymbolSet.tables:type_name -> buf.compiler.v1alpha1.SymbolSet.TablesEntry
+	3,  // 1: buf.compiler.v1alpha1.SymbolTable.imports:type_name -> buf.compiler.v1alpha1.Import
+	4,  // 2: buf.compiler.v1alpha1.SymbolTable.symbols:type_name -> buf.compiler.v1alpha1.Symbol
+	5,  // 3: buf.compiler.v1alpha1.SymbolTable.options:type_name -> buf.compiler.v1alpha1.Value
+	0,  // 4: buf.compiler.v1alpha1.Symbol.kind:type_name -> buf.compiler.v1alpha1.Symbol.Kind
+	5,  // 5: buf.compiler.v1alpha1.Symbol.options:type_name -> buf.compiler.v1alpha1.Value
+	8,  // 6: buf.compiler.v1alpha1.Value.repeated:type_name -> buf.compiler.v1alpha1.Value.Repeated
+	7,  // 7: buf.compiler.v1alpha1.Value.message:type_name -> buf.compiler.v1alpha1.Value.Message
+	2,  // 8: buf.compiler.v1alpha1.SymbolSet.TablesEntry.value:type_name -> buf.compiler.v1alpha1.SymbolTable
+	9,  // 9: buf.compiler.v1alpha1.Value.Message.fields:type_name -> buf.compiler.v1alpha1.Value.Message.FieldsEntry
+	10, // 10: buf.compiler.v1alpha1.Value.Message.extns:type_name -> buf.compiler.v1alpha1.Value.Message.ExtnsEntry
+	5,  // 11: buf.compiler.v1alpha1.Value.Repeated.values:type_name -> buf.compiler.v1alpha1.Value
+	5,  // 12: buf.compiler.v1alpha1.Value.Message.FieldsEntry.value:type_name -> buf.compiler.v1alpha1.Value
+	5,  // 13: buf.compiler.v1alpha1.Value.Message.ExtnsEntry.value:type_name -> buf.compiler.v1alpha1.Value
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_buf_compiler_v1alpha1_symtab_proto_init() }
@@ -439,13 +751,22 @@ func file_buf_compiler_v1alpha1_symtab_proto_init() {
 	if File_buf_compiler_v1alpha1_symtab_proto != nil {
 		return
 	}
+	file_buf_compiler_v1alpha1_symtab_proto_msgTypes[4].OneofWrappers = []any{
+		(*Value_Bool)(nil),
+		(*Value_Int)(nil),
+		(*Value_Uint)(nil),
+		(*Value_Float)(nil),
+		(*Value_String_)(nil),
+		(*Value_Repeated_)(nil),
+		(*Value_Message_)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_compiler_v1alpha1_symtab_proto_rawDesc), len(file_buf_compiler_v1alpha1_symtab_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   5,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/proto/buf/compiler/v1alpha1/symtab.proto
+++ b/internal/proto/buf/compiler/v1alpha1/symtab.proto
@@ -25,6 +25,7 @@ message SymbolSet {
 message SymbolTable {
     repeated Import imports = 1;
     repeated Symbol symbols = 2;
+    Value options = 3;
 }
 
 // Metadata associated with a transitive import.
@@ -63,4 +64,27 @@ message Symbol {
 
     // Whether this symbol can be validly referenced in the current file.
     bool visible = 5;
+
+    Value options = 6;
+}
+
+// An option value attached to a symbol.
+message Value {
+    message Message {
+        map<string, Value> fields = 1;
+        map<string, Value> extns = 2;
+    }
+    message Repeated {
+        repeated Value values = 1;
+    }
+
+    oneof value {
+        bool bool = 1;
+        int64 int = 2;
+        uint64 uint = 3;
+        double float = 4;
+        bytes string = 5;
+        Repeated repeated = 6;
+        Message message = 7;
+    }
 }

--- a/wellknownimports/wellknownimports.go
+++ b/wellknownimports/wellknownimports.go
@@ -19,12 +19,18 @@ package wellknownimports
 import (
 	"embed"
 	"io"
+	"io/fs"
 
 	"github.com/bufbuild/protocompile"
 )
 
 //go:embed google/protobuf/*.proto google/protobuf/*/*.proto
 var files embed.FS
+
+// FS returns a filesystem over the built-in well-known imports.
+func FS() fs.FS {
+	return files
+}
 
 // WithStandardImports returns a new resolver that can provide the source code for the
 // standard imports that are included with protoc. This differs from


### PR DESCRIPTION
This PR implements all of option name resolution, including nested and custom options.

This also makes `descriptor.proto` a mandatory import for all files, generating an ICE if it's missing. It does not affect ordinary symbol resolution unless explicitly imported in source code. This PR also fixes a bug I found with how extensions/fields are differentiated from each other when lowering out of AST.

Finally, this PR adds test output to the existing symtab protos to include options attached to a particular symbol, making it possible to actually test this PR before we added options->FDS.