### PR TITLE
Genearlize `Value.AST` and friends to handle values sourced from multiple expressions

### DIFF
--- a/experimental/ir/ir_value.go
+++ b/experimental/ir/ir_value.go
@@ -43,13 +43,43 @@ type Value struct {
 
 // rawValue is a [rawValueBits] with field information attached to it.
 type rawValue struct {
-	// The expression that this value was evaluated from.
+	// Expressions that contributes to this value.
 	//
-	// If this is an entry in a [MessageValue], this will be an ast.FieldExpr.
-	expr ast.ExprAny
+	// The representation of this field is quite complicated, to deal with
+	// potentially complicated source ASTs. The worst case is as follows.
+	// Consider:
+	//
+	//   option foo = { a: [1, 2, 3], a: [4, 5] }; // (*)
+	//
+	// Here, two ast.FieldExprs contribute to the value of a, but there are
+	// five subexpressions for the elements of a. We would like to be able to
+	// report both those FieldExprs, *and* report an expression for each value
+	// therein.
+	//
+	// However, there is another potentially subtle case we *do not* have to
+	// deal with (for a singular message field a):
+	//
+	//   option foo = { a { b: 1 }, a { c: 2 } };
+	//
+	// This is an error, because foo.a has already been set when we process
+	// the second value. If a is repeated, each of these produces a separate
+	// element.
+	//
+	// Because case (*) is rare, we adopt a compression strategy here. exprs
+	// refers to all contributing expressions for the value. If any array
+	// expressions occurred, elemIndices will be non-nil, and will be a prefix
+	// sum of the number of values that each expr in exprs contributes. This is
+	// binary-searched by Element.AST to find the AST nodes of each element.
+	//
+	// Specifically, elemIndices[i] will be the number of elements that every
+	// expression, up to an including exprs[i], contributes. This layout is
+	// chosen because it significantly simplifies construction and searching of
+	// this slice.
+	exprs       []ast.ExprAny
+	elemIndices []uint32
 
-	// The AST node for the path of the option (compact or otherwise) that
-	// specifies this value. This is intended for diagnostics.
+	// The AST nodes for the path of the option (compact or otherwise) that
+	// specify this value. This is intended for diagnostics.
 	//
 	// For example, the node
 	//
@@ -57,7 +87,12 @@ type rawValue struct {
 	//
 	// results in a field a: {b: {c: 9}}, which is four rawValues deep.
 	// Each of these will have the same optionPath, for a.b.c.
-	optionPath ast.Path
+	//
+	// There will be one such value for each contributing expression, to deal
+	// with the repeated field case
+	//
+	//   option f = 1; option f = 2;
+	optionPaths []ast.Path
 
 	// The field that this value sets. This is where type information comes
 	// from.
@@ -82,46 +117,72 @@ type rawValue struct {
 //     the repeated message fields that they will ultimately become.
 type rawValueBits uint64
 
-// AST returns the expression that evaluated to this value.
+// AST returns a representative expression that evaluated to this value.
+//
+// For complicated options (such as repeated fields), there may be more than
+// one contributing expression; this will just return *one* of them.
 func (v Value) AST() ast.ExprAny {
-	if v.IsZero() {
+	if v.IsZero() || len(v.raw.exprs) == 0 {
 		return ast.ExprAny{}
 	}
 
-	if field := v.raw.expr.AsField(); field.IsZero() {
+	expr := v.raw.exprs[0]
+	if field := expr.AsField(); field.IsZero() {
+		// Unwrap a FieldExpr if necessary.
 		return field.Value()
 	}
 
-	return v.raw.expr
+	return expr
 }
 
-// OptionPath returns the AST node for the path of the option (compact or not)
-// that caused this value to be set.
-func (v Value) OptionPath() ast.Path {
-	if v.IsZero() {
-		return ast.Path{}
+// ASTs returns all expressions that contributed to evaluating this value.
+//
+// There may be more than one such expression, for repeated fields set more
+// than once.
+func (v Value) ASTs() seq.Indexer[ast.ExprAny] {
+	var slice []ast.ExprAny
+	if !v.IsZero() {
+		slice = v.raw.exprs
 	}
-	return v.raw.optionPath
+
+	return seq.NewFixedSlice(slice, func(_ int, expr ast.ExprAny) ast.ExprAny {
+		if field := expr.AsField(); field.IsZero() {
+			return field.Value()
+		}
+		return expr
+	})
 }
 
-// FieldAST returns the field expression that sets this value in a message
-// expression, if it is such a value.
-func (v Value) FieldAST() ast.ExprField {
-	if v.IsZero() {
-		return ast.ExprField{}
+// Options returns the AST node for the options that set this value.
+//
+// There will be one path per value returned from [Value.ASTs].
+func (v Value) OptionPaths() seq.Indexer[ast.Path] {
+	var slice []ast.Path
+	if !v.IsZero() {
+		slice = v.raw.optionPaths
 	}
 
-	return v.raw.expr.AsField()
+	return seq.NewFixedSlice(slice, func(_ int, e ast.Path) ast.Path { return e })
 }
 
-// key returns an AST node that best approximates where this value's field was
-// set.
-func (v Value) key() report.Spanner {
-	if field := v.FieldAST(); !field.IsZero() {
-		return field.Key()
+// MessageKeys returns the AST nodes for each key associated with a value in
+// [Value.ASTs].
+//
+// This will either be the key value from an [ast.FieldExpr] (which need not be
+// an [ast.PathExpr], in the case of an extension) or the [ast.PathExpr]
+// associated with the left-hand-side of an option setting.
+func (v Value) MessageKeys() seq.Indexer[ast.ExprAny] {
+	var slice []ast.ExprAny
+	if !v.IsZero() {
+		slice = v.raw.exprs
 	}
 
-	return v.OptionPath()
+	return seq.NewFixedSlice(slice, func(n int, expr ast.ExprAny) ast.ExprAny {
+		if field := expr.AsField(); !field.IsZero() {
+			return field.Key()
+		}
+		return ast.ExprPath{Path: v.raw.optionPaths[n]}.AsAny()
+	})
 }
 
 // Field returns the field this value sets, which includes the value's type
@@ -155,8 +216,14 @@ func (v Value) Singular() bool {
 // The indexer will be nonempty except for the zero Value. That is to say, unset
 // fields of [MessageValue]s are not represented as a distinct "empty" Value.
 func (v Value) Elements() seq.Indexer[Element] {
-	return seq.NewFixedSlice(v.getElements(), func(_ int, bits rawValueBits) Element {
-		return Element{v.withContext, v.Field(), bits}
+	return seq.NewFixedSlice(v.getElements(), func(n int, bits rawValueBits) Element {
+		return Element{
+			withContext: v.withContext,
+			index:       n,
+			value:       v,
+			field:       v.Field(),
+			bits:        bits,
+		}
 	})
 }
 
@@ -380,8 +447,46 @@ func wrapValue(c *Context, p arena.Pointer[rawValue]) Value {
 // type provides uniform access to such elements. See [Value.Elements].
 type Element struct {
 	withContext
+	index int
+	value Value
 	field Member
 	bits  rawValueBits
+}
+
+// AST returns the expression this value was evaluated from.
+func (e Element) AST() ast.ExprAny {
+	// We do O(log n) work here, because this function doesn't get called except
+	// for diagnostics.
+
+	idx := e.index
+	if e.value.raw.elemIndices != nil {
+		// Figure out which expression contributes the value for e. We're looking
+		// for the least upper bound.
+		//
+		// For example, if we have expressions [1, 2], [3, 4, 5], elemIndices
+		// will be [2, 5], and we have that BinarySearch returns
+		//
+		// 0 -> 0, false
+		// 1 -> 0, false
+		// 2 -> 0, true
+		// 3 -> 1, false
+		// 4 -> 1, false
+		var exact bool
+		idx, exact := slices.BinarySearch(e.value.raw.elemIndices, uint32(e.index))
+		if exact {
+			idx++
+		}
+	}
+
+	expr := e.value.raw.exprs[idx]
+	if array := expr.AsArray(); !array.IsZero() && e.value.raw.elemIndices != nil {
+		// We need to index into the array expression. The index is going to be
+		// offset by the number of expressions before this one, which we
+		// can get via elemIndices.
+		n := e.index - int(e.value.raw.elemIndices[e.index])
+		expr = array.Elements().At(n)
+	}
+	return expr
 }
 
 // Field returns the field this value sets, which includes the value's type

--- a/experimental/ir/lower_eval.go
+++ b/experimental/ir/lower_eval.go
@@ -196,11 +196,33 @@ func (e *evaluator) eval(args evalArgs) Value {
 	}
 
 	if !args.target.IsZero() {
-		if args.target.AST().IsZero() {
-			args.target.raw.expr = args.expr
+		raw := args.target.raw
+		isArray := args.expr.Kind() == ast.ExprKindArray
+
+		// Only populate elemIndices if we run into an array expression.
+		if raw.elemIndices == nil && isArray {
+			for i := range len(raw.exprs) {
+				// If this is the first array we're seeing, each expression
+				// contributes exactly one element.
+				raw.elemIndices = append(raw.elemIndices, uint32(i+1))
+			}
 		}
-		if args.target.OptionPath().IsZero() {
-			args.target.raw.optionPath = args.optionPath
+
+		raw.exprs = append(raw.exprs, args.expr)
+		raw.optionPaths = append(raw.optionPaths, args.optionPath)
+
+		if raw.elemIndices != nil || isArray {
+			var n uint32
+			if raw.elemIndices != nil {
+				n = raw.elemIndices[len(raw.elemIndices)-1]
+			}
+
+			if isArray {
+				n += uint32(args.expr.AsArray().Elements().Len())
+			} else {
+				n++
+			}
+			raw.elemIndices = append(raw.elemIndices, n)
 		}
 	}
 
@@ -656,24 +678,24 @@ func (e *evaluator) evalMessage(args evalArgs, expr ast.ExprDict) Value {
 
 			switch {
 			case field.Presence() == presence.Repeated:
-				copied.target = wrapValue(e.Context, *slot)
+				copied.target = value
 
 			case value.Field() != field:
 				// A different member of a oneof was set.
 				e.Error(errSetMultipleTimes{
 					member: field.Oneof(),
-					first:  value.key(),
+					first:  value.MessageKeys().At(0),
 					second: expr.Key(),
 				})
 				copied.target = Value{}
 
 			case field.Element().IsMessage():
-				copied.target = wrapValue(e.Context, *slot)
+				copied.target = value
 
 			default:
 				e.Error(errSetMultipleTimes{
 					member: field,
-					first:  value.key(),
+					first:  value.MessageKeys().At(0),
 					second: expr.Key(),
 				})
 				copied.target = Value{}
@@ -682,7 +704,9 @@ func (e *evaluator) evalMessage(args evalArgs, expr ast.ExprDict) Value {
 
 		v := e.eval(copied)
 		if slot.Nil() && !v.IsZero() {
-			v.raw.expr = expr.AsAny()
+			// Overwrite the most recently-added expression with the FieldExpr
+			// so that key lookup works correctly.
+			v.raw.exprs[len(v.raw.exprs)-1] = expr.AsAny()
 
 			// Make sure to pick up a freshly allocated value, if this
 			// was the first iteration.

--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -290,7 +290,7 @@ func (r optionRef) resolve() {
 				// A different member of a oneof was set.
 				r.Error(errSetMultipleTimes{
 					member: field.Oneof(),
-					first:  value.OptionPath(),
+					first:  value.OptionPaths().At(0),
 					second: path,
 					root:   pc.IsFirst(),
 				})
@@ -306,7 +306,7 @@ func (r optionRef) resolve() {
 			default:
 				r.Error(errSetMultipleTimes{
 					member: field,
-					first:  value.OptionPath(),
+					first:  value.OptionPaths().At(0),
 					second: path,
 					root:   pc.IsFirst(),
 				})
@@ -348,9 +348,7 @@ func (r optionRef) resolve() {
 		}
 
 		value := newMessage(r.Context, compressMember(r.Context, field)).AsValue()
-		if value.raw.optionPath.IsZero() {
-			value.raw.optionPath = path
-		}
+		value.raw.optionPaths = append(value.raw.optionPaths, path)
 
 		*raw = r.arenas.values.Compress(value.raw)
 		current = value


### PR DESCRIPTION
Today, `Value.AST` returns a single node. This does not fully express how all values could be evaluated. For example, consider the option

```protobuf
option f = { k: [1, 2, 3], x: 5, k: [4, 5] };
```

`f.k` has two disjoint expressions that contribute to it. This PR enhances `Value` to report *both* of these. `Value.AST` continues to report the first of these, for ease of writing diagnostics. `Value.ASTs` returns all of these nodes; `Value.OptionPaths` returns the option paths that set each of these nodes (which may be distinct, for e.g. `option x = 1; option x = 2;` for repeated x), and `Value.MessageKeys` returns either the `FieldExpr.Key` or the corresponding option path for a contributing expression (convenient for diagnostics).

On top of this, `Elements.AST` now returns the expression that an element evaluates to. This *does not* line up with the contributing expression, because a single array can contribute multiple elements. We use a sparse/dense representation, where `rawValue.elemIndices` is used to map from an element index to a contributing node index. There is some subtlety in `lower_eval.go` to build this data structure correctly.