### PR TITLE
Fix state reuse for internal/toposort

### DIFF
--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -58,7 +58,7 @@ func (s *Sorter[Node, Key]) Sort(
 	} else {
 		clear(s.state)
 	}
-	clear(s.stack) // Ensure all pointers are cleared.
+	clear(s.stack) // Ensure all pointers are zeroed.
 	s.stack = s.stack[:0]
 
 	return func(yield func(Node) bool) {
@@ -88,6 +88,8 @@ func (s *Sorter[Node, Key]) Sort(
 					continue
 				}
 
+				var zeroNode Node
+				s.stack[len(s.stack)] = zeroNode
 				s.stack = s.stack[:len(s.stack)-1]
 				if !yieled {
 					if !yield(node) {

--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -72,15 +72,15 @@ func (s *Sorter[Node, Key]) Sort(
 			s.push(root)
 			// This algorithm is DFS that has been tail-call-optimized into a loop.
 			// Each node is visited twice in the loop: once to add its children to
-			// the stack, and once to pop it and add it to the output. The visited
-			// stack tracks whether this is the first or second visit through the
-			// loop.
+			// the stack, and once to pop it and add it to the output. The state
+			// tracks whether this Node has been visisted and if its the first
+			// or second visit through the loop.
 			for len(s.stack) > 0 {
 				node, _ := slicesx.Last(s.stack)
 				k := s.Key(node)
-				yieled, visisted := s.state[k]
+				yieled, visited := s.state[k]
 
-				if !visisted {
+				if !visited {
 					s.state[k] = false
 					for child := range dag(node) {
 						s.push(child)

--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -89,7 +89,7 @@ func (s *Sorter[Node, Key]) Sort(
 				}
 
 				var zeroNode Node
-				s.stack[len(s.stack)] = zeroNode
+				s.stack[len(s.stack)-1] = zeroNode
 				s.stack = s.stack[:len(s.stack)-1]
 				if !yieled {
 					if !yield(node) {

--- a/internal/toposort/toposort.go
+++ b/internal/toposort/toposort.go
@@ -78,7 +78,7 @@ func (s *Sorter[Node, Key]) Sort(
 			for len(s.stack) > 0 {
 				node, _ := slicesx.Last(s.stack)
 				k := s.Key(node)
-				yieled, visited := s.state[k]
+				yielded, visited := s.state[k]
 
 				if !visited {
 					s.state[k] = false
@@ -91,7 +91,7 @@ func (s *Sorter[Node, Key]) Sort(
 				var zeroNode Node
 				s.stack[len(s.stack)-1] = zeroNode
 				s.stack = s.stack[:len(s.stack)-1]
-				if !yieled {
+				if !yielded {
 					if !yield(node) {
 						return
 					}
@@ -104,18 +104,15 @@ func (s *Sorter[Node, Key]) Sort(
 
 func (s *Sorter[Node, Key]) push(v Node) {
 	k := s.Key(v)
-	switch yieled, visited := s.state[k]; {
+	switch yielded, visited := s.state[k]; {
 	case !visited:
 		s.stack = append(s.stack, v)
 
-	case !yieled && visited:
+	case !yielded && visited:
 		prev := slicesx.LastIndexFunc(s.stack, func(n Node) bool {
 			return s.Key(n) == k
 		})
 		suffix := s.stack[prev:]
 		panic(fmt.Sprintf("protocompile/internal: cycle detected: %v -> %v", slicesx.Join(suffix, "->"), v))
-
-	case yieled:
-		return
 	}
 }


### PR DESCRIPTION
This PR reduces the internal states, fixes non-zero elements in the stack slice and fixes cleanup by clearing state on completion.