### PR TITLE
Forbid `uninterpreted_option` from being set

### DIFF
--- a/experimental/ir/builtins.go
+++ b/experimental/ir/builtins.go
@@ -58,6 +58,16 @@ type builtinIDs struct {
 	ServiceOptions   intern.ID `intern:"google.protobuf.ServiceDescriptorProto.options"`
 	MethodOptions    intern.ID `intern:"google.protobuf.MethodDescriptorProto.options"`
 
+	FileUninterpreted      intern.ID `intern:"google.protobuf.FileOptions.uninterpreted_option"`
+	MessageUninterpreted   intern.ID `intern:"google.protobuf.MessageOptions.uninterpreted_option"`
+	FieldUninterpreted     intern.ID `intern:"google.protobuf.FieldOptions.uninterpreted_option"`
+	OneofUninterpreted     intern.ID `intern:"google.protobuf.OneofOptions.uninterpreted_option"`
+	RangeUninterpreted     intern.ID `intern:"google.protobuf.ExtensionRangeOptions.uninterpreted_option"`
+	EnumUninterpreted      intern.ID `intern:"google.protobuf.EnumOptions.uninterpreted_option"`
+	EnumValueUninterpreted intern.ID `intern:"google.protobuf.EnumValueOptions.uninterpreted_option"`
+	ServiceUninterpreted   intern.ID `intern:"google.protobuf.ServiceOptions.uninterpreted_option"`
+	MethodUninterpreted    intern.ID `intern:"google.protobuf.MethodOptions.uninterpreted_option"`
+
 	MapEntry intern.ID `intern:"google.protobuf.MessageOptions.map_entry"`
 }
 

--- a/experimental/ir/testdata/fields/maps/map_entry.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/maps/map_entry.proto.stderr.txt
@@ -3,7 +3,7 @@ error: `map_entry` cannot be set explicitly
    |
 27 |     option map_entry = true;
    |            ^^^^^^^^^
-   = help: map_entry is set automatically for synthetic map entry types, and
+   = help: `map_entry` is set automatically for synthetic map entry types, and
            cannot be set with an option setting
 
 encountered 1 error

--- a/experimental/ir/testdata/options/uinterpreted.proto
+++ b/experimental/ir/testdata/options/uinterpreted.proto
@@ -1,0 +1,43 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.test;
+
+option uninterpreted_option = {};
+
+message M {
+    option uninterpreted_option = {};
+
+    optional int32 x = 1 [uninterpreted_option = {}];
+    extensions 2 [uninterpreted_option = {}];
+    oneof y {
+        option uninterpreted_option = {};
+        int32 z = 3;
+    }
+}
+
+enum E {
+    option uninterpreted_option = {};
+
+    Z = 0 [uninterpreted_option = {}];
+}
+
+service S {
+    option uninterpreted_option = {};
+    rpc X(M) returns (M) {
+        option uninterpreted_option = {};
+    }
+}

--- a/experimental/ir/testdata/options/uinterpreted.proto.fds.yaml
+++ b/experimental/ir/testdata/options/uinterpreted.proto.fds.yaml
@@ -1,0 +1,35 @@
+file:
+- name: "testdata/options/uinterpreted.proto"
+  package: "buf.test"
+  message_type:
+  - name: "M"
+    field:
+    - name: "x"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      options.uninterpreted_option: [{}]
+    - name: "z"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      oneof_index: 0
+    extension_range: [{ start: 2, end: 3, options.uninterpreted_option: [{}] }]
+    oneof_decl: [{ name: "y", options.uninterpreted_option: [{}] }]
+    options.uninterpreted_option: [{}]
+  enum_type:
+  - name: "E"
+    value: [{ name: "Z", number: 0, options.uninterpreted_option: [{}] }]
+    options.uninterpreted_option: [{}]
+  service:
+  - name: "S"
+    method:
+    - name: "X"
+      input_type: "buf.test.M"
+      output_type: "buf.test.M"
+      options.uninterpreted_option: [{}]
+      client_streaming: false
+      server_streaming: false
+    options.uninterpreted_option: [{}]
+  options.uninterpreted_option: [{}]
+  syntax: "proto2"

--- a/experimental/ir/testdata/options/uinterpreted.proto.stderr.txt
+++ b/experimental/ir/testdata/options/uinterpreted.proto.stderr.txt
@@ -1,0 +1,64 @@
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:19:8
+   |
+19 | option uninterpreted_option = {};
+   |        ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:22:12
+   |
+22 |     option uninterpreted_option = {};
+   |            ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:24:27
+   |
+24 |     optional int32 x = 1 [uninterpreted_option = {}];
+   |                           ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:25:19
+   |
+25 |     extensions 2 [uninterpreted_option = {}];
+   |                   ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:27:16
+   |
+27 |         option uninterpreted_option = {};
+   |                ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:33:12
+   |
+33 |     option uninterpreted_option = {};
+   |            ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:35:12
+   |
+35 |     Z = 0 [uninterpreted_option = {}];
+   |            ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:39:12
+   |
+39 |     option uninterpreted_option = {};
+   |            ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+error: `uninterpreted_option` cannot be set explicitly
+  --> testdata/options/uinterpreted.proto:41:16
+   |
+41 |         option uninterpreted_option = {};
+   |                ^^^^^^^^^^^^^^^^^^^^
+   = help: `uninterpreted_option` is an implementation detail of protoc
+
+encountered 9 errors

--- a/experimental/ir/testdata/options/uinterpreted.proto.symtab.yaml
+++ b/experimental/ir/testdata/options/uinterpreted.proto.symtab.yaml
@@ -1,0 +1,58 @@
+tables:
+  "testdata/options/uinterpreted.proto":
+    symbols:
+    - fqn: "buf.test"
+      kind: KIND_PACKAGE
+      file: "testdata/options/uinterpreted.proto"
+    - fqn: "buf.test.M"
+      kind: KIND_MESSAGE
+      file: "testdata/options/uinterpreted.proto"
+      index: 1
+      visible: true
+      options.message.fields:
+        "uninterpreted_option": { repeated.values: [{ message: {} }] }
+    - fqn: "buf.test.E"
+      kind: KIND_ENUM
+      file: "testdata/options/uinterpreted.proto"
+      index: 2
+      visible: true
+      options.message.fields:
+        "uninterpreted_option": { repeated.values: [{ message: {} }] }
+    - fqn: "buf.test.M.x"
+      kind: KIND_FIELD
+      file: "testdata/options/uinterpreted.proto"
+      index: 1
+      visible: true
+      options.message.fields:
+        "uninterpreted_option": { repeated.values: [{ message: {} }] }
+    - fqn: "buf.test.M.z"
+      kind: KIND_FIELD
+      file: "testdata/options/uinterpreted.proto"
+      index: 2
+      visible: true
+    - fqn: "buf.test.Z"
+      kind: KIND_ENUM_VALUE
+      file: "testdata/options/uinterpreted.proto"
+      index: 3
+      visible: true
+      options.message.fields:
+        "uninterpreted_option": { repeated.values: [{ message: {} }] }
+    - fqn: "buf.test.M.y"
+      kind: KIND_ONEOF
+      file: "testdata/options/uinterpreted.proto"
+      index: 1
+      visible: true
+      options.message.fields:
+        "uninterpreted_option": { repeated.values: [{ message: {} }] }
+    - fqn: "buf.test.S"
+      kind: 9
+      file: "testdata/options/uinterpreted.proto"
+      index: 1
+      visible: true
+    - fqn: "buf.test.S.X"
+      kind: 10
+      file: "testdata/options/uinterpreted.proto"
+      index: 1
+      visible: true
+    options.message.fields:
+      "uninterpreted_option": { repeated.values: [{ message: {} }] }


### PR DESCRIPTION
This option gets special language treatment and cannot be set directly. Because our compiler does not use FDP as its IR, we never wind up using this ourselves.