### PR TITLE
Implement enough evaluation to do field number calculations

### DIFF
--- a/experimental/ast/predeclared/predeclared.go
+++ b/experimental/ast/predeclared/predeclared.go
@@ -106,6 +106,11 @@ func (n Name) IsInt() bool {
 	return n >= Int32 && n <= SFixed64
 }
 
+// IsNumber returns whether this is a numeric type.
+func (n Name) IsNumber() bool {
+	return n >= Int32 && n <= Double
+}
+
 // IsUnsigned returns whether this is an unsigned integer type.
 func (n Name) IsUnsigned() bool {
 	switch n {
@@ -129,6 +134,20 @@ func (n Name) IsFloat() bool {
 // IsString returns whether this is a string type (string or bytes).
 func (n Name) IsString() bool {
 	return n == String || n == Bytes
+}
+
+// Bits returns the bit size of a name satisfying [Name.IsNumber].
+//
+// Return 0 for all other names.
+func (n Name) Bits() int {
+	switch n {
+	case Int32, UInt32, SInt32, Fixed32, SFixed32, Float32:
+		return 32
+	case Int64, UInt64, SInt64, Fixed64, SFixed64, Float64:
+		return 64
+	default:
+		return 0
+	}
 }
 
 // IsMapKey returns whether this predeclared name represents one of the map key

--- a/experimental/internal/taxa/noun.go
+++ b/experimental/internal/taxa/noun.go
@@ -61,6 +61,7 @@ const (
 	MethodOuts
 	Signature
 	FieldTag
+	FieldNumber
 	FieldName
 	OptionValue
 	QualifiedName
@@ -179,6 +180,7 @@ var _table_Noun_String = [...]string{
 	MethodOuts:         "method return type",
 	Signature:          "method signature",
 	FieldTag:           "message field tag",
+	FieldNumber:        "field number",
 	FieldName:          "message field name",
 	OptionValue:        "option setting value",
 	QualifiedName:      "qualified name",
@@ -205,7 +207,7 @@ var _table_Noun_String = [...]string{
 	String:             "string literal",
 	Float:              "floating-point literal",
 	Int:                "integer literal",
-	Number:             "number",
+	Number:             "number literal",
 	Semi:               "`;`",
 	Comma:              "`,`",
 	Slash:              "`/`",
@@ -280,6 +282,7 @@ var _table_Noun_GoString = [...]string{
 	MethodOuts:         "MethodOuts",
 	Signature:          "Signature",
 	FieldTag:           "FieldTag",
+	FieldNumber:        "FieldNumber",
 	FieldName:          "FieldName",
 	OptionValue:        "OptionValue",
 	QualifiedName:      "QualifiedName",

--- a/experimental/internal/taxa/noun.go
+++ b/experimental/internal/taxa/noun.go
@@ -87,6 +87,7 @@ const (
 	String
 	Float
 	Int
+	Number
 	Semi
 	Comma
 	Slash
@@ -204,6 +205,7 @@ var _table_Noun_String = [...]string{
 	String:             "string literal",
 	Float:              "floating-point literal",
 	Int:                "integer literal",
+	Number:             "number",
 	Semi:               "`;`",
 	Comma:              "`,`",
 	Slash:              "`/`",
@@ -304,6 +306,7 @@ var _table_Noun_GoString = [...]string{
 	String:             "String",
 	Float:              "Float",
 	Int:                "Int",
+	Number:             "Number",
 	Semi:               "Semi",
 	Comma:              "Comma",
 	Slash:              "Slash",

--- a/experimental/internal/taxa/noun.yaml
+++ b/experimental/internal/taxa/noun.yaml
@@ -64,6 +64,7 @@
   - {name: Signature, string: "method signature"}
 
   - {name: FieldTag, string: "message field tag"}
+  - {name: FieldNumber, string: "field number"}
   - {name: FieldName, string: "message field name"}
   - {name: OptionValue, string: "option setting value"}
 
@@ -96,6 +97,7 @@
   - {name: String, string: "string literal"}
   - {name: Float, string: "floating-point literal"}
   - {name: Int, string: "integer literal"}
+  - {name: Number, string: "number literal"}
 
   - {name: Semi, string: "`;`"}
   - {name: Comma, string: "`,`"}

--- a/experimental/ir/ir_type.go
+++ b/experimental/ir/ir_type.go
@@ -42,7 +42,7 @@ type rawType struct {
 	options         arena.Pointer[rawValue]
 	fqn, name       intern.ID // 0 for predeclared types.
 	parent          arena.Pointer[rawType]
-	fieldsExtnStart uint32
+	fieldsEnd       uint32
 	rangesExtnStart uint32
 	isEnum          bool
 }
@@ -227,7 +227,7 @@ func (t Type) Nested() seq.Indexer[Type] {
 // type.
 func (t Type) Fields() seq.Indexer[Field] {
 	return seq.NewFixedSlice(
-		t.raw.fields[:t.raw.fieldsExtnStart],
+		t.raw.fields[:t.raw.fieldsEnd],
 		func(_ int, p arena.Pointer[rawField]) Field {
 			return wrapField(t.Context(), ref[rawField]{ptr: p})
 		},
@@ -237,7 +237,7 @@ func (t Type) Fields() seq.Indexer[Field] {
 // Extensions returns any extensions nested within this type.
 func (t Type) Extensions() seq.Indexer[Field] {
 	return seq.NewFixedSlice(
-		t.raw.fields[t.raw.fieldsExtnStart:],
+		t.raw.fields[t.raw.fieldsEnd:],
 		func(_ int, p arena.Pointer[rawField]) Field {
 			return wrapField(t.Context(), ref[rawField]{ptr: p})
 		},

--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -70,6 +70,14 @@ func lower(c *Context, r *report.Report, importer Importer) {
 
 	// Perform "early" name resolution, i.e. field names and extension types.
 	resolveNames(c.File(), r)
+
+	// Perform constant evaluation.
+	evaluateFieldNumbers(c.File(), r)
+
+	// Perform more constant evaluation. This is a separate step because we need
+	// to know if an extendee is a MessageSet before checking extension numbers,
+	// since MessageSet field numbers are 32-bit, not 29-bit.
+	evaluateExtensionNumbers(c.File(), r)
 }
 
 // sorry panics with an NYI error, which turns into an ICE inside of the

--- a/experimental/ir/lower_eval.go
+++ b/experimental/ir/lower_eval.go
@@ -1,0 +1,506 @@
+package ir
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/ast/predeclared"
+	"github.com/bufbuild/protocompile/experimental/internal"
+	"github.com/bufbuild/protocompile/experimental/internal/taxa"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/experimental/token"
+	"github.com/bufbuild/protocompile/experimental/token/keyword"
+	"github.com/bufbuild/protocompile/internal/ext/mapsx"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// evaluateFieldNumbers evaluates all non-extension field numbers: that is,
+// the numbers in reserved ranges and in non-extension field and enum value
+// declarations.
+func evaluateFieldNumbers(f File, r *report.Report) {
+	// TODO: Evaluate reserved ranges.
+
+	for ty := range seq.Values(f.AllTypes()) {
+		tags := make(map[int32]Field, ty.Fields().Len())
+		for field := range seq.Values(ty.Fields()) {
+			n, ok := evaluateFieldNumber(field, r)
+			field.raw.number = n
+			if !ok {
+				continue
+			}
+
+			if first, ok := mapsx.Add(tags, n, field); !ok {
+				what := taxa.FieldTag
+				if ty.IsEnum() {
+					what = taxa.EnumValue
+				}
+				r.Errorf("%ss must be unique", what).Apply(
+					report.Snippetf(field.AST().Value(), "used again here"),
+					report.Snippetf(first.AST().Value(), "originally used here"),
+				)
+			}
+		}
+
+		// TODO: compare with extension/reserved ranges.
+	}
+}
+
+// evaluateExtensionNumbers evaluates all extension field numbers: that is,
+// the numbers on extension ranges and extension fields.
+func evaluateExtensionNumbers(f File, r *report.Report) {
+	// TODO: Evaluate extension ranges.
+
+	for extn := range seq.Values(f.AllExtensions()) {
+		n, _ := evaluateFieldNumber(extn, r)
+		extn.raw.number = n
+
+		// TODO: compare with extension ranges.
+	}
+}
+
+func evaluateFieldNumber(field Field, r *report.Report) (int32, bool) {
+	if field.AST().Value().IsZero() {
+		return 0, false // Diagnosed for us elsewhere.
+	}
+
+	e := &evaluator{
+		Context: field.Context(),
+		Report:  r,
+		scope:   field.FullName().Parent(),
+	}
+
+	// Don't bother allocating a whole Value for this.
+	v, ok := e.evalBits(evalArgs{
+		expr:   field.AST().Value(),
+		uint29: field.IsMessageField(), // TODO: MessageSet.
+	})
+
+	return int32(v), ok
+}
+
+// evaluator is the context needed to evaluate an expression.
+type evaluator struct {
+	*Context
+	*report.Report
+	scope FullName
+}
+
+type evalArgs struct {
+	expr ast.ExprAny // The expression to evaluate.
+
+	// The field that this value maps to, if evaluating an option.
+	// If not set, we assume that we're evaluating a field number of some kind.
+	field ref[rawField]
+	// A span for whatever caused the above field to be selected.
+	annotation report.Spanner
+
+	allowMax bool // Whether the max keyword is to be honored.
+	uint29   bool // Whether this is a 29-bit field number.
+}
+
+func (ea evalArgs) Field(c *Context) Field {
+	return wrapField(c, ea.field)
+}
+
+func (ea evalArgs) Type(c *Context) Type {
+	return ea.Field(c).Element()
+}
+
+// mismatch constructs a type mismatch error.
+func (ea evalArgs) mismatch(c *Context, got any) errTypeCheck {
+	var want any
+	if ty := ea.Type(c); !ty.IsZero() {
+		want = ty
+	} else if ea.uint29 {
+		want = taxa.FieldTag
+	} else {
+		want = PredeclaredType(predeclared.Int32)
+	}
+
+	return errTypeCheck{
+		want:       want,
+		got:        got,
+		expr:       ea.expr,
+		annotation: ea.annotation,
+	}
+}
+
+// eval evaluates an expression into a value.
+//
+// Returns a zero value if type-checking fails.
+//
+//nolint:unused // Will be used by options lowering.
+func (e *evaluator) eval(args evalArgs) Value {
+	bits, ok := e.evalBits(args)
+	if !ok {
+		return Value{}
+	}
+	return Value{
+		internal.NewWith(e.Context),
+		e.Context.arenas.values.New(rawValue{
+			expr:  args.expr,
+			field: args.field,
+			bits:  bits,
+		}),
+	}
+}
+
+// evalBits evaluates an expression, returning raw bits for the computed value.
+//
+// [evaluator.eval] is preferred; this is a separate function for the benefit
+// of field number evaluation.
+func (e *evaluator) evalBits(args evalArgs) (rawValueBits, bool) {
+	switch args.expr.Kind() {
+	case ast.ExprKindInvalid, ast.ExprKindError:
+		return 0, false
+
+	case ast.ExprKindLiteral:
+		return e.evalLiteral(args, args.expr.AsLiteral(), false)
+
+	case ast.ExprKindPath:
+		return e.evalPath(args, args.expr.AsPath().Path)
+
+	case ast.ExprKindPrefixed:
+		expr := args.expr.AsPrefixed()
+
+		inner := expr.Expr()
+		switch expr.Prefix() {
+		case keyword.Minus:
+			// Special handling to ensure that negative literals work correctly.
+			if inner.AsLiteral().Kind() == token.Number {
+				return e.evalLiteral(args, args.expr.AsLiteral(), true)
+			}
+
+			// Special cases for certain literals.
+			if inner.AsPath().AsKeyword() == keyword.Inf {
+				v, ok := e.evalPath(args, args.expr.AsPath().Path)
+				v |= 0x8000_0000_0000_0000 // Set the floating-point sign bit.
+				return v, ok
+			}
+
+			// All other expressions cannot have a leading -.
+			err := args.mismatch(e.Context, taxa.Classify(inner))
+			err.want = taxa.Number
+			return 0, true
+		default:
+			panic("unreachable")
+		}
+
+	case ast.ExprKindArray:
+		sorry("array exprs")
+	case ast.ExprKindDict:
+		sorry("message exprs")
+
+	case ast.ExprKindField:
+		break // Legalized in the parser.
+	case ast.ExprKindRange:
+		e.Error(args.mismatch(e.Context, taxa.Range))
+
+	default:
+		panic("unexpected ast.ExprKind")
+	}
+
+	return 0, false
+}
+
+// evalLiteral evaluates a literal expression.
+func (e evaluator) evalLiteral(args evalArgs, expr ast.ExprLiteral, neg bool) (rawValueBits, bool) {
+	scalar := predeclared.Int32
+	if ty := args.Type(e.Context); !ty.IsZero() {
+		scalar = ty.Predeclared()
+	}
+
+	switch expr.Kind() {
+	case token.Number:
+		if n, ok := expr.AsInt(); ok {
+			if !scalar.IsNumber() {
+				e.Error(args.mismatch(e.Context, taxa.Int))
+				return 0, false
+			}
+
+			if args.uint29 {
+				return e.checkIntBounds(args, false, 29, neg, n)
+			}
+			return e.checkIntBounds(args, scalar.IsSigned(), scalar.Bits(), neg, n)
+		}
+
+		if n := expr.AsBigInt(); n != nil {
+			if !scalar.IsNumber() {
+				e.Error(args.mismatch(e.Context, taxa.Int))
+				return 0, false
+			}
+
+			if args.uint29 {
+				return e.checkIntBounds(args, false, 29, neg, n)
+			}
+			return e.checkIntBounds(args, scalar.IsSigned(), scalar.Bits(), neg, n)
+		} else if n, ok := expr.AsFloat(); ok {
+			if !scalar.IsFloat() {
+				e.Error(args.mismatch(e.Context, taxa.Float))
+				return 0, false
+			}
+
+			// 32-bit floats are stored as 64-bit floats; this conversion is
+			// lossless.
+			return rawValueBits(math.Float64bits(n)), true
+		}
+
+	case token.String:
+		sorry("string literals")
+	}
+
+	return 0, false
+}
+
+// checkIntBounds checks that an integer is within the bounds of a possibly
+// signed value with the given number of bits. Failure results in a saturated
+// result.
+//
+// If neg is set, this means that the expression had a - out in front of it.
+//
+// If bits == 29, the field number bounds check is used instead, which disallows
+// 0 and values in the implementation-reserved range.
+func (e *evaluator) checkIntBounds(args evalArgs, signed bool, bits int, neg bool, got any) (rawValueBits, bool) {
+	err := func() *report.Diagnostic {
+		return e.Error(errLiteralRange{
+			errTypeCheck: args.mismatch(e.Context, nil),
+			got:          got,
+			signed:       signed,
+			bits:         bits,
+		})
+	}
+
+	var tooLarge bool
+	var value uint64
+	switch v := got.(type) {
+	case uint64:
+		value = v
+	case *big.Int:
+		// We assume that a big.Int is always larger than a uint64.
+		tooLarge = true
+	}
+
+	if signed {
+		hi := (int64(1) << (bits - 1)) - 1
+		lo := ^hi // Ensure that lo is sign-extended to 64 bits.
+
+		if neg {
+			value = -value
+		}
+		value := int64(value)
+
+		if (neg && tooLarge) || value < lo {
+			err()
+			return rawValueBits(lo), false
+		}
+		if (!neg && tooLarge) || value > hi {
+			err()
+			return rawValueBits(hi), false
+		}
+	} else {
+		if neg {
+			err()
+			return 0, false
+		}
+
+		hi := (uint64(1) << bits) - 1
+		if value > hi {
+			err()
+			return rawValueBits(hi), false
+		}
+	}
+
+	if bits == 29 {
+		if value == 0 {
+			err()
+			return 0, false
+		}
+
+		// Check that this is not one of the special reserved numbers.
+		if !protowire.Number(value).IsValid() {
+			err().Apply(report.Notef(
+				"also, the range `%v to %v` is reserved for internal use",
+				protowire.FirstReservedNumber, protowire.LastReservedNumber,
+			))
+			return 0, false
+		}
+	}
+
+	return rawValueBits(value), true
+}
+
+// evalPath evaluates a path expression.
+func (e evaluator) evalPath(args evalArgs, expr ast.Path) (rawValueBits, bool) {
+	if ty := args.Type(e.Context); ty.IsEnum() {
+		// We can just plumb the text of the expression directly here, since
+		// if it's anything that isn't an identifier, this lookup will fail.
+		value := ty.FieldByName(expr.Span().Text())
+
+		// TODO: This depends on field numbers being resolved before options,
+		// but some options need to be resolved first.
+		if !value.IsZero() {
+			return rawValueBits(value.Number()), true
+		}
+	}
+
+	scalar := predeclared.Int32
+	if ty := args.Type(e.Context); !ty.IsZero() {
+		scalar = ty.Predeclared()
+	}
+
+	// If we see a name that matches one of the predeclared names, resolve
+	// to it, just like it would for type lookup.
+	switch name := expr.AsPredeclared(); name {
+	case predeclared.Max:
+		if !scalar.IsNumber() {
+			e.Error(args.mismatch(e.Context, taxa.PredeclaredMax))
+			return 0, false
+		}
+
+		ok := args.allowMax
+		if !ok {
+			e.Errorf("%s outside of %s", taxa.PredeclaredMax, taxa.Range).Apply(
+				report.Snippet(expr),
+				report.Notef(
+					"the special %s expression is only allowed in a %s",
+					taxa.PredeclaredMax, taxa.Range),
+			)
+		}
+
+		if args.uint29 {
+			return rawValueBits(protowire.MaxValidNumber), ok
+		}
+
+		if scalar.IsFloat() {
+			return rawValueBits(math.Float64bits(math.Inf(0))), ok
+		}
+
+		n := uint64(1) << scalar.Bits()
+		if scalar.IsSigned() {
+			n >>= 1
+		}
+		n--
+		return rawValueBits(n), ok
+
+	case predeclared.True, predeclared.False:
+		if scalar != predeclared.Bool {
+			e.Error(args.mismatch(e.Context, PredeclaredType(predeclared.Bool)))
+		}
+
+		switch name {
+		case predeclared.False:
+			return 0, true
+		case predeclared.True:
+			return 1, true
+		}
+
+	case predeclared.Inf, predeclared.NAN:
+		if !scalar.IsFloat() {
+			e.Error(args.mismatch(e.Context, PredeclaredType(predeclared.Float64)))
+		}
+
+		switch name {
+		case predeclared.Inf:
+			return rawValueBits(math.Float64bits(math.Inf(0))), true
+		case predeclared.NAN:
+			return rawValueBits(math.Float64bits(math.NaN())), true
+		}
+	}
+
+	// Perform symbol lookup in the current scope. This isn't what protoc
+	// does, but it allows us to produce better diagnostics.
+	sym := symbolRef{
+		Context: e.Context,
+		Report:  e.Report,
+
+		scope: e.scope,
+		name:  FullName(expr.Canonicalized()),
+
+		allowScalars: true,
+	}.resolve()
+
+	if !sym.IsZero() {
+		e.Error(args.mismatch(e.Context, sym))
+	}
+	return 0, false
+}
+
+// errTypeCheck is a type-checking failure.
+type errTypeCheck struct {
+	want, got any
+
+	expr       report.Spanner
+	annotation report.Spanner
+}
+
+// Diagnose implements [report.Diagnose].
+func (e errTypeCheck) Diagnose(d *report.Diagnostic) {
+	strings := func(v any) (name, what string) {
+		type symbol interface {
+			FullName() FullName
+			noun() taxa.Noun
+		}
+
+		if sym, ok := v.(symbol); ok {
+			name = "`" + string(sym.FullName()) + "`"
+			return name, sym.noun().String() + " " + name
+		}
+
+		name = fmt.Sprint(v)
+		return name, name
+	}
+
+	wantName, wantWhat := strings(e.want)
+	gotName, gotWhat := strings(e.got)
+
+	d.Apply(
+		report.Message("mismatched types"),
+		report.Snippetf(e.expr, "expected %s, found %s", wantName, gotName),
+		report.Notef("expected %s\n   found %s", wantWhat, gotWhat),
+	)
+	if e.annotation != nil {
+		d.Apply(report.Snippetf(e.annotation, "expected due to this"))
+	}
+}
+
+// errLiteralRange is like [errTypeCheck], but is specifically about integer
+// ranges.
+type errLiteralRange struct {
+	errTypeCheck
+	got    any
+	signed bool
+	bits   int
+}
+
+func (e errLiteralRange) Diagnose(d *report.Diagnostic) {
+	name := e.want
+	if sym, ok := e.want.(interface{ FullName() FullName }); ok {
+		name = "`" + string(sym.FullName()) + "`"
+	}
+
+	var lo, hi uint64
+	var sign string
+	if e.signed {
+		sign = "-"
+		lo = uint64(1) << (e.bits - 1)
+		hi = lo - 1
+	} else {
+		if e.bits == 29 {
+			lo = 1
+		}
+		hi = (uint64(1) << e.bits) - 1
+	}
+
+	d.Apply(
+		report.Message("literal out of range for %s", name),
+		report.Snippetf(e.expr, "expected %s", name),
+		report.Notef("the range for %s is `%v%v to %v`", name, sign, lo, hi),
+	)
+
+	if e.annotation != nil {
+		d.Apply(report.Snippetf(e.annotation, "expected due to this"))
+	}
+}

--- a/experimental/ir/lower_resolve.go
+++ b/experimental/ir/lower_resolve.go
@@ -214,7 +214,7 @@ func (r symbolRef) diagnoseLookup(sym Symbol, expectedName FullName) {
 		return
 	}
 
-	if k := sym.Kind(); !r.accept(k) {
+	if k := sym.Kind(); r.accept != nil && !r.accept(k) {
 		r.Errorf("expected %s, found %s `%s`", r.want, k.noun(), sym.FullName()).Apply(
 			report.Snippetf(r.span, "expected %s", r.want),
 			report.Snippetf(sym.Definition(), "defined here"),

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -152,6 +152,8 @@ func (w *walker) newType(def ast.DeclDef, parent any) Type {
 		fqn:    c.session.intern.Intern(fqn),
 		parent: c.arenas.types.Compress(parentTy.raw),
 	})
+	ptr := c.arenas.types.Deref(raw)
+	ptr.fieldsByName = ptr.fieldsByNameFunc(w.Context())
 
 	if !parentTy.IsZero() {
 		parentTy.raw.nested = append(parentTy.raw.nested, raw)

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -188,11 +188,13 @@ func (w *walker) newField(def ast.DeclDef, parent any) Field {
 	}
 
 	if !parentTy.IsZero() {
-		parentTy.raw.fields = append(parentTy.raw.fields, id)
 
 		if _, ok := parent.(extend); ok {
+			parentTy.raw.fields = append(parentTy.raw.fields, id)
 			c.extns = append(c.extns, id)
-			parentTy.raw.fieldsExtnStart++
+		} else {
+			parentTy.raw.fields = slices.Insert(parentTy.raw.fields, int(parentTy.raw.fieldsEnd), id)
+			parentTy.raw.fieldsEnd++
 		}
 	} else if _, ok := parent.(extend); ok {
 		c.extns = slices.Insert(c.extns, c.topLevelExtnsEnd, id)

--- a/experimental/ir/lower_walk.go
+++ b/experimental/ir/lower_walk.go
@@ -190,7 +190,6 @@ func (w *walker) newField(def ast.DeclDef, parent any) Field {
 	}
 
 	if !parentTy.IsZero() {
-
 		if _, ok := parent.(extend); ok {
 			parentTy.raw.fields = append(parentTy.raw.fields, id)
 			c.extns = append(c.extns, id)

--- a/experimental/ir/testdata/extend/import_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/extend/import_private.proto.yaml.fds.yaml
@@ -5,7 +5,7 @@ file:
     package: "test"
     dependency: ["b.proto"]
     extension:
-      - { name: "a", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-      - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-      - { name: "c", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "a", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "b", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "c", number: 3, label: LABEL_OPTIONAL, type: TYPE_INT32 }
     syntax: "proto3"

--- a/experimental/ir/testdata/extend/invalid_partial.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/invalid_partial.proto.fds.yaml
@@ -8,7 +8,7 @@ file:
           - name: "M"
             extension:
               - name: "x"
-                number: 0
+                number: 1
                 label: LABEL_OPTIONAL
                 type: TYPE_INT32
                 extendee: ".test.M.N"

--- a/experimental/ir/testdata/extend/invalid_partial.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/invalid_partial.proto.fds.yaml
@@ -6,7 +6,7 @@ file:
         nested_type:
           - name: "N"
           - name: "M"
-            field:
+            extension:
               - name: "x"
                 number: 0
                 label: LABEL_OPTIONAL

--- a/experimental/ir/testdata/extend/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/ok.proto.fds.yaml
@@ -3,7 +3,7 @@ file:
     package: "test"
     message_type:
       - name: "Foo"
-        field:
+        extension:
           - name: "x1"
             number: 0
             label: LABEL_OPTIONAL

--- a/experimental/ir/testdata/extend/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/ok.proto.fds.yaml
@@ -5,24 +5,24 @@ file:
       - name: "Foo"
         extension:
           - name: "x1"
-            number: 0
+            number: 1
             label: LABEL_OPTIONAL
             type: TYPE_INT32
             extendee: ".test.Foo.Foo"
           - name: "x2"
-            number: 0
+            number: 2
             label: LABEL_OPTIONAL
             type: TYPE_MESSAGE
             type_name: ".test.Foo.Foo"
             extendee: ".test.Foo.Foo"
           - name: "x3"
-            number: 0
+            number: 3
             label: LABEL_REPEATED
             type: TYPE_MESSAGE
             type_name: ".test.Foo"
             extendee: ".test.Foo"
           - name: "x4"
-            number: 0
+            number: 4
             label: LABEL_REPEATED
             type: TYPE_MESSAGE
             type_name: ".test.Foo"
@@ -30,23 +30,23 @@ file:
         nested_type: [{ name: "Foo" }]
     extension:
       - name: "x5"
-        number: 0
+        number: 5
         label: LABEL_OPTIONAL
         type: TYPE_INT32
         extendee: ".test.Foo"
       - name: "x6"
-        number: 0
+        number: 6
         label: LABEL_OPTIONAL
         type: TYPE_MESSAGE
         type_name: ".test.Foo"
         extendee: ".test.Foo"
       - name: "x7"
-        number: 0
+        number: 7
         label: LABEL_OPTIONAL
         type: TYPE_INT32
         extendee: ".test.Foo.Foo"
       - name: "x8"
-        number: 0
+        number: 8
         label: LABEL_OPTIONAL
         type: TYPE_MESSAGE
         type_name: ".test.Foo"

--- a/experimental/ir/testdata/extend/skip_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/extend/skip_private.proto.yaml.fds.yaml
@@ -13,7 +13,7 @@ file:
     dependency: ["b.proto"]
     extension:
       - name: "m"
-        number: 0
+        number: 1
         label: LABEL_OPTIONAL
         type: TYPE_INT32
         extendee: ".foo.M"

--- a/experimental/ir/testdata/extend/skip_wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/skip_wrong_kind.proto.fds.yaml
@@ -6,14 +6,14 @@ file:
         nested_type:
           - name: "N"
           - name: "P"
-            field: [{ name: "n", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
-            enum_type: [{ name: "X" }]
+            extension: [{ name: "n", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+            enum_type: [{ name: "X", value: [{ name: "N", number: 0 }] }]
           - name: "Q"
-            field:
+            extension:
               - name: "n"
                 number: 0
                 label: LABEL_OPTIONAL
                 type: TYPE_INT32
                 extendee: ".test.M.Q.N"
-            enum_type: [{ name: "N" }]
+            enum_type: [{ name: "N", value: [{ name: "Q", number: 0 }] }]
     syntax: "proto2"

--- a/experimental/ir/testdata/extend/skip_wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/skip_wrong_kind.proto.fds.yaml
@@ -6,14 +6,14 @@ file:
         nested_type:
           - name: "N"
           - name: "P"
-            extension: [{ name: "n", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
-            enum_type: [{ name: "X", value: [{ name: "N", number: 0 }] }]
+            extension: [{ name: "n", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+            enum_type: [{ name: "X", value: [{ name: "N", number: 1 }] }]
           - name: "Q"
             extension:
               - name: "n"
-                number: 0
+                number: 1
                 label: LABEL_OPTIONAL
                 type: TYPE_INT32
                 extendee: ".test.M.Q.N"
-            enum_type: [{ name: "N", value: [{ name: "Q", number: 0 }] }]
+            enum_type: [{ name: "N", value: [{ name: "Q", number: 1 }] }]
     syntax: "proto2"

--- a/experimental/ir/testdata/extend/wrong_kind.proto
+++ b/experimental/ir/testdata/extend/wrong_kind.proto
@@ -26,21 +26,21 @@ message Foo {
         optional int32 y = 2;
     }
     extend Bar {
-        optional int32 z = 2;
+        optional int32 z = 3;
     }
     extend test {
-        optional int32 w = 3;
+        optional int32 w = 4;
     }
 
     oneof self {
-        int32 a = 4;
+        int32 a = 5;
     }
 
     extend self {
-        optional int32 b = 5;
+        optional int32 b = 6;
     }
 
     extend string {
-        optional int32 capacity = 3;
+        optional int32 capacity = 7;
     }
 }

--- a/experimental/ir/testdata/extend/wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/wrong_kind.proto.fds.yaml
@@ -5,25 +5,25 @@ file:
       - name: "Foo"
         field:
           - name: "a"
-            number: 0
+            number: 5
             label: LABEL_OPTIONAL
             type: TYPE_INT32
             oneof_index: 0
         extension:
-          - { name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-          - { name: "y", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "x", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "y", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
           - name: "z"
-            number: 0
+            number: 3
             label: LABEL_OPTIONAL
             type: TYPE_INT32
             extendee: ".test.Foo.Bar"
-          - { name: "w", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-          - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "w", number: 4, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "b", number: 6, label: LABEL_OPTIONAL, type: TYPE_INT32 }
           - name: "capacity"
-            number: 0
+            number: 7
             label: LABEL_OPTIONAL
             type: TYPE_INT32
             extendee: ".string"
-        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 0 }] }]
+        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 1 }] }]
         oneof_decl: [{ name: "self" }]
     syntax: "proto2"

--- a/experimental/ir/testdata/extend/wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/wrong_kind.proto.fds.yaml
@@ -4,6 +4,12 @@ file:
     message_type:
       - name: "Foo"
         field:
+          - name: "a"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+            oneof_index: 0
+        extension:
           - { name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
           - { name: "y", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
           - name: "z"
@@ -12,18 +18,12 @@ file:
             type: TYPE_INT32
             extendee: ".test.Foo.Bar"
           - { name: "w", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-          - name: "a"
-            number: 0
-            label: LABEL_OPTIONAL
-            type: TYPE_INT32
-            oneof_index: 0
           - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-        extension:
           - name: "capacity"
             number: 0
             label: LABEL_OPTIONAL
             type: TYPE_INT32
             extendee: ".string"
-        enum_type: [{ name: "Bar" }]
+        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 0 }] }]
         oneof_decl: [{ name: "self" }]
     syntax: "proto2"

--- a/experimental/ir/testdata/fields/import_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/fields/import_private.proto.yaml.fds.yaml
@@ -7,7 +7,7 @@ file:
     message_type:
       - name: "N"
         field:
-          - { name: "m1", number: 0, label: LABEL_OPTIONAL }
-          - { name: "m2", number: 0, label: LABEL_OPTIONAL }
-          - { name: "m3", number: 0, label: LABEL_OPTIONAL }
+          - { name: "m1", number: 1, label: LABEL_OPTIONAL }
+          - { name: "m2", number: 2, label: LABEL_OPTIONAL }
+          - { name: "m3", number: 3, label: LABEL_OPTIONAL }
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/import_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/fields/import_private.proto.yaml.fds.yaml
@@ -6,8 +6,8 @@ file:
     dependency: ["b.proto"]
     message_type:
       - name: "N"
-        extension:
-          - { name: "m1", number: 0 }
-          - { name: "m2", number: 0 }
-          - { name: "m3", number: 0 }
+        field:
+          - { name: "m1", number: 0, label: LABEL_OPTIONAL }
+          - { name: "m2", number: 0, label: LABEL_OPTIONAL }
+          - { name: "m3", number: 0, label: LABEL_OPTIONAL }
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/import_private.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/fields/import_private.proto.yaml.stderr.txt
@@ -1,0 +1,25 @@
+error: cannot find `M` in this scope
+  --> c.proto:7:3
+   |
+ 7 |   M m1 = 1;
+   |   ^ not found in this scope
+   = help: the full name of this scope is `test.N`
+
+error: expected type, found `package` declaration `test`
+  --> c.proto:8:3
+   |
+ 8 |   test.M m2 = 2;
+   |   ^^^^^^ expected type
+  ::: b.proto:2:1
+   |
+ 2 | package test;
+   | ------------- defined here
+
+error: cannot find `.test.M` in this scope
+  --> c.proto:9:3
+   |
+ 9 |   .test.M m3 = 3;
+   |   ^^^^^^^ not found in this scope
+   = help: the full name of this scope is `test.N`
+
+encountered 3 errors

--- a/experimental/ir/testdata/fields/invalid_partial.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/invalid_partial.proto.fds.yaml
@@ -8,7 +8,7 @@ file:
           - name: "M"
             field:
               - name: "n"
-                number: 0
+                number: 1
                 label: LABEL_OPTIONAL
                 type: TYPE_MESSAGE
                 type_name: ".test.M.N"

--- a/experimental/ir/testdata/fields/invalid_partial.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/invalid_partial.proto.fds.yaml
@@ -3,5 +3,13 @@ file:
     package: "test"
     message_type:
       - name: "M"
-        nested_type: [{ name: "N" }, { name: "M", extension: [{ name: "n", number: 0 }] }]
+        nested_type:
+          - name: "N"
+          - name: "M"
+            field:
+              - name: "n"
+                number: 0
+                label: LABEL_OPTIONAL
+                type: TYPE_MESSAGE
+                type_name: ".test.M.N"
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/invalid_partial.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/invalid_partial.proto.stderr.txt
@@ -1,0 +1,12 @@
+error: cannot find `M.N` in this scope
+  --> testdata/fields/invalid_partial.proto:22:9
+   |
+20 |     message N {}
+   |             - found possibly related symbol `test.M.N`
+21 |     message M {
+22 |         M.N n = 1;
+   |         ^^^ not found in this scope
+   = note: Protobuf's name lookup rules expected a symbol `test.M.M.N`, rather
+           than the one we found
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/ok.proto.fds.yaml
@@ -3,13 +3,41 @@ file:
     package: "test"
     message_type:
       - name: "Foo"
-        extension:
-          - { name: "foo", number: 0 }
-          - { name: "bar", number: 0 }
-          - { name: "bars", number: 0 }
-          - { name: "foos", number: 0 }
-          - { name: "foo0", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
-          - { name: "bar0", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
+        field:
+          - name: "foo"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo"
+            oneof_index: 1
+            proto3_optional: true
+          - name: "bar"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo.Bar"
+          - name: "bars"
+            number: 0
+            label: LABEL_REPEATED
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo.Bar"
+          - name: "foos"
+            number: 0
+            label: LABEL_REPEATED
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo"
+          - name: "foo0"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo"
+            oneof_index: 0
+          - name: "bar0"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".test.Foo.Bar"
+            oneof_index: 0
         nested_type: [{ name: "Bar" }]
-        oneof_decl: [{ name: "baz" }]
+        oneof_decl: [{ name: "baz" }, { name: "_foo" }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/ok.proto.fds.yaml
@@ -5,35 +5,35 @@ file:
       - name: "Foo"
         field:
           - name: "foo"
-            number: 0
+            number: 1
             label: LABEL_OPTIONAL
             type: TYPE_MESSAGE
             type_name: ".test.Foo"
             oneof_index: 1
             proto3_optional: true
           - name: "bar"
-            number: 0
+            number: 2
             label: LABEL_OPTIONAL
             type: TYPE_MESSAGE
             type_name: ".test.Foo.Bar"
           - name: "bars"
-            number: 0
+            number: 3
             label: LABEL_REPEATED
             type: TYPE_MESSAGE
             type_name: ".test.Foo.Bar"
           - name: "foos"
-            number: 0
+            number: 4
             label: LABEL_REPEATED
             type: TYPE_MESSAGE
             type_name: ".test.Foo"
           - name: "foo0"
-            number: 0
+            number: 5
             label: LABEL_OPTIONAL
             type: TYPE_MESSAGE
             type_name: ".test.Foo"
             oneof_index: 0
           - name: "bar0"
-            number: 0
+            number: 6
             label: LABEL_OPTIONAL
             type: TYPE_MESSAGE
             type_name: ".test.Foo.Bar"

--- a/experimental/ir/testdata/fields/skip_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/fields/skip_private.proto.yaml.fds.yaml
@@ -11,5 +11,12 @@ file:
   - name: "c.proto"
     package: "foo.bar.baz"
     dependency: ["b.proto"]
-    message_type: [{ name: "N", extension: [{ name: "m", number: 0 }] }]
+    message_type:
+      - name: "N"
+        field:
+          - name: "m"
+            number: 0
+            label: LABEL_OPTIONAL
+            type: TYPE_MESSAGE
+            type_name: ".foo.M"
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/skip_private.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/fields/skip_private.proto.yaml.fds.yaml
@@ -15,7 +15,7 @@ file:
       - name: "N"
         field:
           - name: "m"
-            number: 0
+            number: 1
             label: LABEL_OPTIONAL
             type: TYPE_MESSAGE
             type_name: ".foo.M"

--- a/experimental/ir/testdata/fields/skip_wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/skip_wrong_kind.proto.fds.yaml
@@ -6,6 +6,11 @@ file:
         nested_type:
           - name: "N"
           - name: "P"
-            extension: [{ name: "n", number: 0 }]
-            enum_type: [{ name: "X" }]
+            field:
+              - name: "n"
+                number: 0
+                label: LABEL_OPTIONAL
+                type: TYPE_MESSAGE
+                type_name: ".test.M.N"
+            enum_type: [{ name: "X", value: [{ name: "N", number: 0 }] }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/skip_wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/skip_wrong_kind.proto.fds.yaml
@@ -8,9 +8,9 @@ file:
           - name: "P"
             field:
               - name: "n"
-                number: 0
+                number: 1
                 label: LABEL_OPTIONAL
                 type: TYPE_MESSAGE
                 type_name: ".test.M.N"
-            enum_type: [{ name: "X", value: [{ name: "N", number: 0 }] }]
+            enum_type: [{ name: "X", value: [{ name: "N", number: 1 }] }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/wrong_kind.proto
+++ b/experimental/ir/testdata/fields/wrong_kind.proto
@@ -24,6 +24,6 @@ message Foo {
     test z = 3;
 
     oneof self {
-        self a = 3;
+        self a = 4;
     }
 }

--- a/experimental/ir/testdata/fields/wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/wrong_kind.proto.fds.yaml
@@ -4,10 +4,10 @@ file:
     message_type:
       - name: "Foo"
         field:
-          - { name: "x", number: 0, label: LABEL_OPTIONAL }
-          - { name: "y", number: 0, label: LABEL_OPTIONAL }
-          - { name: "z", number: 0, label: LABEL_OPTIONAL }
-          - { name: "a", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
-        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 0 }] }]
+          - { name: "x", number: 1, label: LABEL_OPTIONAL }
+          - { name: "y", number: 2, label: LABEL_OPTIONAL }
+          - { name: "z", number: 3, label: LABEL_OPTIONAL }
+          - { name: "a", number: 4, label: LABEL_OPTIONAL, oneof_index: 0 }
+        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 1 }] }]
         oneof_decl: [{ name: "self" }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/wrong_kind.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/wrong_kind.proto.fds.yaml
@@ -3,11 +3,11 @@ file:
     package: "test"
     message_type:
       - name: "Foo"
-        extension:
-          - { name: "x", number: 0 }
-          - { name: "y", number: 0 }
-          - { name: "z", number: 0 }
+        field:
+          - { name: "x", number: 0, label: LABEL_OPTIONAL }
+          - { name: "y", number: 0, label: LABEL_OPTIONAL }
+          - { name: "z", number: 0, label: LABEL_OPTIONAL }
           - { name: "a", number: 0, label: LABEL_OPTIONAL, oneof_index: 0 }
-        enum_type: [{ name: "Bar" }]
+        enum_type: [{ name: "Bar", value: [{ name: "BAZ", number: 0 }] }]
         oneof_decl: [{ name: "self" }]
     syntax: "proto3"

--- a/experimental/ir/testdata/fields/wrong_kind.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/wrong_kind.proto.stderr.txt
@@ -31,7 +31,7 @@ error: expected type, found oneof definition `test.Foo.self`
    |
 26 |     oneof self {
    |           ---- defined here
-27 |         self a = 3;
+27 |         self a = 4;
    |         ^^^^ expected type
 
 encountered 4 errors

--- a/experimental/ir/testdata/fields/wrong_kind.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/wrong_kind.proto.stderr.txt
@@ -1,0 +1,37 @@
+error: expected type, found message field `test.Foo.x`
+  --> testdata/fields/wrong_kind.proto:22:5
+   |
+22 |     x x = 1;
+   |     ^ - defined here
+   |     |
+   |     expected type
+
+error: expected type, found enum value `test.Foo.BAZ`
+  --> testdata/fields/wrong_kind.proto:23:5
+   |
+20 |     enum Bar { BAZ = 1; }
+   |                --- defined here
+21 |
+22 |     x x = 1;
+23 |     BAZ y = 2;
+   |     ^^^ expected type
+
+error: expected type, found `package` declaration `test`
+  --> testdata/fields/wrong_kind.proto:24:5
+   |
+17 | package test;
+   | ------------- defined here
+...
+23 |     BAZ y = 2;
+24 |     test z = 3;
+   |     ^^^^ expected type
+
+error: expected type, found oneof definition `test.Foo.self`
+  --> testdata/fields/wrong_kind.proto:27:9
+   |
+26 |     oneof self {
+   |           ---- defined here
+27 |         self a = 3;
+   |         ^^^^ expected type
+
+encountered 4 errors

--- a/experimental/ir/testdata/smoke.proto
+++ b/experimental/ir/testdata/smoke.proto
@@ -18,8 +18,8 @@ package buf.test;
 
 message Foo {
     optional int32 a = 1;
-    optional int32 b = 1;
-    optional int32 c = 1;
+    optional int32 b = 2;
+    optional int32 c = 3;
 }
 
 enum BAR {

--- a/experimental/ir/testdata/smoke.proto.fds.yaml
+++ b/experimental/ir/testdata/smoke.proto.fds.yaml
@@ -4,13 +4,13 @@ file:
     message_type:
       - name: "Foo"
         field:
-          - { name: "a", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-          - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
-          - { name: "c", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "a", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "b", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "c", number: 3, label: LABEL_OPTIONAL, type: TYPE_INT32 }
     enum_type:
       - name: "BAR"
         value:
           - { name: "BAR_ZERO", number: 0 }
-          - { name: "BAR_A", number: 0 }
-          - { name: "BAR_B", number: 0 }
+          - { name: "BAR_A", number: 1 }
+          - { name: "BAR_B", number: 2 }
     syntax: "proto2"

--- a/experimental/ir/testdata/smoke.proto.fds.yaml
+++ b/experimental/ir/testdata/smoke.proto.fds.yaml
@@ -3,9 +3,14 @@ file:
     package: "buf.test"
     message_type:
       - name: "Foo"
-        extension:
-          - { name: "a", number: 0 }
-          - { name: "b", number: 0 }
-          - { name: "c", number: 0 }
-    enum_type: [{ name: "BAR" }]
+        field:
+          - { name: "a", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "b", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "c", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+    enum_type:
+      - name: "BAR"
+        value:
+          - { name: "BAR_ZERO", number: 0 }
+          - { name: "BAR_A", number: 0 }
+          - { name: "BAR_B", number: 0 }
     syntax: "proto2"

--- a/experimental/ir/testdata/symtab/double_def.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/symtab/double_def.proto.yaml.fds.yaml
@@ -13,9 +13,12 @@ file:
     dependency: ["dep/foo.proto"]
     message_type:
       - name: "Main"
-      - { name: "Main", extension: [{ name: "x", number: 0 }] }
-      - { name: "Foo", enum_type: [{ name: "BAR" }] }
-      - { name: "Main", extension: [{ name: "x", number: 0 }] }
+      - name: "Main"
+        field: [{ name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+      - name: "Foo"
+        enum_type: [{ name: "BAR", value: [{ name: "BAR", number: 0 }] }]
+      - name: "Main"
+        field: [{ name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_STRING }]
     syntax: "proto2"
   - name: "main2.proto"
     package: "dep.foo.Foo"

--- a/experimental/ir/testdata/symtab/double_def.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/symtab/double_def.proto.yaml.fds.yaml
@@ -14,11 +14,11 @@ file:
     message_type:
       - name: "Main"
       - name: "Main"
-        field: [{ name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+        field: [{ name: "x", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
       - name: "Foo"
         enum_type: [{ name: "BAR", value: [{ name: "BAR", number: 0 }] }]
       - name: "Main"
-        field: [{ name: "x", number: 0, label: LABEL_OPTIONAL, type: TYPE_STRING }]
+        field: [{ name: "x", number: 2, label: LABEL_OPTIONAL, type: TYPE_STRING }]
     syntax: "proto2"
   - name: "main2.proto"
     package: "dep.foo.Foo"

--- a/experimental/ir/testdata/tags/fields.proto
+++ b/experimental/ir/testdata/tags/fields.proto
@@ -1,0 +1,51 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package test;
+
+message M {
+    optional int32 x = 1;
+    optional int32 y = 2;
+    optional int32 y2 = 2;
+
+    optional int32 z1 = 0;
+    optional int32 z12 = 0;
+    optional int32 z2 = 0x1fffffff;
+    optional int32 z3 = 0x20000000;
+    optional int32 z4 = 0Xffffffff;
+    optional int32 z5 = 04777777777;
+
+    optional int32 z6 = 0xffffffffffffffffffffffffffffffff;
+
+    optional int32 z6 = -1;
+
+    optional int32 r1 = 19000;
+    optional int32 r2 = 19001;
+    optional int32 r3 = 19999;
+
+    optional int32 k1 = 18999;
+    optional int32 k2 = 20000;
+
+    optional float f1 = 1.0;
+    optional float f2 = -1.0;
+    optional float f3 = inf;
+    optional float f4 = -inf;
+    optional float f5 = nan;
+
+    optional bool b1 = false;
+    optional bool b2 = true;
+    optional bool b3 = max;
+}

--- a/experimental/ir/testdata/tags/fields.proto.fds.yaml
+++ b/experimental/ir/testdata/tags/fields.proto.fds.yaml
@@ -1,0 +1,46 @@
+file:
+  - name: "testdata/tags/fields.proto"
+    package: "test"
+    message_type:
+      - name: "M"
+        field:
+          - { name: "x", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "y", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "y2", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "z1", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "z12", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - name: "z2"
+            number: 536870911
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+          - name: "z3"
+            number: 536870911
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+          - name: "z4"
+            number: 536870911
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+          - name: "z5"
+            number: 536870911
+            label: LABEL_OPTIONAL
+            type: TYPE_INT32
+          - { name: "z6", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "z6", number: 0, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "r1", number: 19000, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "r2", number: 19001, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "r3", number: 19999, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "k1", number: 18999, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "k2", number: 20000, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+          - { name: "f1", number: 0, label: LABEL_OPTIONAL, type: TYPE_FLOAT }
+          - { name: "f2", number: 0, label: LABEL_OPTIONAL, type: TYPE_FLOAT }
+          - { name: "f3", number: 0, label: LABEL_OPTIONAL, type: TYPE_FLOAT }
+          - { name: "f4", number: 0, label: LABEL_OPTIONAL, type: TYPE_FLOAT }
+          - { name: "f5", number: 0, label: LABEL_OPTIONAL, type: TYPE_FLOAT }
+          - { name: "b1", number: 0, label: LABEL_OPTIONAL, type: TYPE_BOOL }
+          - { name: "b2", number: 0, label: LABEL_OPTIONAL, type: TYPE_BOOL }
+          - name: "b3"
+            number: 536870911
+            label: LABEL_OPTIONAL
+            type: TYPE_BOOL
+    syntax: "proto2"

--- a/experimental/ir/testdata/tags/fields.proto.stderr.txt
+++ b/experimental/ir/testdata/tags/fields.proto.stderr.txt
@@ -1,0 +1,161 @@
+error: field numbers must be unique
+  --> testdata/tags/fields.proto:22:25
+   |
+21 |     optional int32 y = 2;
+   |                        - first used here
+22 |     optional int32 y2 = 2;
+   |                         ^ used again here
+
+error: field number out of range
+  --> testdata/tags/fields.proto:24:25
+   |
+24 |     optional int32 z1 = 0;
+   |                         ^
+   = note: the range for field numbers is `1 to 536870911`,
+           minus `19000 to 19999`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:25:26
+   |
+25 |     optional int32 z12 = 0;
+   |                          ^
+   = note: the range for field numbers is `1 to 536870911`,
+           minus `19000 to 19999`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:27:25
+   |
+27 |     optional int32 z3 = 0x20000000;
+   |                         ^^^^^^^^^^
+   = note: the range for field numbers is `0x1 to 0x1fffffff`,
+           minus `0x4a38 to 0x4e1f`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:28:25
+   |
+28 |     optional int32 z4 = 0Xffffffff;
+   |                         ^^^^^^^^^^
+   = note: the range for field numbers is `0X1 to 0X1fffffff`,
+           minus `0X4a38 to 0X4e1f`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:29:25
+   |
+29 |     optional int32 z5 = 04777777777;
+   |                         ^^^^^^^^^^^
+   = note: the range for field numbers is `01 to 03777777777`,
+           minus `045070 to 047037`, which is reserved for internal use
+
+error: `z6` declared multiple times
+  --> testdata/tags/fields.proto:31:20
+   |
+31 |     optional int32 z6 = 0xffffffffffffffffffffffffffffffff;
+   |                    ^^ first here, as a message field
+32 |
+33 |     optional int32 z6 = -1;
+   |                    -- ...also declared here
+
+error: field number out of range
+  --> testdata/tags/fields.proto:31:25
+   |
+31 |     optional int32 z6 = 0xffffffffffffffffffffffffffffffff;
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: the range for field numbers is `0x1 to 0x1fffffff`,
+           minus `0x4a38 to 0x4e1f`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:33:25
+   |
+33 |     optional int32 z6 = -1;
+   |                         ^^
+   = note: the range for field numbers is `1 to 536870911`,
+           minus `19000 to 19999`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:35:25
+   |
+35 |     optional int32 r1 = 19000;
+   |                         ^^^^^
+   = note: the range for field numbers is `1 to 536870911`,
+           minus `19000 to 19999`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:36:25
+   |
+36 |     optional int32 r2 = 19001;
+   |                         ^^^^^
+   = note: the range for field numbers is `1 to 536870911`,
+           minus `19000 to 19999`, which is reserved for internal use
+
+error: field number out of range
+  --> testdata/tags/fields.proto:37:25
+   |
+37 |     optional int32 r3 = 19999;
+   |                         ^^^^^
+   = note: the range for field numbers is `1 to 536870911`,
+           minus `19000 to 19999`, which is reserved for internal use
+
+error: mismatched types
+  --> testdata/tags/fields.proto:42:25
+   |
+42 |     optional float f1 = 1.0;
+   |                         ^^^ expected field number, found floating-point literal
+   = note: expected: field number
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/fields.proto:43:25
+   |
+43 |     optional float f2 = -1.0;
+   |                         ^^^^ expected field number, found floating-point literal
+   = note: expected: field number
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/fields.proto:44:25
+   |
+44 |     optional float f3 = inf;
+   |                         ^^^ expected field number, found floating-point literal
+   = note: expected: field number
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/fields.proto:45:25
+   |
+45 |     optional float f4 = -inf;
+   |                         ^^^^ expected field number, found floating-point literal
+   = note: expected: field number
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/fields.proto:46:25
+   |
+46 |     optional float f5 = nan;
+   |                         ^^^ expected field number, found floating-point literal
+   = note: expected: field number
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/fields.proto:48:24
+   |
+48 |     optional bool b1 = false;
+   |                        ^^^^^ expected field number, found `bool`
+   = note: expected: field number
+              found: scalar type `bool`
+
+error: mismatched types
+  --> testdata/tags/fields.proto:49:24
+   |
+49 |     optional bool b2 = true;
+   |                        ^^^^ expected field number, found `bool`
+   = note: expected: field number
+              found: scalar type `bool`
+
+error: `max` outside of range expression
+  --> testdata/tags/fields.proto:50:24
+   |
+50 |     optional bool b3 = max;
+   |                        ^^^
+   = note: the special `max` expression is only allowed in a range expression
+
+encountered 20 errors

--- a/experimental/ir/testdata/tags/fields.proto.symtab.yaml
+++ b/experimental/ir/testdata/tags/fields.proto.symtab.yaml
@@ -1,0 +1,124 @@
+tables:
+  "testdata/tags/fields.proto":
+    symbols:
+      - { fqn: "test", kind: KIND_PACKAGE, file: "testdata/tags/fields.proto" }
+      - fqn: "test.M"
+        kind: KIND_MESSAGE
+        file: "testdata/tags/fields.proto"
+        index: 1
+        visible: true
+      - fqn: "test.M.x"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 1
+        visible: true
+      - fqn: "test.M.y"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 2
+        visible: true
+      - fqn: "test.M.y2"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 3
+        visible: true
+      - fqn: "test.M.z1"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 4
+        visible: true
+      - fqn: "test.M.z12"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 5
+        visible: true
+      - fqn: "test.M.z2"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 6
+        visible: true
+      - fqn: "test.M.z3"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 7
+        visible: true
+      - fqn: "test.M.z4"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 8
+        visible: true
+      - fqn: "test.M.z5"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 9
+        visible: true
+      - fqn: "test.M.z6"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 10
+        visible: true
+      - fqn: "test.M.r1"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 12
+        visible: true
+      - fqn: "test.M.r2"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 13
+        visible: true
+      - fqn: "test.M.r3"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 14
+        visible: true
+      - fqn: "test.M.k1"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 15
+        visible: true
+      - fqn: "test.M.k2"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 16
+        visible: true
+      - fqn: "test.M.f1"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 17
+        visible: true
+      - fqn: "test.M.f2"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 18
+        visible: true
+      - fqn: "test.M.f3"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 19
+        visible: true
+      - fqn: "test.M.f4"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 20
+        visible: true
+      - fqn: "test.M.f5"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 21
+        visible: true
+      - fqn: "test.M.b1"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 22
+        visible: true
+      - fqn: "test.M.b2"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 23
+        visible: true
+      - fqn: "test.M.b3"
+        kind: KIND_FIELD
+        file: "testdata/tags/fields.proto"
+        index: 24
+        visible: true

--- a/experimental/ir/testdata/tags/values.proto
+++ b/experimental/ir/testdata/tags/values.proto
@@ -1,0 +1,41 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package test;
+
+enum E {
+    UNKNOWN = 0;
+    X = 1;
+    Y = 2;
+    Y2 = 2;
+
+    Z1 = -1;
+    Z2 = 0x7fffffff;
+    Z3 = -0x80000000;
+    Z4 = 0x80000000;
+    Z5 = -0x80000001;
+    Z6 = 0xffffffffffffffffffffffffffffffff;
+
+    F1 = 1.0;
+    F2 = -1.0;
+    F3 = inf;
+    F4 = -inf;
+    F5 = nan;
+
+    B1 = false;
+    B2 = true;
+    B3 = max;
+}

--- a/experimental/ir/testdata/tags/values.proto.fds.yaml
+++ b/experimental/ir/testdata/tags/values.proto.fds.yaml
@@ -1,0 +1,25 @@
+file:
+  - name: "testdata/tags/values.proto"
+    package: "test"
+    enum_type:
+      - name: "E"
+        value:
+          - { name: "UNKNOWN", number: 0 }
+          - { name: "X", number: 1 }
+          - { name: "Y", number: 2 }
+          - { name: "Y2", number: 2 }
+          - { name: "Z1", number: -1 }
+          - { name: "Z2", number: 2147483647 }
+          - { name: "Z3", number: -2147483648 }
+          - { name: "Z4", number: 2147483647 }
+          - { name: "Z5", number: -2147483648 }
+          - { name: "Z6", number: 2147483647 }
+          - { name: "F1", number: 0 }
+          - { name: "F2", number: 0 }
+          - { name: "F3", number: 0 }
+          - { name: "F4", number: 0 }
+          - { name: "F5", number: 0 }
+          - { name: "B1", number: 0 }
+          - { name: "B2", number: 0 }
+          - { name: "B3", number: 2147483647 }
+    syntax: "proto2"

--- a/experimental/ir/testdata/tags/values.proto.stderr.txt
+++ b/experimental/ir/testdata/tags/values.proto.stderr.txt
@@ -1,0 +1,93 @@
+error: enum values must be unique
+  --> testdata/tags/values.proto:23:10
+   |
+22 |     Y = 2;
+   |         - first used here
+23 |     Y2 = 2;
+   |          ^ used again here
+
+error: literal out of range for `int32`
+  --> testdata/tags/values.proto:28:10
+   |
+28 |     Z4 = 0x80000000;
+   |          ^^^^^^^^^^
+   = note: the range for `int32` is `-0x80000000 to 0x7fffffff`
+
+error: literal out of range for `int32`
+  --> testdata/tags/values.proto:29:10
+   |
+29 |     Z5 = -0x80000001;
+   |          ^^^^^^^^^^^
+   = note: the range for `int32` is `-0x80000000 to 0x7fffffff`
+
+error: literal out of range for `int32`
+  --> testdata/tags/values.proto:30:10
+   |
+30 |     Z6 = 0xffffffffffffffffffffffffffffffff;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: the range for `int32` is `-0x80000000 to 0x7fffffff`
+
+error: mismatched types
+  --> testdata/tags/values.proto:32:10
+   |
+32 |     F1 = 1.0;
+   |          ^^^ expected `int32`, found floating-point literal
+   = note: expected: scalar type `int32`
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/values.proto:33:10
+   |
+33 |     F2 = -1.0;
+   |          ^^^^ expected `int32`, found floating-point literal
+   = note: expected: scalar type `int32`
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/values.proto:34:10
+   |
+34 |     F3 = inf;
+   |          ^^^ expected `int32`, found floating-point literal
+   = note: expected: scalar type `int32`
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/values.proto:35:10
+   |
+35 |     F4 = -inf;
+   |          ^^^^ expected `int32`, found floating-point literal
+   = note: expected: scalar type `int32`
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/values.proto:36:10
+   |
+36 |     F5 = nan;
+   |          ^^^ expected `int32`, found floating-point literal
+   = note: expected: scalar type `int32`
+              found: floating-point literal
+
+error: mismatched types
+  --> testdata/tags/values.proto:38:10
+   |
+38 |     B1 = false;
+   |          ^^^^^ expected `int32`, found `bool`
+   = note: expected: scalar type `int32`
+              found: scalar type `bool`
+
+error: mismatched types
+  --> testdata/tags/values.proto:39:10
+   |
+39 |     B2 = true;
+   |          ^^^^ expected `int32`, found `bool`
+   = note: expected: scalar type `int32`
+              found: scalar type `bool`
+
+error: `max` outside of range expression
+  --> testdata/tags/values.proto:40:10
+   |
+40 |     B3 = max;
+   |          ^^^
+   = note: the special `max` expression is only allowed in a range expression
+
+encountered 12 errors

--- a/experimental/ir/testdata/tags/values.proto.symtab.yaml
+++ b/experimental/ir/testdata/tags/values.proto.symtab.yaml
@@ -1,0 +1,99 @@
+tables:
+  "testdata/tags/values.proto":
+    symbols:
+      - { fqn: "test", kind: KIND_PACKAGE, file: "testdata/tags/values.proto" }
+      - fqn: "test.E"
+        kind: KIND_ENUM
+        file: "testdata/tags/values.proto"
+        index: 1
+        visible: true
+      - fqn: "test.UNKNOWN"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 1
+        visible: true
+      - fqn: "test.X"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 2
+        visible: true
+      - fqn: "test.Y"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 3
+        visible: true
+      - fqn: "test.Y2"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 4
+        visible: true
+      - fqn: "test.Z1"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 5
+        visible: true
+      - fqn: "test.Z2"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 6
+        visible: true
+      - fqn: "test.Z3"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 7
+        visible: true
+      - fqn: "test.Z4"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 8
+        visible: true
+      - fqn: "test.Z5"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 9
+        visible: true
+      - fqn: "test.Z6"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 10
+        visible: true
+      - fqn: "test.F1"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 11
+        visible: true
+      - fqn: "test.F2"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 12
+        visible: true
+      - fqn: "test.F3"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 13
+        visible: true
+      - fqn: "test.F4"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 14
+        visible: true
+      - fqn: "test.F5"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 15
+        visible: true
+      - fqn: "test.B1"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 16
+        visible: true
+      - fqn: "test.B2"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 17
+        visible: true
+      - fqn: "test.B3"
+        kind: KIND_ENUM_VALUE
+        file: "testdata/tags/values.proto"
+        index: 18
+        visible: true


### PR DESCRIPTION
This PR adds an expression evaluator that is currently only used to evaluate field number expressions. It will be filled out more completely when the stubs are filled in to implement option evaluation.

There's a lot of things stubbed out in field number evaluation, because reserved/extension ranges are not implemented yet, and there is a somewhat complex dependency with options evaluation. In particular, options can depend on enum values, but enum value validity depends on options (due to `allow_alias`). Depending on how I choose to break this dependency cycle, the layout for an `ir.Value` containing an enum value may instead contain the enum value _index_ instead of a _number_. That is, `option optimize_for = SPEED` would record the index of SPEED, since the number is not yet available.