### PR TITLE
Fix semantic merge conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ generate: $(BIN)/license-header $(BIN)/goyacc wellknownimports test-descriptors 
 
 .PHONY: generate-golden
 generate-golden: generate
-	PATH="$(BIN)$(PATH_SEP)$(PATH)" PROTOCOMPILE_REFRESH=** $(GO) test ./experimental/...
+	PATH="$(BIN)$(PATH_SEP)$(PATH)" PROTOCOMPILE_REFRESH=** $(GO) test  ./... -run 'TestSourceCodeInfoOptions|TestIR|TestLexer|TestParse|TestRender' || true
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,10 @@ generate: $(BIN)/license-header $(BIN)/goyacc wellknownimports test-descriptors 
 			--copyright-holder "Buf Technologies, Inc." \
 			--year-range "$(COPYRIGHT_YEARS)"
 
+.PHONY: generate-golden
+generate-golden: generate
+	PATH="$(BIN)$(PATH_SEP)$(PATH)" PROTOCOMPILE_REFRESH=** $(GO) test ./experimental/...
+
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies
 	go get -u -t ./... && go mod tidy -v

--- a/experimental/ir/testdata/options/builtin.proto.stderr.txt
+++ b/experimental/ir/testdata/options/builtin.proto.stderr.txt
@@ -5,9 +5,9 @@ error: option `deprecated` set multiple times
     |            ---------- first set here...
  24 |     option deprecated = true;
     |            ^^^^^^^^^^ ... also set here
-   ::: google/protobuf/descriptor.proto:601:17
+   ::: google/protobuf/descriptor.proto:611:17
     |
-601 |   optional bool deprecated = 3 [default = false];
+611 |   optional bool deprecated = 3 [default = false];
     |                 ---------- not a repeated field
     = note: a non-`repeated` option may be set at most once
 

--- a/sourceinfo/source_code_info_test.go
+++ b/sourceinfo/source_code_info_test.go
@@ -163,8 +163,7 @@ func fixupProtocSourceCodeInfo(info *descriptorpb.SourceCodeInfo) {
 func TestSourceCodeInfoOptions(t *testing.T) {
 	t.Parallel()
 
-	// set to true to re-generate golden output file
-	const regenerateGoldenOutputFile = false
+	regenerateGoldenOutputFile := os.Getenv("PROTOCOMPILE_REFRESH") != ""
 
 	generateSourceInfoText := func(t *testing.T, filename string, mode protocompile.SourceInfoMode) string {
 		t.Helper()


### PR DESCRIPTION
There was a semantic merge conflict between #525 (protobuf-go and protoc update) and #511 (@mcy's latest change in the experimental/ir package, for evaluating constant expressions). All that was needed was to re-generate some golden files that were updated/added in #511. This pull request does that, but it also adds a make target to make that task simpler in the future (just `make generate-golden`).