### PR TITLE
Fix a panic in `internal/toposort`

### DIFF
--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -25,6 +25,7 @@ import (
 const (
 	unsorted byte = iota
 	working
+	walking
 	sorted
 )
 
@@ -84,23 +85,27 @@ func (s *Sorter[Node, Key]) Sort(
 			// loop.
 			for len(s.stack) > 0 {
 				node, _ := slicesx.Last(s.stack)
-				visit := slicesx.LastPointer(s.visited)
+				k := s.Key(node)
+				state := s.state[k]
 
-				if !*visit {
+				if state == unsorted {
+					s.state[k] = working
 					for child := range dag(node) {
-						s.push(child)
+						if s.state[s.Key(child)] != sorted {
+							s.push(child)
+						}
 					}
-
-					*visit = true
 					continue
 				}
 
+				fmt.Println(k, s.state)
+
 				s.stack = s.stack[:len(s.stack)-1]
 				s.visited = s.visited[:len(s.visited)-1]
-				s.state[s.Key(node)] = sorted
-				if !yield(node) {
+				if state != sorted && !yield(node) {
 					return
 				}
+				s.state[k] = sorted
 			}
 		}
 	}
@@ -110,15 +115,16 @@ func (s *Sorter[Node, Key]) push(v Node) {
 	k := s.Key(v)
 	switch s.state[k] {
 	case unsorted:
-		s.state[k] = working
 		s.stack = append(s.stack, v)
 		s.visited = append(s.visited, false)
+
 	case working:
 		prev := slicesx.LastIndexFunc(s.stack, func(n Node) bool {
 			return s.Key(n) == k
 		})
 		suffix := s.stack[prev:]
 		panic(fmt.Sprintf("protocompile/internal: cycle detected: %v -> %v", slicesx.Join(suffix, "->"), v))
+
 	case sorted:
 		return
 	}

--- a/internal/toposort/toposort_test.go
+++ b/internal/toposort/toposort_test.go
@@ -81,6 +81,12 @@ func TestSort(t *testing.T) {
 			want:  []int{4, 2, 3, 1},
 		},
 		{
+			name:  "diamond",
+			dag:   dag{1: {3, 2}, 2: {3}, 3: {}},
+			roots: []int{1},
+			want:  []int{3, 2, 1},
+		},
+		{
 			name:  "y",
 			dag:   dag{1: {2}, 2: {4}, 3: {4}, 4: {}},
 			roots: []int{1},


### PR DESCRIPTION
Topological sorting was unable to handle the following graph:

```
a -> [c, b]
b -> [c]
c -> []
```

Note that the ordering of the children of a is important. This PR fixes this panic and adds a regression test.