### PR TITLE
Implement map type lowering

### DIFF
--- a/experimental/ast/type.go
+++ b/experimental/ast/type.go
@@ -136,6 +136,14 @@ func (t TypeAny) AsGeneric() TypeGeneric {
 	}}
 }
 
+// RemovePrefixes removes all [TypePrefix] values wrapping this type.
+func (t TypeAny) RemovePrefixes() TypeAny {
+	for t.Kind() == TypeKindPrefixed {
+		t = t.AsPrefixed().Type()
+	}
+	return t
+}
+
 // report.Span implements [report.Spanner].
 func (t TypeAny) Span() report.Span {
 	// At most one of the below will produce a non-zero type, and that will be

--- a/experimental/ir/ir_file.go
+++ b/experimental/ir/ir_file.go
@@ -96,6 +96,8 @@ type langSymbols struct {
 	oneofOptions,
 	enumOptions,
 	enumValueOptions arena.Pointer[rawMember]
+
+	mapEntry arena.Pointer[rawMember]
 }
 
 type withContext = internal.With[*Context]

--- a/experimental/ir/ir_name.go
+++ b/experimental/ir/ir_name.go
@@ -17,6 +17,7 @@ package ir
 import (
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/bufbuild/protocompile/internal/ext/stringsx"
 	"github.com/bufbuild/protocompile/internal/ext/unsafex"
@@ -111,4 +112,23 @@ func (n FullName) appendToBytes(b []byte, names ...string) []byte {
 	}
 
 	return b
+}
+
+// toPascal converts a string to PascalCase, according to the wonky algorithm
+// specified at https://protobuf.com/docs/language-spec#default-json-names.
+func toPascal(snake string, leadingUppercase bool) string {
+	var buf strings.Builder
+	uppercase := leadingUppercase
+	for _, r := range snake {
+		if r == '_' {
+			uppercase = true
+			continue
+		}
+		if uppercase {
+			r = unicode.ToUpper(r)
+			uppercase = false
+		}
+		buf.WriteRune(r)
+	}
+	return buf.String()
 }

--- a/experimental/ir/ir_symbol.go
+++ b/experimental/ir/ir_symbol.go
@@ -133,7 +133,12 @@ func (s Symbol) Definition() report.Span {
 	case SymbolKindPackage:
 		return s.File().AST().Package().Span()
 	case SymbolKindMessage, SymbolKindEnum:
-		return s.AsType().AST().Name().Span()
+		ty := s.AsType()
+		if mf := ty.MapField(); !mf.IsZero() {
+			return mf.TypeAST().Span()
+		}
+
+		return ty.AST().Name().Span()
 	case SymbolKindField, SymbolKindEnumValue, SymbolKindExtension:
 		return s.AsMember().AST().Name().Span()
 	case SymbolKindOneof:

--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -42,6 +42,8 @@ type Session struct {
 		OneofOptions     intern.ID `intern:"google.protobuf.OneofDescriptorProto.options"`
 		EnumOptions      intern.ID `intern:"google.protobuf.EnumDescriptorProto.options"`
 		EnumValueOptions intern.ID `intern:"google.protobuf.EnumValueDescriptorProto.options"`
+
+		MapEntry intern.ID `intern:"google.protobuf.MessageOptions.map_entry"`
 	}
 }
 
@@ -87,6 +89,8 @@ func lower(c *Context, r *report.Report, importer Importer) {
 
 	// Now, resolve all the imports.
 	buildImports(c.File(), r, importer)
+
+	generateMapEntries(c.File(), r)
 
 	// Next, we can build various symbol tables in preparation for name
 	// resolution.

--- a/experimental/ir/lower_eval.go
+++ b/experimental/ir/lower_eval.go
@@ -269,7 +269,7 @@ func (e *evaluator) evalBits(args evalArgs) (rawValueBits, bool) {
 }
 
 // evalKey evaluates a key in a message literal.
-func (e *evaluator) evalKey(args evalArgs, expr ast.ExprAny) Member {
+func (e *evaluator) evalKey(args evalArgs, expr ast.ExprField) Member {
 	// There are a number of potentially incorrect ways of specifying
 	// a field here, which we want to diagnose.
 	//
@@ -287,17 +287,34 @@ func (e *evaluator) evalKey(args evalArgs, expr ast.ExprAny) Member {
 	//
 	// Everything else is unrecoverable.
 	ty := args.Type()
+
+	mapFieldHelp := func(d *report.Diagnostic) {
+		if !ty.MapField().IsZero() {
+			d.Apply(
+				// TODO: Generate a suggestion.
+				report.Helpf(
+					"the text format lacks syntax for map-typed fields; instead, the syntax "+
+						"is the same as for a repeated message whose fields are named `key` and `value`",
+				),
+				report.Helpf(
+					"for example, `map_field { key: ..., value: ... }`",
+				),
+			)
+		}
+	}
+
 	cannotResolveKey := func() {
-		e.Errorf("cannot resolve %s name for `%s`", taxa.Field, ty.FullName()).Apply(
+		d := e.Errorf("cannot resolve %s name for `%s`", taxa.Field, ty.FullName()).Apply(
 			report.Snippetf(expr, "field referenced here"),
 			report.Snippetf(args.annotation, "expected `%s` field due to this", ty.Name()),
 		)
+		mapFieldHelp(d)
 	}
 
 	var member Member
 	var path string
 	var hasBrackets, isPath, isNumber, isString bool
-	key := expr
+	key := expr.Key()
 again:
 	switch key.Kind() {
 	case ast.ExprKindPath:
@@ -309,11 +326,12 @@ again:
 			}
 
 			// This appears to be an Any type name.
-			e.Errorf("unexpected %s", taxa.TypeURL).Apply(
-				report.Snippet(expr),
+			d := e.Errorf("unexpected %s", taxa.TypeURL).Apply(
+				report.Snippet(expr.Key()),
 				report.Snippetf(args.annotation, "expected this to be `google.protobuf.Any`"),
 				report.Notef("%s may only appear in a `google.protobuf.Any`-typed %s", taxa.Dict),
 			)
+			mapFieldHelp(d)
 			return Member{}
 		}
 
@@ -375,7 +393,7 @@ again:
 
 			scope: e.scope,
 			name:  FullName(path),
-			span:  expr,
+			span:  expr.Key(),
 		}.resolve()
 
 		if sym.IsZero() {
@@ -388,12 +406,13 @@ again:
 			cannotResolveKey()
 			return Member{}
 		} else if !sym.Kind().IsMessageField() {
-			e.Error(errTypeCheck{
+			d := e.Error(errTypeCheck{
 				want:       fmt.Sprintf("`%s` field", ty.FullName()),
 				got:        sym,
-				expr:       expr,
+				expr:       expr.Key(),
 				annotation: args.annotation,
 			})
+			mapFieldHelp(d)
 			return Member{}
 		}
 		// NOTE: Absolute paths in this position are diagnosed in the parser.
@@ -404,12 +423,13 @@ again:
 validate:
 	// Validate that the member is actually of the correct type.
 	if member.Container() != ty {
-		e.Error(errTypeCheck{
+		d := e.Error(errTypeCheck{
 			want:       fmt.Sprintf("`%s` field", ty.FullName()),
 			got:        fmt.Sprintf("`%s` field", member.Container().FullName()),
-			expr:       expr,
+			expr:       expr.Key(),
 			annotation: args.annotation,
 		})
+		mapFieldHelp(d)
 		return Member{}
 	}
 
@@ -426,9 +446,9 @@ validate:
 		}
 
 		d := e.Errorf("%s `%s` referenced incorrectly", member.noun(), member.FullName()).Apply(
-			report.Snippetf(expr, "referenced here"),
-			report.SuggestEdits(expr, fmt.Sprintf("reference it as `%s`", replace), report.Edit{
-				Start: 0, End: expr.Span().Len(),
+			report.Snippetf(expr.Key(), "referenced here"),
+			report.SuggestEdits(expr.Key(), fmt.Sprintf("reference it as `%s`", replace), report.Edit{
+				Start: 0, End: expr.Key().Span().Len(),
 				Replace: replace,
 			}),
 		)
@@ -453,6 +473,7 @@ validate:
 				d.Apply(report.Notef("due to a parser quirk, `.protoc` rejects quoted strings here, even though textproto does not"))
 			}
 		}
+		mapFieldHelp(d)
 	}
 
 	return member
@@ -612,7 +633,7 @@ func (e *evaluator) evalMessage(args evalArgs, expr ast.ExprDict) Value {
 	}
 
 	for expr := range seq.Values(expr.Elements()) {
-		field := e.evalKey(args, expr.Key())
+		field := e.evalKey(args, expr)
 		if field.IsZero() {
 			continue
 		}
@@ -621,7 +642,7 @@ func (e *evaluator) evalMessage(args evalArgs, expr ast.ExprDict) Value {
 		copied.textFormat = true
 		copied.isConcreteAny = false
 		copied.expr = expr.Value()
-		copied.annotation = field.AST().Type()
+		copied.annotation = field.TypeAST()
 		copied.field = field
 		copied.rawField = ref[rawMember]{}
 

--- a/experimental/ir/lower_maps.go
+++ b/experimental/ir/lower_maps.go
@@ -1,0 +1,117 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/internal"
+	"github.com/bufbuild/protocompile/experimental/ir/presence"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/seq"
+)
+
+// generateMapEntries generates map entry types for all map-typed fields.
+func generateMapEntries(f File, r *report.Report) {
+	c := f.Context()
+	for parent := range seq.Values(f.AllTypes()) {
+		if !parent.IsMessage() {
+			continue
+		}
+
+		for field := range seq.Values(parent.Members()) {
+			// optional, repeated etc. on map types is already legalized in
+			// the parser.
+			decl := field.AST().Type().RemovePrefixes().AsGeneric()
+			if decl.IsZero() {
+				continue
+			}
+
+			key, value := decl.AsMap()
+			if key.IsZero() {
+				continue // Legalized in the parser.
+			}
+
+			name := toPascal(field.Name(), true) + "Entry"
+			fqn := parent.FullName().Append(name)
+
+			// Set option map_entry = true;
+			dpIdx := int32(len(f.Context().imports.files))
+			dp := f.Context().imports.DescriptorProto().Context()
+			messageOptions := ref[rawMember]{dpIdx, dp.langSymbols.messageOptions}
+			mapEntry := ref[rawMember]{dpIdx, dp.langSymbols.mapEntry}
+			options := newMessage(c, messageOptions)
+			*options.insert(wrapMember(c, mapEntry)) = c.arenas.values.NewCompressed(rawValue{
+				field: mapEntry,
+				bits:  1,
+			})
+
+			// Construct the type itself.
+			raw := c.arenas.types.NewCompressed(rawType{
+				def:    field.AST(),
+				name:   c.session.intern.Intern(name),
+				fqn:    c.session.intern.Intern(string(fqn)),
+				parent: c.arenas.types.Compress(parent.raw),
+				options: c.arenas.values.NewCompressed(rawValue{
+					field: messageOptions,
+					bits:  rawValueBits(c.arenas.messages.Compress(options.raw)),
+				}),
+
+				mapEntryOf: c.arenas.members.Compress(field.raw),
+			})
+			ty := Type{internal.NewWith(c), c.arenas.types.Deref(raw)}
+			ty.raw.memberByName = sync.OnceValue(ty.makeMembersByName)
+			parent.raw.nested = append(parent.raw.nested, raw)
+			c.types = append(c.types, raw)
+
+			// Construct the fields and att them to ty.
+			makeField := func(name string, number int32, elem ast.TypeAny) {
+				fqn := fqn.Append(name)
+
+				id := c.arenas.members.NewCompressed(rawMember{
+					name:   c.session.intern.Intern(name),
+					fqn:    c.session.intern.Intern(string(fqn)),
+					parent: c.arenas.types.Compress(ty.raw),
+					number: number,
+					oneof:  -int32(presence.Explicit),
+				})
+
+				ty.raw.members = slices.Insert(ty.raw.members, int(ty.raw.extnsStart), id)
+				ty.raw.extnsStart++
+			}
+
+			makeField("key", 1, key)
+			makeField("value", 2, value)
+
+			// Update the field to be a repeated field of the given type.
+			field.raw.elem.ptr = raw
+			field.raw.oneof = -int32(presence.Repeated)
+		}
+	}
+
+	for extn := range seq.Values(f.AllExtensions()) {
+		k, _ := extn.AST().Type().RemovePrefixes().AsGeneric().AsMap()
+		if !k.IsZero() {
+			r.Errorf("unsupported map-typed extension").Apply(
+				report.Snippetf(extn.AST().Type(), "declared here"),
+				report.Helpf("extensions cannot be map-typed; instead, "+
+					"define a message type with a map-typed field"),
+			)
+			continue
+		}
+	}
+}

--- a/experimental/ir/lower_numbers.go
+++ b/experimental/ir/lower_numbers.go
@@ -28,6 +28,11 @@ import (
 // declarations.
 func evaluateFieldNumbers(f File, r *report.Report) {
 	for ty := range seq.Values(f.AllTypes()) {
+		if !ty.MapField().IsZero() {
+			// Map entry types come with numbers pre-calculated.
+			continue
+		}
+
 		scope := ty.FullName()
 
 		var kind memberNumber

--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -63,6 +63,11 @@ func resolveOptions(f File, r *report.Report) {
 	}
 
 	for ty := range seq.Values(f.AllTypes()) {
+		if !ty.MapField().IsZero() {
+			// Map entries already come with options pre-calculated.
+			continue
+		}
+
 		for def := range bodyOptions(ty.AST().Body()) {
 			options := messageOptions
 			if ty.IsEnum() {
@@ -250,6 +255,14 @@ func (r optionRef) resolve() {
 				}
 				return
 			}
+		}
+
+		if pc.IsFirst() && field.InternedFullName() == r.session.langIDs.MapEntry {
+			r.Errorf("`map_entry` cannot be set explicitly").Apply(
+				report.Snippet(pc),
+				report.Helpf("map_entry is set automatically for synthetic map "+
+					"entry types, and cannot be set with an %s", taxa.Option),
+			)
 		}
 
 		path, _ = pc.SplitAfter()

--- a/experimental/ir/lower_resolve.go
+++ b/experimental/ir/lower_resolve.go
@@ -53,7 +53,7 @@ func resolveNames(f File, r *report.Report) {
 
 // resolveFieldType fully resolves the type of a field (extension or otherwise).
 func resolveFieldType(field Member, r *report.Report) {
-	ty := field.AST().Type()
+	ty := field.TypeAST()
 	var path ast.Path
 	kind := presence.Explicit
 	switch ty.Kind() {
@@ -67,21 +67,6 @@ func resolveFieldType(field Member, r *report.Report) {
 		path = ty.AsPath().Path
 
 	case ast.TypeKindPrefixed:
-		// Unwrap as many prefixed fields as necessary to get to the bottom
-		// of this.
-		inner := ty
-		for {
-			if p := inner.AsPath(); !p.IsZero() {
-				path = p.Path
-				break
-			}
-			if p := inner.AsPrefixed(); !p.IsZero() {
-				inner = p.Type()
-				continue
-			}
-			sorry("map fields")
-		}
-
 		switch ty.AsPrefixed().Prefix() {
 		case keyword.Optional:
 			kind = presence.Explicit
@@ -91,8 +76,19 @@ func resolveFieldType(field Member, r *report.Report) {
 			kind = presence.Repeated
 		}
 
+		// Unwrap as many prefixed fields as necessary to get to the bottom
+		// of this.
+		ty = ty.RemovePrefixes()
+		if p := ty.AsPath().Path; !p.IsZero() {
+			path = p
+			break
+		}
+
+		fallthrough
+
 	case ast.TypeKindGeneric:
-		sorry("map fields")
+		// Resolved elsewhere.
+		return
 	}
 
 	if path.IsZero() {
@@ -123,6 +119,36 @@ func resolveFieldType(field Member, r *report.Report) {
 	if sym.Kind().IsType() {
 		field.raw.elem.file = sym.ref.file
 		field.raw.elem.ptr = arena.Pointer[rawType](sym.raw.data)
+
+		if mf := sym.AsType().MapField(); !mf.IsZero() {
+			r.Errorf("use of synthetic map entry type").Apply(
+				report.Snippetf(path, "referenced here"),
+				report.Snippetf(mf.TypeAST(), "synthesized by this type"),
+				report.Helpf("despite having a user-visible symbol, map entry "+
+					"types cannot be used as field types"),
+			)
+		}
+
+		if !field.Container().MapField().IsZero() && field.Number() == 1 {
+			// Legalize that the key type must be comparable.
+			ty := sym.AsType()
+			if !ty.Predeclared().IsMapKey() {
+				d := r.Error(errTypeCheck{
+					want: "comparable type",
+					got:  ty,
+					expr: field.TypeAST(),
+				}).Apply(report.Helpf(
+					"comparable types are integer types, " +
+						"`string`, and `bool`",
+				))
+
+				if ty.IsEnum() {
+					d.Apply(report.Helpf(
+						"counterintuitively, user-defined enum types " +
+							"are not comparable and cannot be used as map keys"))
+				}
+			}
+		}
 	}
 }
 
@@ -164,6 +190,8 @@ func resolveLangSymbols(c *Context) {
 
 		enumOptions:      mustResolve[rawMember](c, names.EnumOptions, SymbolKindField),
 		enumValueOptions: mustResolve[rawMember](c, names.EnumValueOptions, SymbolKindField),
+
+		mapEntry: mustResolve[rawMember](c, names.MapEntry, SymbolKindField),
 	}
 }
 

--- a/experimental/ir/lower_symbols.go
+++ b/experimental/ir/lower_symbols.go
@@ -331,4 +331,19 @@ func (e errDuplicates) Diagnose(d *report.Diagnostic) {
 			v.Name(),
 		))
 	}
+
+	for i := range e.refs {
+		ty := e.symbol(i).AsType()
+		if mf := ty.MapField(); !mf.IsZero() {
+			d.Apply(
+				report.Snippetf(mf.AST().Name(), "implies `repeated %s`", ty.Name()),
+				report.Helpf(
+					"map-typed fields implicitly declare a nested message type: "+
+						"field `%s` produces a map entry type `%s`",
+					mf.Name(), ty.Name(),
+				),
+			)
+			break
+		}
+	}
 }

--- a/experimental/ir/testdata/fields/maps/collision.proto
+++ b/experimental/ir/testdata/fields/maps/collision.proto
@@ -1,0 +1,23 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message Foo {
+    map<int32, int32> foo_bar = 1;
+
+    message FooBarEntry {}
+}

--- a/experimental/ir/testdata/fields/maps/collision.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/collision.proto.fds.yaml
@@ -1,0 +1,19 @@
+file:
+- name: "testdata/fields/maps/collision.proto"
+  package: "test"
+  message_type:
+  - name: "Foo"
+    field:
+    - name: "foo_bar"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.FooBarEntry"
+    nested_type:
+    - name: "FooBarEntry"
+    - name: "FooBarEntry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+  syntax: "proto3"

--- a/experimental/ir/testdata/fields/maps/collision.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/collision.proto.stderr.txt
@@ -1,0 +1,14 @@
+error: `FooBarEntry` declared multiple times
+  --> testdata/fields/maps/collision.proto:20:5
+   |
+20 |     map<int32, int32> foo_bar = 1;
+   |     ^^^^^^^^^^^^^^^^^ ------- implies `repeated FooBarEntry`
+   |     |
+   |     first here, as a message type
+21 |
+22 |     message FooBarEntry {}
+   |             ----------- ...also declared here
+   = help: map-typed fields implicitly declare a nested message type: field
+           `foo_bar` produces a map entry type `FooBarEntry`
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/maps/collision.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/collision.proto.symtab.yaml
@@ -1,0 +1,32 @@
+tables:
+  "testdata/fields/maps/collision.proto":
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/fields/maps/collision.proto"
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/collision.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.FooBarEntry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/collision.proto"
+      index: 3
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.foo_bar"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/collision.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.FooBarEntry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/collision.proto"
+      index: 2
+      visible:
+    - fqn: "test.Foo.FooBarEntry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/collision.proto"
+      index: 3
+      visible:

--- a/experimental/ir/testdata/fields/maps/entry_misuse.proto
+++ b/experimental/ir/testdata/fields/maps/entry_misuse.proto
@@ -1,0 +1,22 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message Foo {
+    map<int32, int32> foo_bar = 1;
+    repeated FooBarEntry foo_bars = 2;
+}

--- a/experimental/ir/testdata/fields/maps/entry_misuse.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/entry_misuse.proto.fds.yaml
@@ -1,0 +1,23 @@
+file:
+- name: "testdata/fields/maps/entry_misuse.proto"
+  package: "test"
+  message_type:
+  - name: "Foo"
+    field:
+    - name: "foo_bar"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.FooBarEntry"
+    - name: "foo_bars"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.FooBarEntry"
+    nested_type:
+    - name: "FooBarEntry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+  syntax: "proto3"

--- a/experimental/ir/testdata/fields/maps/entry_misuse.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/entry_misuse.proto.stderr.txt
@@ -1,0 +1,11 @@
+error: use of synthetic map entry type
+  --> testdata/fields/maps/entry_misuse.proto:21:14
+   |
+20 |     map<int32, int32> foo_bar = 1;
+   |     ----------------- synthesized by this type
+21 |     repeated FooBarEntry foo_bars = 2;
+   |              ^^^^^^^^^^^ referenced here
+   = help: despite having a user-visible symbol, map entry types cannot be used
+           as field types
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/maps/entry_misuse.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/entry_misuse.proto.symtab.yaml
@@ -1,0 +1,37 @@
+tables:
+  "testdata/fields/maps/entry_misuse.proto":
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/fields/maps/entry_misuse.proto"
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/entry_misuse.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.FooBarEntry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/entry_misuse.proto"
+      index: 2
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.foo_bar"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/entry_misuse.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.foo_bars"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/entry_misuse.proto"
+      index: 2
+      visible:
+    - fqn: "test.Foo.FooBarEntry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/entry_misuse.proto"
+      index: 3
+      visible:
+    - fqn: "test.Foo.FooBarEntry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/entry_misuse.proto"
+      index: 4
+      visible:

--- a/experimental/ir/testdata/fields/maps/extension.proto
+++ b/experimental/ir/testdata/fields/maps/extension.proto
@@ -1,0 +1,25 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package test;
+
+message Foo {
+    extensions 1;
+}
+
+extend Foo {
+    map<int32, int32> m = 1;
+}

--- a/experimental/ir/testdata/fields/maps/extension.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/extension.proto.fds.yaml
@@ -1,0 +1,6 @@
+file:
+- name: "testdata/fields/maps/extension.proto"
+  package: "test"
+  message_type: [{ name: "Foo", extension_range: [{ start: 1, end: 1 }] }]
+  extension: [{ name: "m", number: 1 }]
+  syntax: "proto2"

--- a/experimental/ir/testdata/fields/maps/extension.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/extension.proto.stderr.txt
@@ -1,0 +1,9 @@
+error: unsupported map-typed extension
+  --> testdata/fields/maps/extension.proto:24:5
+   |
+24 |     map<int32, int32> m = 1;
+   |     ^^^^^^^^^^^^^^^^^ declared here
+   = help: extensions cannot be map-typed; instead, define a message type with a
+           map-typed field
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/maps/extension.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/extension.proto.symtab.yaml
@@ -1,0 +1,16 @@
+tables:
+  "testdata/fields/maps/extension.proto":
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/fields/maps/extension.proto"
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/extension.proto"
+      index: 1
+      visible:
+    - fqn: "test.m"
+      kind: KIND_EXTENSION
+      file: "testdata/fields/maps/extension.proto"
+      index: 1
+      visible:

--- a/experimental/ir/testdata/fields/maps/invalid_key.proto
+++ b/experimental/ir/testdata/fields/maps/invalid_key.proto
@@ -1,0 +1,29 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message Foo {
+    map<float, int32> m1 = 1;
+    map<double, int32> m2 = 2;
+    map<bytes, int32> m3 = 3;
+    map<Foo, int32> m4 = 4;
+    map<Enum, int32> m5 = 5;
+}
+
+enum Enum {
+    Z = 0;
+}

--- a/experimental/ir/testdata/fields/maps/invalid_key.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/invalid_key.proto.fds.yaml
@@ -1,0 +1,67 @@
+file:
+- name: "testdata/fields/maps/invalid_key.proto"
+  package: "test"
+  message_type:
+  - name: "Foo"
+    field:
+    - name: "m1"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.M1Entry"
+    - name: "m2"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.M2Entry"
+    - name: "m3"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.M3Entry"
+    - name: "m4"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.M4Entry"
+    - name: "m5"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.M5Entry"
+    nested_type:
+    - name: "M1Entry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_FLOAT }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+    - name: "M2Entry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_DOUBLE }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+    - name: "M3Entry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_BYTES }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+    - name: "M4Entry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".test.Foo"
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+    - name: "M5Entry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_ENUM
+        type_name: ".test.Enum"
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+  enum_type: [{ name: "Enum", value: [{ name: "Z", number: 0 }] }]
+  syntax: "proto3"

--- a/experimental/ir/testdata/fields/maps/invalid_key.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/invalid_key.proto.stderr.txt
@@ -1,0 +1,48 @@
+error: mismatched types
+  --> testdata/fields/maps/invalid_key.proto:20:9
+   |
+20 |     map<float, int32> m1 = 1;
+   |         ^^^^^ expected comparable type, found `float`
+   = note: expected: comparable type
+              found: scalar type `float`
+   = help: comparable types are integer types, `string`, and `bool`
+
+error: mismatched types
+  --> testdata/fields/maps/invalid_key.proto:21:9
+   |
+21 |     map<double, int32> m2 = 2;
+   |         ^^^^^^ expected comparable type, found `double`
+   = note: expected: comparable type
+              found: scalar type `double`
+   = help: comparable types are integer types, `string`, and `bool`
+
+error: mismatched types
+  --> testdata/fields/maps/invalid_key.proto:22:9
+   |
+22 |     map<bytes, int32> m3 = 3;
+   |         ^^^^^ expected comparable type, found `bytes`
+   = note: expected: comparable type
+              found: scalar type `bytes`
+   = help: comparable types are integer types, `string`, and `bool`
+
+error: mismatched types
+  --> testdata/fields/maps/invalid_key.proto:23:9
+   |
+23 |     map<Foo, int32> m4 = 4;
+   |         ^^^ expected comparable type, found `test.Foo`
+   = note: expected: comparable type
+              found: message type `test.Foo`
+   = help: comparable types are integer types, `string`, and `bool`
+
+error: mismatched types
+  --> testdata/fields/maps/invalid_key.proto:24:9
+   |
+24 |     map<Enum, int32> m5 = 5;
+   |         ^^^^ expected comparable type, found `test.Enum`
+   = note: expected: comparable type
+              found: enum type `test.Enum`
+   = help: comparable types are integer types, `string`, and `bool`
+   = help: counterintuitively, user-defined enum types are not comparable and
+           cannot be used as map keys
+
+encountered 5 errors

--- a/experimental/ir/testdata/fields/maps/invalid_key.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/invalid_key.proto.symtab.yaml
@@ -1,0 +1,126 @@
+tables:
+  "testdata/fields/maps/invalid_key.proto":
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.M1Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 3
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.M2Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 4
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.M3Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 5
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.M4Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 6
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.M5Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 7
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Enum"
+      kind: KIND_ENUM
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 2
+      visible:
+    - fqn: "test.Foo.m1"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.m2"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 2
+      visible:
+    - fqn: "test.Foo.m3"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 3
+      visible:
+    - fqn: "test.Foo.m4"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 4
+      visible:
+    - fqn: "test.Foo.m5"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 5
+      visible:
+    - fqn: "test.Foo.M1Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 7
+      visible:
+    - fqn: "test.Foo.M1Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 8
+      visible:
+    - fqn: "test.Foo.M2Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 9
+      visible:
+    - fqn: "test.Foo.M2Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 10
+      visible:
+    - fqn: "test.Foo.M3Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 11
+      visible:
+    - fqn: "test.Foo.M3Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 12
+      visible:
+    - fqn: "test.Foo.M4Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 13
+      visible:
+    - fqn: "test.Foo.M4Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 14
+      visible:
+    - fqn: "test.Foo.M5Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 15
+      visible:
+    - fqn: "test.Foo.M5Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 16
+      visible:
+    - fqn: "test.Z"
+      kind: KIND_ENUM_VALUE
+      file: "testdata/fields/maps/invalid_key.proto"
+      index: 6
+      visible:

--- a/experimental/ir/testdata/fields/maps/map_entry.proto
+++ b/experimental/ir/testdata/fields/maps/map_entry.proto
@@ -1,0 +1,30 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+    optional google.protobuf.MessageOptions options = 10000;
+}
+
+message Foo {
+    option map_entry = true;
+
+    // This is silly but valid and must be accepted.
+    option (options).map_entry = true;
+}

--- a/experimental/ir/testdata/fields/maps/map_entry.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/map_entry.proto.fds.yaml
@@ -1,0 +1,13 @@
+file:
+- name: "testdata/fields/maps/map_entry.proto"
+  package: "test"
+  dependency: ["google/protobuf/descriptor.proto"]
+  message_type: [{ name: "Foo", options: {} }]
+  extension:
+  - name: "options"
+    number: 10000
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".google.protobuf.MessageOptions"
+    extendee: ".google.protobuf.MessageOptions"
+  syntax: "proto3"

--- a/experimental/ir/testdata/fields/maps/map_entry.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/map_entry.proto.stderr.txt
@@ -1,0 +1,9 @@
+error: `map_entry` cannot be set explicitly
+  --> testdata/fields/maps/map_entry.proto:26:12
+   |
+26 |     option map_entry = true;
+   |            ^^^^^^^^^
+   = help: map_entry is set automatically for synthetic map entry types, and
+           cannot be set with an option setting
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/maps/map_entry.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/map_entry.proto.symtab.yaml
@@ -1,0 +1,20 @@
+tables:
+  "testdata/fields/maps/map_entry.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: }]
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/fields/maps/map_entry.proto"
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/map_entry.proto"
+      index: 1
+      visible:
+      options.message:
+        fields: { "map_entry": { bool: } }
+        extns: { "test.options": { message.fields: { "map_entry": { bool: } } } }
+    - fqn: "test.options"
+      kind: KIND_EXTENSION
+      file: "testdata/fields/maps/map_entry.proto"
+      index: 1
+      visible:

--- a/experimental/ir/testdata/fields/maps/map_option.proto
+++ b/experimental/ir/testdata/fields/maps/map_option.proto
@@ -1,0 +1,40 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+    optional Foo foo = 10000;
+}
+
+message Foo {
+    option (foo).map = {
+        key: "a"
+        value {
+            map [
+                {key: "a"},
+                {key: "b"}
+            ]
+            map {
+                "my_key": {},
+            }
+        }
+    };
+
+    map<string, Foo> map = 1;
+}

--- a/experimental/ir/testdata/fields/maps/map_option.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/map_option.proto.fds.yaml
@@ -1,0 +1,31 @@
+file:
+- name: "testdata/fields/maps/map_option.proto"
+  package: "test"
+  dependency: ["google/protobuf/descriptor.proto"]
+  message_type:
+  - name: "Foo"
+    field:
+    - name: "map"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.MapEntry"
+    nested_type:
+    - name: "MapEntry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_STRING }
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".test.Foo"
+      options: {}
+    options: {}
+  extension:
+  - name: "foo"
+    number: 10000
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".test.Foo"
+    extendee: ".google.protobuf.MessageOptions"
+  syntax: "proto3"

--- a/experimental/ir/testdata/fields/maps/map_option.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/map_option.proto.stderr.txt
@@ -1,0 +1,14 @@
+error: cannot resolve message field name for `test.Foo.MapEntry`
+  --> testdata/fields/maps/map_option.proto:34:17
+   |
+34 |                 "my_key": {},
+   |                 ^^^^^^^^^^^^ field referenced here
+...
+39 |     map<string, Foo> map = 1;
+   |     ---------------- expected `MapEntry` field due to this
+   = help: the text format lacks syntax for map-typed fields; instead, the
+           syntax is the same as for a repeated message whose fields are named
+           `key` and `value`
+   = help: for example, `map_field { key: ..., value: ... }`
+
+encountered 1 error

--- a/experimental/ir/testdata/fields/maps/map_option.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/map_option.proto.symtab.yaml
@@ -1,0 +1,52 @@
+tables:
+  "testdata/fields/maps/map_option.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: }]
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/fields/maps/map_option.proto"
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/map_option.proto"
+      index: 1
+      visible:
+      options.message.extns:
+        "test.foo":
+          message.fields:
+            "map":
+              repeated.values:
+              - message.fields:
+                  "key": { string: "a" }
+                  "value":
+                    message.fields:
+                      "map":
+                        repeated.values:
+                        - message.fields: { "key": { string: "a" } }
+                        - message.fields: { "key": { string: "b" } }
+                        - message: {}
+    - fqn: "test.Foo.MapEntry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/map_option.proto"
+      index: 2
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.map"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/map_option.proto"
+      index: 2
+      visible:
+    - fqn: "test.Foo.MapEntry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/map_option.proto"
+      index: 3
+      visible:
+    - fqn: "test.Foo.MapEntry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/map_option.proto"
+      index: 4
+      visible:
+    - fqn: "test.foo"
+      kind: KIND_EXTENSION
+      file: "testdata/fields/maps/map_option.proto"
+      index: 1
+      visible:

--- a/experimental/ir/testdata/fields/maps/ok.proto
+++ b/experimental/ir/testdata/fields/maps/ok.proto
@@ -1,0 +1,25 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message Foo {
+    map<int32, int32> foo = 1;
+    map<string, Foo> bar = 2;
+
+    map<int32, int32> __foo2__ = 3;
+    map<int32, int32> __foo_3__ = 4;
+}

--- a/experimental/ir/testdata/fields/maps/ok.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/ok.proto.fds.yaml
@@ -1,0 +1,52 @@
+file:
+- name: "testdata/fields/maps/ok.proto"
+  package: "test"
+  message_type:
+  - name: "Foo"
+    field:
+    - name: "foo"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.FooEntry"
+    - name: "bar"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.BarEntry"
+    - name: "__foo2__"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.Foo2Entry"
+    - name: "__foo_3__"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Foo.Foo3Entry"
+    nested_type:
+    - name: "FooEntry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+    - name: "BarEntry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_STRING }
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".test.Foo"
+      options: {}
+    - name: "Foo2Entry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+    - name: "Foo3Entry"
+      field:
+      - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+      options: {}
+  syntax: "proto3"

--- a/experimental/ir/testdata/fields/maps/ok.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/ok.proto.symtab.yaml
@@ -1,0 +1,93 @@
+tables:
+  "testdata/fields/maps/ok.proto":
+    symbols:
+    - { fqn: "test", kind: KIND_PACKAGE, file: "testdata/fields/maps/ok.proto" }
+    - fqn: "test.Foo"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/ok.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.FooEntry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/ok.proto"
+      index: 2
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.BarEntry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/ok.proto"
+      index: 3
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.Foo2Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/ok.proto"
+      index: 4
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.Foo3Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/ok.proto"
+      index: 5
+      visible:
+      options.message.fields: { "map_entry": { bool: } }
+    - fqn: "test.Foo.foo"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 1
+      visible:
+    - fqn: "test.Foo.bar"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 2
+      visible:
+    - fqn: "test.Foo.__foo2__"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 3
+      visible:
+    - fqn: "test.Foo.__foo_3__"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 4
+      visible:
+    - fqn: "test.Foo.FooEntry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 5
+      visible:
+    - fqn: "test.Foo.FooEntry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 6
+      visible:
+    - fqn: "test.Foo.BarEntry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 7
+      visible:
+    - fqn: "test.Foo.BarEntry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 8
+      visible:
+    - fqn: "test.Foo.Foo2Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 9
+      visible:
+    - fqn: "test.Foo.Foo2Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 10
+      visible:
+    - fqn: "test.Foo.Foo3Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 11
+      visible:
+    - fqn: "test.Foo.Foo3Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/ok.proto"
+      index: 12
+      visible:

--- a/experimental/ir/testdata/options/values/message.proto.stderr.txt
+++ b/experimental/ir/testdata/options/values/message.proto.stderr.txt
@@ -275,7 +275,7 @@ error: cannot resolve message field name for `buf.test.Foo`
   --> testdata/options/values/message.proto:36:5
    |
 36 |     1000: 1,
-   |     ^^^^ field referenced here
+   |     ^^^^^^^ field referenced here
 ...
 58 |     optional Foo x = 1000;
    |     ------------ expected `Foo` field due to this
@@ -284,7 +284,7 @@ error: cannot resolve message field name for `buf.test.Foo`
   --> testdata/options/values/message.proto:38:5
    |
 38 |     [z]: 0,
-   |     ^^^ field referenced here
+   |     ^^^^^^ field referenced here
 39 |     [Foo.z]: 1,
 ...
 58 |     optional Foo x = 1000;

--- a/experimental/parser/legalize_type.go
+++ b/experimental/parser/legalize_type.go
@@ -21,7 +21,6 @@ import (
 	"github.com/bufbuild/protocompile/experimental/internal/taxa"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/token/keyword"
-	"github.com/bufbuild/protocompile/internal/ext/iterx"
 )
 
 // legalizeMethodParams legalizes part of the signature of a method.
@@ -210,20 +209,21 @@ func legalizeFieldType(p *parser, ty ast.TypeAny, topLevel bool, oneof ast.DeclD
 			)
 		default:
 			k, v := ty.AsMap()
-			if !k.AsPath().AsPredeclared().IsMapKey() {
+
+			switch k.Kind() {
+			case ast.TypeKindPath:
+				legalizeFieldType(p, k, false, oneof)
+			case ast.TypeKindPrefixed:
+				p.Error(errUnexpected{
+					what:  k.AsPrefixed().PrefixToken(),
+					where: taxa.MapKey.In(),
+				})
+			default:
 				p.Error(errUnexpected{
 					what:  k,
 					where: taxa.MapKey.In(),
-					got:   "non-comparable type",
-				}).Apply(
-					report.Helpf(
-						"a map key must be one of the following types: %s",
-						iterx.Join(iterx.Filter(
-							predeclared.All(),
-							func(p predeclared.Name) bool { return p.IsMapKey() },
-						), ", "),
-					),
-				)
+					want:  taxa.TypePath.AsSet(),
+				})
 			}
 
 			switch v.Kind() {

--- a/experimental/parser/testdata/parser/lists.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/lists.proto.stderr.txt
@@ -484,29 +484,11 @@ error: missing message field tag in declaration
 54 |     map<int, int> x;
    |     ^^^^^^^^^^^^^^^^
 
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/lists.proto:54:9
-   |
-54 |     map<int, int> x;
-   |         ^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
-
 error: missing message field tag in declaration
   --> testdata/parser/lists.proto:55:5
    |
 55 |     map<int int> x;
    |     ^^^^^^^^^^^^^^^
-
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/lists.proto:55:9
-   |
-55 |     map<int int> x;
-   |         ^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
 
 error: unexpected type name in type parameters
   --> testdata/parser/lists.proto:55:13
@@ -525,15 +507,6 @@ error: missing message field tag in declaration
    |
 56 |     map<int,, int> x;
    |     ^^^^^^^^^^^^^^^^^
-
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/lists.proto:56:9
-   |
-56 |     map<int,, int> x;
-   |         ^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
 
 error: unexpected extra `,` in type parameters
   --> testdata/parser/lists.proto:56:13
@@ -600,29 +573,11 @@ error: unexpected leading `,` in type parameters
 59 | +     map<int, int> x;
    |
 
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/lists.proto:59:10
-   |
-59 |     map<,int, int> x;
-   |          ^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
-
 error: missing message field tag in declaration
   --> testdata/parser/lists.proto:60:5
    |
 60 |     map<int; int> x;
    |     ^^^^^^^^^^^^^^^^
-
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/lists.proto:60:9
-   |
-60 |     map<int; int> x;
-   |         ^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
 
 error: unexpected `;` in type parameters
   --> testdata/parser/lists.proto:60:12
@@ -637,15 +592,6 @@ error: missing message field tag in declaration
 ...  |
 64 | |     > x;
    | \________^
-
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/lists.proto:62:9
-   |
-62 |         int,
-   |         ^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
 
 error: unexpected trailing `,` in type parameters
   --> testdata/parser/lists.proto:63:12
@@ -887,4 +833,4 @@ error: unexpected `message` after reserved range
 76 |     reserved a, b c;
    |                    +
 
-encountered 94 errors and 2 warnings
+encountered 88 errors and 2 warnings

--- a/experimental/parser/testdata/parser/type/generic.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/type/generic.proto.stderr.txt
@@ -1,21 +1,3 @@
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/type/generic.proto:21:9
-   |
-21 |     map<M, M> x2 = 2;
-   |         ^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
-
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/type/generic.proto:22:9
-   |
-22 |     map<test.M, .test.M> x3 = 3;
-   |         ^^^^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
-
 error: unexpected type in map value type
   --> testdata/parser/type/generic.proto:23:17
    |
@@ -71,15 +53,6 @@ error: unexpected `repeated` in map value type
    |
 34 |     map<string, repeated string> x11 = 11;
    |                 ^^^^^^^^
-
-error: unexpected non-comparable type in map key type
-  --> testdata/parser/type/generic.proto:35:9
-   |
-35 |     map<optional .test.M, required test.M> x12 = 12;
-   |         ^^^^^^^^^^^^^^^^
-   = help: a map key must be one of the following types: int32, int64, uint32,
-           uint64, sint32, sint64, fixed32, fixed64, sfixed32, sfixed64, bool,
-           string
 
 error: unexpected `required` in map value type
   --> testdata/parser/type/generic.proto:35:27
@@ -147,4 +120,4 @@ error: only message types may appear in method return type
 44 |     rpc X3(map<string, repeated string>) returns (stream map<string, string>) {}
    |                                                          ^^^^^^^^^^^^^^^^^^^
 
-encountered 21 errors and 1 warning
+encountered 18 errors and 1 warning


### PR DESCRIPTION
This PR makes map types work and lower into the IR.

It does so by adding an extra step where we manually construct synthetic types and fields in such a way that symbol resolution Just Works. I also added several checks to make sure that all the weird corner cases around maps are properly respected throughout.