### PR TITLE
Rename `ir.Field` to `ir.Member`

### DIFF
--- a/experimental/ir/fdp.go
+++ b/experimental/ir/fdp.go
@@ -141,7 +141,7 @@ func (dg *descGenerator) file(file File, fdp *descriptorpb.FileDescriptorProto) 
 func (dg *descGenerator) message(ty Type, mdp *descriptorpb.DescriptorProto) {
 	mdp.Name = addr(ty.Name())
 
-	for field := range seq.Values(ty.Fields()) {
+	for field := range seq.Values(ty.Members()) {
 		fd := new(descriptorpb.FieldDescriptorProto)
 		mdp.Field = append(mdp.Field, fd)
 		dg.field(field, fd)
@@ -204,7 +204,7 @@ func (dg *descGenerator) message(ty Type, mdp *descriptorpb.DescriptorProto) {
 
 		// Only now that we have added all of the normal oneofs do we add the
 		// synthetic oneofs.
-		for i, field := range seq.All(ty.Fields()) {
+		for i, field := range seq.All(ty.Members()) {
 			if field.Presence() != presence.Explicit ||
 				!field.Oneof().IsZero() {
 				continue
@@ -246,7 +246,7 @@ var predeclaredToFDPType = []descriptorpb.FieldDescriptorProto_Type{
 	predeclared.Bytes:  descriptorpb.FieldDescriptorProto_TYPE_BYTES,
 }
 
-func (dg *descGenerator) field(f Field, fdp *descriptorpb.FieldDescriptorProto) {
+func (dg *descGenerator) field(f Member, fdp *descriptorpb.FieldDescriptorProto) {
 	fdp.Name = addr(f.Name())
 	fdp.Number = addr(f.Number())
 
@@ -301,7 +301,7 @@ func (dg *descGenerator) oneof(o Oneof, odp *descriptorpb.OneofDescriptorProto) 
 func (dg *descGenerator) enum(ty Type, edp *descriptorpb.EnumDescriptorProto) {
 	edp.Name = addr(ty.Name())
 
-	for field := range seq.Values(ty.Fields()) {
+	for field := range seq.Values(ty.Members()) {
 		evd := new(descriptorpb.EnumValueDescriptorProto)
 		edp.Value = append(edp.Value, evd)
 		dg.enumValue(field, evd)
@@ -326,7 +326,7 @@ func (dg *descGenerator) enum(ty Type, edp *descriptorpb.EnumDescriptorProto) {
 	}
 }
 
-func (dg *descGenerator) enumValue(f Field, evdp *descriptorpb.EnumValueDescriptorProto) {
+func (dg *descGenerator) enumValue(f Member, evdp *descriptorpb.EnumValueDescriptorProto) {
 	evdp.Name = addr(f.Name())
 	evdp.Number = addr(f.Number())
 

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -49,7 +49,7 @@ type Context struct {
 	types            []arena.Pointer[rawType]
 	topLevelTypesEnd int // Index of the last top-level type in types.
 
-	extns            []arena.Pointer[rawField]
+	extns            []arena.Pointer[rawMember]
 	topLevelExtnsEnd int // Index of the last top-level extension in extns.
 
 	options arena.Pointer[rawValue]
@@ -73,7 +73,7 @@ type Context struct {
 
 	arenas struct {
 		types     arena.Arena[rawType]
-		fields    arena.Arena[rawField]
+		members   arena.Arena[rawMember]
 		extendees arena.Arena[rawExtendee]
 		oneofs    arena.Arena[rawOneof]
 		symbols   arena.Arena[rawSymbol]
@@ -95,7 +95,7 @@ type langSymbols struct {
 	fieldOptions,
 	oneofOptions,
 	enumOptions,
-	enumValueOptions arena.Pointer[rawField]
+	enumValueOptions arena.Pointer[rawMember]
 }
 
 type withContext = internal.With[*Context]
@@ -245,23 +245,23 @@ func (f File) AllTypes() seq.Indexer[Type] {
 
 // Extensions returns the top level extensions defined in this file (i.e.,
 // the contents of any top-level `extends` blocks).
-func (f File) Extensions() seq.Indexer[Field] {
+func (f File) Extensions() seq.Indexer[Member] {
 	return seq.NewFixedSlice(
 		f.Context().extns[:f.Context().topLevelExtnsEnd],
-		func(_ int, p arena.Pointer[rawField]) Field {
+		func(_ int, p arena.Pointer[rawMember]) Member {
 			// Implicitly in current file.
-			return wrapField(f.Context(), ref[rawField]{ptr: p})
+			return wrapMember(f.Context(), ref[rawMember]{ptr: p})
 		},
 	)
 }
 
 // AllExtensions returns all extensions defined in this file.
-func (f File) AllExtensions() seq.Indexer[Field] {
+func (f File) AllExtensions() seq.Indexer[Member] {
 	return seq.NewFixedSlice(
 		f.Context().extns,
-		func(_ int, p arena.Pointer[rawField]) Field {
+		func(_ int, p arena.Pointer[rawMember]) Member {
 			// Implicitly in current file.
-			return wrapField(f.Context(), ref[rawField]{ptr: p})
+			return wrapMember(f.Context(), ref[rawMember]{ptr: p})
 		},
 	)
 }

--- a/experimental/ir/ir_symbol.go
+++ b/experimental/ir/ir_symbol.go
@@ -96,14 +96,14 @@ func (s Symbol) AsType() Type {
 	})
 }
 
-// AsField returns the field this symbol refers to, if it is one.
-func (s Symbol) AsField() Field {
-	if !s.Kind().IsField() {
-		return Field{}
+// AsMember returns the member this symbol refers to, if it is one.
+func (s Symbol) AsMember() Member {
+	if !s.Kind().IsMember() {
+		return Member{}
 	}
-	return wrapField(s.InDefFile().Context(), ref[rawField]{
+	return wrapMember(s.InDefFile().Context(), ref[rawMember]{
 		file: 0, // Symbol context == context of declaring file.
-		ptr:  arena.Pointer[rawField](s.raw.data),
+		ptr:  arena.Pointer[rawMember](s.raw.data),
 	})
 }
 
@@ -132,7 +132,7 @@ func (s Symbol) Definition() report.Span {
 	case SymbolKindMessage, SymbolKindEnum:
 		return s.AsType().AST().Name().Span()
 	case SymbolKindField, SymbolKindEnumValue, SymbolKindExtension:
-		return s.AsField().AST().Name().Span()
+		return s.AsMember().AST().Name().Span()
 	case SymbolKindOneof:
 		return s.AsOneof().AST().Name().Span()
 	}
@@ -166,9 +166,9 @@ func (k SymbolKind) IsType() bool {
 	}
 }
 
-// IsField returns whether this is a field's symbol kind. This includes
+// IsMember returns whether this is a field's symbol kind. This includes
 // enum values, which the ir package treats as fields of enum types.
-func (k SymbolKind) IsField() bool {
+func (k SymbolKind) IsMember() bool {
 	switch k {
 	case SymbolKindField, SymbolKindExtension, SymbolKindEnumValue:
 		return true

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -185,7 +185,7 @@ func symtabProto(files []ir.File, t *Test) *compilerpb.SymbolSet {
 			case ir.SymbolKindMessage, ir.SymbolKindEnum:
 				options = sym.AsType().Options()
 			case ir.SymbolKindField, ir.SymbolKindExtension, ir.SymbolKindEnumValue:
-				options = sym.AsField().Options()
+				options = sym.AsMember().Options()
 			case ir.SymbolKindOneof:
 				options = sym.AsOneof().Options()
 			}

--- a/experimental/ir/lower_resolve.go
+++ b/experimental/ir/lower_resolve.go
@@ -35,7 +35,7 @@ func resolveNames(f File, r *report.Report) {
 
 	for ty := range seq.Values(f.AllTypes()) {
 		if ty.IsMessage() {
-			for field := range seq.Values(ty.Fields()) {
+			for field := range seq.Values(ty.Members()) {
 				resolveFieldType(field, r)
 			}
 		}
@@ -51,7 +51,7 @@ func resolveNames(f File, r *report.Report) {
 }
 
 // resolveFieldType fully resolves the type of a field (extension or otherwise).
-func resolveFieldType(field Field, r *report.Report) {
+func resolveFieldType(field Member, r *report.Report) {
 	ty := field.AST().Type()
 	var path ast.Path
 	kind := presence.Explicit
@@ -153,8 +153,8 @@ func resolveLangSymbols(c *Context) {
 		return
 	}
 
-	field := func(name string) arena.Pointer[rawField] {
-		return mustResolve[rawField](c, "google.protobuf."+name, SymbolKindField)
+	field := func(name string) arena.Pointer[rawMember] {
+		return mustResolve[rawMember](c, "google.protobuf."+name, SymbolKindField)
 	}
 
 	c.langSymbols = &langSymbols{

--- a/experimental/ir/lower_symbols.go
+++ b/experimental/ir/lower_symbols.go
@@ -42,7 +42,7 @@ func buildLocalSymbols(f File) {
 
 	for ty := range seq.Values(f.AllTypes()) {
 		newTypeSymbol(ty)
-		for f := range seq.Values(ty.Fields()) {
+		for f := range seq.Values(ty.Members()) {
 			newFieldSymbol(f)
 		}
 		for f := range seq.Values(ty.Extensions()) {
@@ -73,7 +73,7 @@ func newTypeSymbol(ty Type) {
 	c.exported = append(c.exported, ref[rawSymbol]{ptr: sym})
 }
 
-func newFieldSymbol(f Field) {
+func newFieldSymbol(f Member) {
 	c := f.Context()
 	kind := SymbolKindField
 	if !f.raw.extendee.Nil() {
@@ -84,7 +84,7 @@ func newFieldSymbol(f Field) {
 	sym := c.arenas.symbols.NewCompressed(rawSymbol{
 		kind: kind,
 		fqn:  f.InternedFullName(),
-		data: arena.Untyped(c.arenas.fields.Compress(f.raw)),
+		data: arena.Untyped(c.arenas.members.Compress(f.raw)),
 	})
 	c.exported = append(c.exported, ref[rawSymbol]{ptr: sym})
 }
@@ -309,7 +309,7 @@ func (e errDuplicates) Diagnose(d *report.Diagnostic) {
 	// bug with enum scoping.
 	for i := range e.refs {
 		s := e.symbol(i)
-		v := s.AsField()
+		v := s.AsMember()
 		if !v.Container().IsEnum() {
 			continue
 		}

--- a/experimental/ir/synthetic.go
+++ b/experimental/ir/synthetic.go
@@ -55,8 +55,8 @@ func (sn *syntheticNames) generate(candidate string, message Type) string {
 		//    synthetic group types.
 		// 5. Nested enums' values, due to a language bug.
 		*sn = mapsx.CollectSet(iterx.Chain(
-			seq.Map(message.Fields(), Field.InternedName),
-			seq.Map(message.Extensions(), Field.InternedName),
+			seq.Map(message.Members(), Member.InternedName),
+			seq.Map(message.Extensions(), Member.InternedName),
 			seq.Map(message.Oneofs(), Oneof.InternedName),
 			iterx.FlatMap(seq.Values(message.Nested()), func(ty Type) iter.Seq[intern.ID] {
 				if !ty.IsEnum() {
@@ -66,7 +66,7 @@ func (sn *syntheticNames) generate(candidate string, message Type) string {
 				return iterx.Chain(
 					iterx.Of(ty.InternedName()),
 					// We need to include the enum values' names.
-					seq.Map(ty.Fields(), Field.InternedName),
+					seq.Map(ty.Members(), Member.InternedName),
 				)
 			}),
 		))


### PR DESCRIPTION
`ir.Field` covers both message fields and enum values, because they are so similar. However, the name may confuse some, if they do not interpret enum values as the "fields" of an enum.

This PR simply renames `ir.Field` to `ir.Member` to resolve this confusion.