### PR TITLE
Fix a panic when calling `ir.MessageValue.Fields`

### DIFF
--- a/experimental/ir/ir_value.go
+++ b/experimental/ir/ir_value.go
@@ -436,6 +436,10 @@ func (v MessageValue) Concrete() MessageValue {
 // Fields yields the fields within this message literal, in insertion order.
 func (v MessageValue) Fields() iter.Seq[Value] {
 	return func(yield func(Value) bool) {
+		if v.IsZero() {
+			return
+		}
+
 		for _, p := range v.raw.entries {
 			v := wrapValue(v.Context(), p)
 			if !v.IsZero() && !yield(v) {


### PR DESCRIPTION
Due to an oversight, calling `Fields()` on a zero `ir.MessageValue` panics if you try to use the iterator. With this change, the iterator now correctly yields zero values.