### PR TITLE
Remove unused func

### DIFF
--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -111,9 +111,3 @@ func lower(c *Context, r *report.Report, importer Importer) {
 	// Perform "late" name resolution, that is, options.
 	resolveOptions(c.File(), r)
 }
-
-// sorry panics with an NYI error, which turns into an ICE inside of the
-// lowering logic.
-func sorry(what string) {
-	panic("sorry, not yet implemented: " + what)
-}


### PR DESCRIPTION
`ir.sorry` is no longer used, removing this.