### PR TITLE
Implement message set constraint validation

### DIFF
--- a/experimental/ast/type.go
+++ b/experimental/ast/type.go
@@ -16,6 +16,7 @@
 package ast
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/bufbuild/protocompile/experimental/internal"
@@ -134,6 +135,19 @@ func (t TypeAny) AsGeneric() TypeGeneric {
 		t.withContext,
 		t.Context().Nodes().types.generics.Deref(ptr),
 	}}
+}
+
+// Prefixes is an iterator over all [TypePrefix]es wrapping this type.
+func (t TypeAny) Prefixes() iter.Seq[TypePrefixed] {
+	return func(yield func(TypePrefixed) bool) {
+		for t.Kind() == TypeKindPrefixed {
+			prefixed := t.AsPrefixed()
+			if !yield(prefixed) {
+				return
+			}
+			t = prefixed.Type()
+		}
+	}
 }
 
 // RemovePrefixes removes all [TypePrefix] values wrapping this type.

--- a/experimental/internal/taxa/noun.go
+++ b/experimental/internal/taxa/noun.go
@@ -79,6 +79,7 @@ const (
 	TypeParams
 	TypePrefix
 	MessageType
+	MessageSet
 	EnumType
 	ScalarType
 	MapKey
@@ -184,7 +185,7 @@ var _table_Noun_String = [...]string{
 	Signature:          "method signature",
 	FieldTag:           "message field tag",
 	FieldNumber:        "field number",
-	MessageSetNumber:   "`MessageSet` extension number",
+	MessageSetNumber:   "message set extension number",
 	FieldName:          "message field name",
 	OptionValue:        "option setting value",
 	QualifiedName:      "qualified name",
@@ -201,6 +202,7 @@ var _table_Noun_String = [...]string{
 	TypeParams:         "type parameters",
 	TypePrefix:         "type modifier",
 	MessageType:        "message type",
+	MessageSet:         "message set type",
 	EnumType:           "enum type",
 	ScalarType:         "scalar type",
 	MapKey:             "map key type",
@@ -306,6 +308,7 @@ var _table_Noun_GoString = [...]string{
 	TypeParams:         "TypeParams",
 	TypePrefix:         "TypePrefix",
 	MessageType:        "MessageType",
+	MessageSet:         "MessageSet",
 	EnumType:           "EnumType",
 	ScalarType:         "ScalarType",
 	MapKey:             "MapKey",

--- a/experimental/internal/taxa/noun.yaml
+++ b/experimental/internal/taxa/noun.yaml
@@ -65,7 +65,7 @@
 
   - {name: FieldTag, string: "message field tag"}
   - {name: FieldNumber, string: "field number"}
-  - {name: MessageSetNumber, string: "`MessageSet` extension number"}
+  - {name: MessageSetNumber, string: "message set extension number"}
   - {name: FieldName, string: "message field name"}
   - {name: OptionValue, string: "option setting value"}
 
@@ -86,6 +86,7 @@
   - {name: TypePrefix, string: "type modifier"}
 
   - {name: MessageType, string: "message type"}
+  - {name: MessageSet, string: "message set type"}
   - {name: EnumType, string: "enum type"}
   - {name: ScalarType, string: "scalar type"}
 

--- a/experimental/ir/builtins.go
+++ b/experimental/ir/builtins.go
@@ -41,6 +41,8 @@ type builtins struct {
 	ServiceOptions   Member
 	MethodOptions    Member
 
+	MessageSet Member
+
 	MapEntry      Member
 	OptionTargets Member
 }
@@ -60,6 +62,9 @@ type builtinIDs struct {
 	EnumValueOptions intern.ID `intern:"google.protobuf.EnumValueDescriptorProto.options"`
 	ServiceOptions   intern.ID `intern:"google.protobuf.ServiceDescriptorProto.options"`
 	MethodOptions    intern.ID `intern:"google.protobuf.MethodDescriptorProto.options"`
+
+	MessageSet intern.ID `intern:"google.protobuf.MessageOptions.message_set_wire_format"`
+	AllowAlias intern.ID `intern:"google.protobuf.EnumOptions.allow_alias"`
 
 	MapEntry      intern.ID `intern:"google.protobuf.MessageOptions.map_entry"`
 	OptionTargets intern.ID `intern:"google.protobuf.FieldOptions.targets"`

--- a/experimental/ir/ir_member.go
+++ b/experimental/ir/ir_member.go
@@ -66,24 +66,29 @@ type rawMember struct {
 	isGroup       bool
 }
 
-// Returns whether this is a non-extension message field.
+// IsMessageField returns whether this is a non-extension message field.
 func (m Member) IsMessageField() bool {
 	return !m.IsZero() && !m.raw.elem.ptr.Nil() && m.raw.extendee.Nil()
 }
 
-// Returns whether this is a extension message field.
+// IsExtension returns whether this is a extension message field.
 func (m Member) IsExtension() bool {
 	return !m.IsZero() && !m.raw.elem.ptr.Nil() && !m.raw.extendee.Nil()
 }
 
-// Returns whether this is an enum value.
+// IsEnumValue returns whether this is an enum value.
 func (m Member) IsEnumValue() bool {
 	return !m.IsZero() && m.raw.elem.ptr.Nil()
 }
 
-// Returns whether this is a group-encoded field.
+// IsGroup returns whether this is a group-encoded field.
 func (m Member) IsGroup() bool {
 	return !m.IsZero() && m.raw.isGroup
+}
+
+// IsMap returns whether this is a map field.
+func (m Member) IsMap() bool {
+	return !m.IsZero() && m == m.Element().MapField()
 }
 
 // IsSynthetic returns whether or not this is a synthetic field, such as the

--- a/experimental/ir/lower.go
+++ b/experimental/ir/lower.go
@@ -87,6 +87,7 @@ func lower(c *Context, r *report.Report, importer Importer) {
 
 	// Perform "early" name resolution, i.e. field names and extension types.
 	resolveNames(c.File(), r)
+	resolveEarlyOptions(c.File())
 
 	// Perform constant evaluation.
 	evaluateFieldNumbers(c.File(), r)
@@ -102,4 +103,7 @@ func lower(c *Context, r *report.Report, importer Importer) {
 	// done in two separate steps.
 	populateOptionTargets(c.File(), r)
 	validateOptionTargets(c.File(), r)
+
+	// Validate all the little constraint details that didn't get caught above.
+	validateConstraints(c.File(), r)
 }

--- a/experimental/ir/lower_maps.go
+++ b/experimental/ir/lower_maps.go
@@ -28,91 +28,107 @@ import (
 // generateMapEntries generates map entry types for all map-typed fields.
 func generateMapEntries(f File, r *report.Report) {
 	c := f.Context()
+	lowerField := func(field Member) {
+		// optional, repeated etc. on map types is already legalized in
+		// the parser.
+		decl := field.AST().Type().RemovePrefixes().AsGeneric()
+		if decl.IsZero() {
+			return
+		}
+
+		key, _ := decl.AsMap()
+		if key.IsZero() {
+			return // Legalized in the parser.
+		}
+
+		parent := field.Parent()
+		base := parent.FullName()
+		if base == "" {
+			base = f.Package()
+		}
+		name := pcinternal.MapEntry(field.Name())
+		fqn := base.Append(name)
+
+		// Set option map_entry = true;
+		builtins := c.builtins()
+		messageOptions := builtins.MessageOptions.toRef(c)
+		mapEntry := builtins.MapEntry.toRef(c)
+
+		options := newMessage(c, builtins.MessageOptions.toRef(c))
+		*options.insert(wrapMember(c, mapEntry)) =
+			c.arenas.values.NewCompressed(rawValue{
+				field: mapEntry,
+				bits:  1,
+			})
+
+		// Construct the type itself.
+		raw := c.arenas.types.NewCompressed(rawType{
+			def:    field.AST(),
+			name:   c.session.intern.Intern(name),
+			fqn:    c.session.intern.Intern(string(fqn)),
+			parent: c.arenas.types.Compress(parent.raw),
+			options: c.arenas.values.NewCompressed(rawValue{
+				field: messageOptions,
+				bits:  rawValueBits(c.arenas.messages.Compress(options.raw)),
+			}),
+
+			mapEntryOf: c.arenas.members.Compress(field.raw),
+		})
+		ty := Type{internal.NewWith(c), c.arenas.types.Deref(raw)}
+		ty.raw.memberByName = sync.OnceValue(ty.makeMembersByName)
+		if parent.IsZero() {
+			c.types = slices.Insert(c.types, c.topLevelTypesEnd, raw)
+			c.topLevelTypesEnd++
+		} else {
+			c.types = append(c.types, raw)
+			parent.raw.nested = append(parent.raw.nested, raw)
+		}
+
+		// Construct the fields and attach them to ty.
+		makeField := func(name string, number int32) {
+			fqn := fqn.Append(name)
+
+			id := c.arenas.members.NewCompressed(rawMember{
+				name:   c.session.intern.Intern(name),
+				fqn:    c.session.intern.Intern(string(fqn)),
+				parent: c.arenas.types.Compress(ty.raw),
+				number: number,
+				oneof:  -int32(presence.Explicit),
+			})
+
+			ty.raw.members = slices.Insert(ty.raw.members, int(ty.raw.extnsStart), id)
+			ty.raw.extnsStart++
+		}
+
+		makeField("key", 1)
+		makeField("value", 2)
+
+		// Update the field to be a repeated field of the given type.
+		field.raw.elem.ptr = raw
+		field.raw.oneof = -int32(presence.Repeated)
+	}
+
 	for parent := range seq.Values(f.AllTypes()) {
 		if !parent.IsMessage() {
 			continue
 		}
 
 		for field := range seq.Values(parent.Members()) {
-			// optional, repeated etc. on map types is already legalized in
-			// the parser.
-			decl := field.AST().Type().RemovePrefixes().AsGeneric()
-			if decl.IsZero() {
-				continue
-			}
-
-			key, _ := decl.AsMap()
-			if key.IsZero() {
-				continue // Legalized in the parser.
-			}
-
-			name := pcinternal.MapEntry(field.Name())
-			fqn := parent.FullName().Append(name)
-
-			// Set option map_entry = true;
-			builtins := c.builtins()
-			messageOptions := builtins.MessageOptions.toRef(c)
-			mapEntry := builtins.MapEntry.toRef(c)
-
-			options := newMessage(c, builtins.MessageOptions.toRef(c))
-			*options.insert(wrapMember(c, mapEntry)) =
-				c.arenas.values.NewCompressed(rawValue{
-					field: mapEntry,
-					bits:  1,
-				})
-
-			// Construct the type itself.
-			raw := c.arenas.types.NewCompressed(rawType{
-				def:    field.AST(),
-				name:   c.session.intern.Intern(name),
-				fqn:    c.session.intern.Intern(string(fqn)),
-				parent: c.arenas.types.Compress(parent.raw),
-				options: c.arenas.values.NewCompressed(rawValue{
-					field: messageOptions,
-					bits:  rawValueBits(c.arenas.messages.Compress(options.raw)),
-				}),
-
-				mapEntryOf: c.arenas.members.Compress(field.raw),
-			})
-			ty := Type{internal.NewWith(c), c.arenas.types.Deref(raw)}
-			ty.raw.memberByName = sync.OnceValue(ty.makeMembersByName)
-			parent.raw.nested = append(parent.raw.nested, raw)
-			c.types = append(c.types, raw)
-
-			// Construct the fields and attach them to ty.
-			makeField := func(name string, number int32) {
-				fqn := fqn.Append(name)
-
-				id := c.arenas.members.NewCompressed(rawMember{
-					name:   c.session.intern.Intern(name),
-					fqn:    c.session.intern.Intern(string(fqn)),
-					parent: c.arenas.types.Compress(ty.raw),
-					number: number,
-					oneof:  -int32(presence.Explicit),
-				})
-
-				ty.raw.members = slices.Insert(ty.raw.members, int(ty.raw.extnsStart), id)
-				ty.raw.extnsStart++
-			}
-
-			makeField("key", 1)
-			makeField("value", 2)
-
-			// Update the field to be a repeated field of the given type.
-			field.raw.elem.ptr = raw
-			field.raw.oneof = -int32(presence.Repeated)
+			lowerField(field)
 		}
 	}
 
 	for extn := range seq.Values(f.AllExtensions()) {
 		k, _ := extn.AST().Type().RemovePrefixes().AsGeneric().AsMap()
-		if !k.IsZero() {
-			r.Errorf("unsupported map-typed extension").Apply(
-				report.Snippetf(extn.AST().Type(), "declared here"),
-				report.Helpf("extensions cannot be map-typed; instead, "+
-					"define a message type with a map-typed field"),
-			)
+		if k.IsZero() {
 			continue
 		}
+
+		r.Errorf("unsupported map-typed extension").Apply(
+			report.Snippetf(extn.AST().Type(), "declared here"),
+			report.Helpf("extensions cannot be map-typed; instead, "+
+				"define a message type with a map-typed field"),
+		)
+		lowerField(extn)
 	}
 }

--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -24,9 +24,65 @@ import (
 	"github.com/bufbuild/protocompile/experimental/ir/presence"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/experimental/token/keyword"
 	"github.com/bufbuild/protocompile/internal/arena"
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
+	"github.com/bufbuild/protocompile/internal/intern"
 )
+
+// resolveEarlyOptions resolves options whose values must be discovered very
+// early during compilation. This does not create option values, nor does it
+// generate diagnostics; it simply records this information to special fields
+// in [Type].
+func resolveEarlyOptions(f File) {
+	builtins := &f.Context().session.builtins
+	for ty := range seq.Values(f.AllTypes()) {
+		for decl := range seq.Values(ty.AST().Body().Decls()) {
+			def := decl.AsDef()
+			if def.IsZero() || def.Classify() != ast.DefKindOption {
+				continue
+			}
+			option := def.AsOption().Option
+
+			// If this option's path has more than one component, skip.
+			first, ok := iterx.OnlyOne(option.Path.Components)
+			if !ok || !first.Separator().IsZero() {
+				continue
+			}
+
+			// Resolve the name of this option.
+			var name intern.ID
+			if ident := first.AsIdent(); !ident.IsZero() {
+				switch ident.Text() {
+				case "message_set_wire_format":
+					name = builtins.MessageSet
+				case "allow_alias":
+					name = builtins.AllowAlias
+				}
+			} else if extn := first.AsExtension(); !extn.IsZero() {
+				sym, _ := f.Context().imported.resolve(
+					f.Context(),
+					ty.Scope(),
+					FullName(extn.Canonicalized()),
+					nil,
+					nil,
+				)
+				name = wrapSymbol(f.Context(), sym).AsMember().InternedFullName()
+			}
+
+			// Get the value of this option. We only care about a value of
+			// "true" for both options.
+			value := option.Value.AsPath().AsKeyword() == keyword.True
+
+			switch name {
+			case builtins.MessageSet:
+				ty.raw.isMessageSet = ty.IsMessage() && value
+			case builtins.AllowAlias:
+				ty.raw.allowsAlias = ty.IsEnum() && value
+			}
+		}
+	}
+}
 
 // resolveOptions resolves all of the options in a file.
 func resolveOptions(f File, r *report.Report) {

--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -1,0 +1,95 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir
+
+import (
+	"github.com/bufbuild/protocompile/experimental/ast"
+	"github.com/bufbuild/protocompile/experimental/ast/syntax"
+	"github.com/bufbuild/protocompile/experimental/internal/taxa"
+	"github.com/bufbuild/protocompile/experimental/ir/presence"
+	"github.com/bufbuild/protocompile/experimental/report"
+	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/experimental/token/keyword"
+	"github.com/bufbuild/protocompile/internal/ext/iterx"
+)
+
+// validateConstraints validates miscellaneous constraints that depend on the
+// whole IR being constructed properly.
+func validateConstraints(f File, r *report.Report) {
+	builtins := f.Context().builtins()
+
+	for ty := range seq.Values(f.Types()) {
+		for member := range seq.Values(ty.Members()) {
+			if ty.IsMessageSet() {
+				r.Errorf("field declared in %s `%s`", taxa.MessageSet, ty.FullName()).Apply(
+					report.Snippet(member.AST()),
+					report.Snippetf(ty.Options().Field(builtins.MessageSet).MessageKeys().At(0), "declared as message set here"),
+					report.Helpf("message set types may only declare extension ranges"),
+				)
+			}
+		}
+
+		if ty.IsMessageSet() {
+			if f.Syntax() == syntax.Proto3 {
+				r.Errorf("%s are not supported", taxa.MessageSet).Apply(
+					report.Snippet(ty.AST()),
+					report.Snippetf(ty.Options().Field(builtins.MessageSet).MessageKeys().At(0), "declared as message set here"),
+					report.Snippetf(f.AST().Syntax().Value(), "\"proto3\" specified here"),
+					report.Helpf("%ss cannot be defined in \"proto3\" only", taxa.MessageSet),
+					report.Helpf("%ss are not implemented correctly in most Protobuf implementations", taxa.MessageSet),
+				)
+			} else {
+				r.Warnf("%ss are deprecated", taxa.MessageSet).Apply(
+					report.Snippet(ty.AST()),
+					report.Snippetf(ty.Options().Field(builtins.MessageSet).MessageKeys().At(0), "declared as message set here"),
+					report.Helpf("%ss are not implemented correctly in most Protobuf implementations", taxa.MessageSet),
+				)
+			}
+
+			if ty.ExtensionRanges().Len() == 0 {
+				r.Errorf("%s `%s` declares no %ss", taxa.MessageSet, ty.FullName(), taxa.Extensions).Apply(
+					report.Snippet(ty.AST()),
+					report.Snippetf(ty.Options().Field(builtins.MessageSet).MessageKeys().At(0), "declared as message set here"),
+				)
+			}
+		}
+	}
+
+	for extn := range seq.Values(f.AllExtensions()) {
+		extendee := extn.Container()
+		if extendee.IsMessageSet() && !extn.IsMap() {
+			// NOTE: extensions already cannot be map fields, so we don't need to diagnose them.
+
+			if extn.Presence() == presence.Repeated {
+				_, repeated := iterx.Find(extn.AST().Type().Prefixes(), func(ty ast.TypePrefixed) bool {
+					return ty.Prefix() == keyword.Repeated
+				})
+
+				r.Errorf("repeated message set extension").Apply(
+					report.Snippet(repeated.PrefixToken()),
+					report.Snippetf(extendee.Options().Field(builtins.MessageSet).MessageKeys().At(0), "declared as message set here"),
+					report.Helpf("message set extensions must be singular message fields"),
+				)
+			}
+			if !extn.Element().IsMessage() {
+				r.Errorf("non-message message set extension").Apply(
+					report.Snippet(extn.AST().Type().RemovePrefixes()),
+					report.Snippetf(extendee.Options().Field(builtins.MessageSet).MessageKeys().At(0), "declared as message set here"),
+					report.Helpf("message set extensions must be singular message fields"),
+				)
+			}
+		}
+	}
+}

--- a/experimental/ir/testdata/extend/message_set.proto
+++ b/experimental/ir/testdata/extend/message_set.proto
@@ -1,0 +1,45 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package google.protobuf.test; // To make sure early option rez works correctly.
+
+import "google/protobuf/descriptor.proto";
+
+message M1 {
+    option message_set_wire_format = true;
+}
+
+message M2 {
+    option (MessageOptions.message_set_wire_format) = true;
+    optional int32 x = 1;
+}
+
+message M3 {
+    option (protobuf.MessageOptions.message_set_wire_format) = true;
+    extensions 1 to max;
+    extensions 0x7fffffff;
+}
+
+extend M3 {
+    optional M1 m1 = 1;
+    repeated M2 m2 = 2;
+    optional int32 m3 = 3;
+
+    map<string, string> m4 = 4;
+
+    optional M3 m5 = 0x7fffffff;
+    optional M3 m6 = 0xffffffff;
+}

--- a/experimental/ir/testdata/extend/message_set.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/message_set.proto.fds.yaml
@@ -1,0 +1,54 @@
+file:
+- name: "testdata/extend/message_set.proto"
+  package: "google.protobuf.test"
+  dependency: ["google/protobuf/descriptor.proto"]
+  message_type:
+  - { name: "M1", options.message_set_wire_format: true }
+  - name: "M2"
+    field: [{ name: "x", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }]
+    options.message_set_wire_format: true
+  - name: "M3"
+    extension_range: [{ start: 1, end: 2147483647 }, { start: 0, end: 1 }]
+    options.message_set_wire_format: true
+  - name: "M4Entry"
+    field:
+    - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_STRING }
+    - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_STRING }
+    options.map_entry: true
+  extension:
+  - name: "m1"
+    number: 1
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".google.protobuf.test.M1"
+    extendee: ".google.protobuf.test.M3"
+  - name: "m2"
+    number: 2
+    label: LABEL_REPEATED
+    type: TYPE_MESSAGE
+    type_name: ".google.protobuf.test.M2"
+    extendee: ".google.protobuf.test.M3"
+  - name: "m3"
+    number: 3
+    label: LABEL_OPTIONAL
+    type: TYPE_INT32
+    extendee: ".google.protobuf.test.M3"
+  - name: "m4"
+    number: 4
+    label: LABEL_REPEATED
+    type: TYPE_MESSAGE
+    type_name: ".google.protobuf.test.M4Entry"
+    extendee: ".google.protobuf.test.M3"
+  - name: "m5"
+    number: 2147483646
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".google.protobuf.test.M3"
+    extendee: ".google.protobuf.test.M3"
+  - name: "m6"
+    number: 2147483646
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".google.protobuf.test.M3"
+    extendee: ".google.protobuf.test.M3"
+  syntax: "proto2"

--- a/experimental/ir/testdata/extend/message_set.proto.stderr.txt
+++ b/experimental/ir/testdata/extend/message_set.proto.stderr.txt
@@ -1,0 +1,154 @@
+error: message set type `google.protobuf.test.M1` declares no extension ranges
+  --> testdata/extend/message_set.proto:21:1
+   |
+21 | / message M1 {
+22 | |     option message_set_wire_format = true;
+   | |            ----------------------- declared as message set here
+23 | | }
+   | \_^
+
+warning: message set types are deprecated
+  --> testdata/extend/message_set.proto:21:1
+   |
+21 | / message M1 {
+22 | |     option message_set_wire_format = true;
+   | |            ----------------------- declared as message set here
+23 | | }
+   | \_^
+   = help: message set types are not implemented correctly in most Protobuf
+           implementations
+
+error: message set type `google.protobuf.test.M2` declares no extension ranges
+  --> testdata/extend/message_set.proto:25:1
+   |
+25 | / message M2 {
+26 | |     option (MessageOptions.message_set_wire_format) = true;
+   | |            ---------------------------------------- declared as message set here
+27 | |     optional int32 x = 1;
+28 | | }
+   | \_^
+
+warning: message set types are deprecated
+  --> testdata/extend/message_set.proto:25:1
+   |
+25 | / message M2 {
+26 | |     option (MessageOptions.message_set_wire_format) = true;
+   | |            ---------------------------------------- declared as message set here
+27 | |     optional int32 x = 1;
+28 | | }
+   | \_^
+   = help: message set types are not implemented correctly in most Protobuf
+           implementations
+
+warning: redundant custom option setting syntax
+   --> testdata/extend/message_set.proto:26:12
+    |
+ 26 |     option (MessageOptions.message_set_wire_format) = true;
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this field is not a message extension
+   ::: google/protobuf/descriptor.proto:600:17
+    |
+600 |   optional bool message_set_wire_format = 1 [default = false];
+    |                 ----------------------- field declared inside of `google.protobuf.MessageOptions` here
+   ::: testdata/extend/message_set.proto:26:12
+   help: replace `(...)` with a field name
+    |
+ 26 | -     option (MessageOptions.message_set_wire_format) = true;
+ 26 | +     option message_set_wire_format = true;
+    |
+    = help: custom option setting syntax should only be used with message
+            extensions
+
+error: field declared in message set type `google.protobuf.test.M2`
+  --> testdata/extend/message_set.proto:27:5
+   |
+26 |     option (MessageOptions.message_set_wire_format) = true;
+   |            ---------------------------------------- declared as message set here
+27 |     optional int32 x = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: message set types may only declare extension ranges
+
+warning: message set types are deprecated
+  --> testdata/extend/message_set.proto:30:1
+   |
+30 | / message M3 {
+31 | |     option (protobuf.MessageOptions.message_set_wire_format) = true;
+   | |            ------------------------------------------------- declared as message set here
+32 | |     extensions 1 to max;
+33 | |     extensions 0x7fffffff;
+34 | | }
+   | \_^
+   = help: message set types are not implemented correctly in most Protobuf
+           implementations
+
+warning: redundant custom option setting syntax
+   --> testdata/extend/message_set.proto:31:12
+    |
+ 31 |     option (protobuf.MessageOptions.message_set_wire_format) = true;
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this field is not a message extension
+   ::: google/protobuf/descriptor.proto:600:17
+    |
+600 |   optional bool message_set_wire_format = 1 [default = false];
+    |                 ----------------------- field declared inside of `google.protobuf.MessageOptions` here
+   ::: testdata/extend/message_set.proto:31:12
+   help: replace `(...)` with a field name
+    |
+ 31 | -     option (protobuf.MessageOptions.message_set_wire_format) = true;
+ 31 | +     option message_set_wire_format = true;
+    |
+    = help: custom option setting syntax should only be used with message
+            extensions
+
+error: literal out of range for message set extension number
+  --> testdata/extend/message_set.proto:33:16
+   |
+33 |     extensions 0x7fffffff;
+   |                ^^^^^^^^^^
+   = note: the range for message set extension number is `0x0 to 0x7ffffffe`
+
+error: repeated message set extension
+  --> testdata/extend/message_set.proto:38:5
+   |
+31 |     option (protobuf.MessageOptions.message_set_wire_format) = true;
+   |            ------------------------------------------------- declared as message set here
+32 |     extensions 1 to max;
+...
+37 |     optional M1 m1 = 1;
+38 |     repeated M2 m2 = 2;
+   |     ^^^^^^^^
+   = help: message set extensions must be singular message fields
+
+error: non-message message set extension
+  --> testdata/extend/message_set.proto:39:14
+   |
+31 |     option (protobuf.MessageOptions.message_set_wire_format) = true;
+   |            ------------------------------------------------- declared as message set here
+32 |     extensions 1 to max;
+...
+38 |     repeated M2 m2 = 2;
+39 |     optional int32 m3 = 3;
+   |              ^^^^^
+   = help: message set extensions must be singular message fields
+
+error: unsupported map-typed extension
+  --> testdata/extend/message_set.proto:41:5
+   |
+41 |     map<string, string> m4 = 4;
+   |     ^^^^^^^^^^^^^^^^^^^ declared here
+   = help: extensions cannot be map-typed; instead, define a message type with a
+           map-typed field
+
+error: literal out of range for message set extension number
+  --> testdata/extend/message_set.proto:43:22
+   |
+43 |     optional M3 m5 = 0x7fffffff;
+   |                      ^^^^^^^^^^
+   = note: the range for message set extension number is `0x0 to 0x7ffffffe`
+
+error: literal out of range for message set extension number
+  --> testdata/extend/message_set.proto:44:22
+   |
+44 |     optional M3 m6 = 0xffffffff;
+   |                      ^^^^^^^^^^
+   = note: the range for message set extension number is `0x0 to 0x7ffffffe`
+
+encountered 9 errors and 5 warnings

--- a/experimental/ir/testdata/extend/message_set.proto.symtab.yaml
+++ b/experimental/ir/testdata/extend/message_set.proto.symtab.yaml
@@ -1,0 +1,76 @@
+tables:
+  "testdata/extend/message_set.proto":
+    imports: [{ path: "google/protobuf/descriptor.proto", visible: true }]
+    symbols:
+    - fqn: "google.protobuf.test"
+      kind: KIND_PACKAGE
+      file: "testdata/extend/message_set.proto"
+    - fqn: "google.protobuf.test.M1"
+      kind: KIND_MESSAGE
+      file: "testdata/extend/message_set.proto"
+      index: 1
+      visible: true
+      options.message.fields: { "message_set_wire_format": { bool: true } }
+    - fqn: "google.protobuf.test.M2"
+      kind: KIND_MESSAGE
+      file: "testdata/extend/message_set.proto"
+      index: 2
+      visible: true
+      options.message.fields: { "message_set_wire_format": { bool: true } }
+    - fqn: "google.protobuf.test.M3"
+      kind: KIND_MESSAGE
+      file: "testdata/extend/message_set.proto"
+      index: 3
+      visible: true
+      options.message.fields: { "message_set_wire_format": { bool: true } }
+    - fqn: "google.protobuf.test.M4Entry"
+      kind: KIND_MESSAGE
+      file: "testdata/extend/message_set.proto"
+      index: 4
+      visible: true
+      options.message.fields: { "map_entry": { bool: true } }
+    - fqn: "google.protobuf.test.M2.x"
+      kind: KIND_FIELD
+      file: "testdata/extend/message_set.proto"
+      index: 1
+      visible: true
+    - fqn: "google.protobuf.test.M4Entry.key"
+      kind: KIND_FIELD
+      file: "testdata/extend/message_set.proto"
+      index: 8
+      visible: true
+    - fqn: "google.protobuf.test.M4Entry.value"
+      kind: KIND_FIELD
+      file: "testdata/extend/message_set.proto"
+      index: 9
+      visible: true
+    - fqn: "google.protobuf.test.m1"
+      kind: KIND_EXTENSION
+      file: "testdata/extend/message_set.proto"
+      index: 2
+      visible: true
+    - fqn: "google.protobuf.test.m2"
+      kind: KIND_EXTENSION
+      file: "testdata/extend/message_set.proto"
+      index: 3
+      visible: true
+    - fqn: "google.protobuf.test.m3"
+      kind: KIND_EXTENSION
+      file: "testdata/extend/message_set.proto"
+      index: 4
+      visible: true
+    - fqn: "google.protobuf.test.m4"
+      kind: KIND_EXTENSION
+      file: "testdata/extend/message_set.proto"
+      index: 5
+      visible: true
+    - fqn: "google.protobuf.test.m5"
+      kind: KIND_EXTENSION
+      file: "testdata/extend/message_set.proto"
+      index: 6
+      visible: true
+    - fqn: "google.protobuf.test.m6"
+      kind: KIND_EXTENSION
+      file: "testdata/extend/message_set.proto"
+      index: 7
+      visible: true

--- a/experimental/ir/testdata/extend/message_set_proto3.proto
+++ b/experimental/ir/testdata/extend/message_set_proto3.proto
@@ -1,0 +1,22 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+message M1 {
+    option message_set_wire_format = true;
+    extensions 1 to max;
+}

--- a/experimental/ir/testdata/extend/message_set_proto3.proto.fds.yaml
+++ b/experimental/ir/testdata/extend/message_set_proto3.proto.fds.yaml
@@ -1,0 +1,8 @@
+file:
+- name: "testdata/extend/message_set_proto3.proto"
+  package: "test"
+  message_type:
+  - name: "M1"
+    extension_range: [{ start: 1, end: 2147483647 }]
+    options.message_set_wire_format: true
+  syntax: "proto3"

--- a/experimental/ir/testdata/extend/message_set_proto3.proto.stderr.txt
+++ b/experimental/ir/testdata/extend/message_set_proto3.proto.stderr.txt
@@ -1,0 +1,23 @@
+error: extension ranges are not permitted in proto3
+  --> testdata/extend/message_set_proto3.proto:21:5
+   |
+21 |     extensions 1 to max;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: message set type are not supported
+  --> testdata/extend/message_set_proto3.proto:19:1
+   |
+15 |   syntax = "proto3";
+   |            -------- "proto3" specified here
+...
+19 | / message M1 {
+20 | |     option message_set_wire_format = true;
+   | |            ----------------------- declared as message set here
+21 | |     extensions 1 to max;
+22 | | }
+   | \_^
+   = help: message set types cannot be defined in "proto3" only
+   = help: message set types are not implemented correctly in most Protobuf
+           implementations
+
+encountered 2 errors

--- a/experimental/ir/testdata/extend/message_set_proto3.proto.symtab.yaml
+++ b/experimental/ir/testdata/extend/message_set_proto3.proto.symtab.yaml
@@ -1,0 +1,12 @@
+tables:
+  "testdata/extend/message_set_proto3.proto":
+    symbols:
+    - fqn: "test"
+      kind: KIND_PACKAGE
+      file: "testdata/extend/message_set_proto3.proto"
+    - fqn: "test.M1"
+      kind: KIND_MESSAGE
+      file: "testdata/extend/message_set_proto3.proto"
+      index: 1
+      visible: true
+      options.message.fields: { "message_set_wire_format": { bool: true } }

--- a/experimental/ir/testdata/fields/maps/extension.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/extension.proto.fds.yaml
@@ -1,6 +1,18 @@
 file:
 - name: "testdata/fields/maps/extension.proto"
   package: "test"
-  message_type: [{ name: "Foo", extension_range: [{ start: 1, end: 2 }] }]
-  extension: [{ name: "m", number: 1 }]
+  message_type:
+  - { name: "Foo", extension_range: [{ start: 1, end: 2 }] }
+  - name: "MEntry"
+    field:
+    - { name: "key", number: 1, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+    - { name: "value", number: 2, label: LABEL_OPTIONAL, type: TYPE_INT32 }
+    options.map_entry: true
+  extension:
+  - name: "m"
+    number: 1
+    label: LABEL_REPEATED
+    type: TYPE_MESSAGE
+    type_name: ".test.MEntry"
+    extendee: ".test.Foo"
   syntax: "proto2"

--- a/experimental/ir/testdata/fields/maps/extension.proto.symtab.yaml
+++ b/experimental/ir/testdata/fields/maps/extension.proto.symtab.yaml
@@ -9,6 +9,22 @@ tables:
       file: "testdata/fields/maps/extension.proto"
       index: 1
       visible: true
+    - fqn: "test.MEntry"
+      kind: KIND_MESSAGE
+      file: "testdata/fields/maps/extension.proto"
+      index: 2
+      visible: true
+      options.message.fields: { "map_entry": { bool: true } }
+    - fqn: "test.MEntry.key"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/extension.proto"
+      index: 2
+      visible: true
+    - fqn: "test.MEntry.value"
+      kind: KIND_FIELD
+      file: "testdata/fields/maps/extension.proto"
+      index: 3
+      visible: true
     - fqn: "test.m"
       kind: KIND_EXTENSION
       file: "testdata/fields/maps/extension.proto"

--- a/experimental/ir/testdata/imports/ok.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/ok.proto.yaml.stderr.txt
@@ -1,9 +1,9 @@
-warning: use of `import weak`
+warning: `import weak` is deprecated
   --> main.proto:6:1
    |
  6 | import weak "c.proto";
    | ^^^^^^^^^^^
-   = help: `import weak` is deprecated and not supported correctly in most
-           Protobuf implementations
+   = help: `import weak` is not implemented correctly in most Protobuf
+           implementations
 
 encountered 1 warning

--- a/experimental/parser/legalize_def.go
+++ b/experimental/parser/legalize_def.go
@@ -231,7 +231,7 @@ func legalizeFieldLike(p *parser, what taxa.Noun, def ast.DeclDef, parent classi
 				report.Notef("group syntax is not available in proto3 or editions"),
 			)
 		} else {
-			p.Errorf("groups syntax is not supported").Apply(
+			p.Errorf("group syntax is not supported").Apply(
 				report.Snippet(def.Type().RemovePrefixes()),
 				report.Notef("group syntax is only available in proto2"),
 			)

--- a/experimental/parser/legalize_file.go
+++ b/experimental/parser/legalize_file.go
@@ -375,10 +375,9 @@ func legalizeImport(p *parser, parent classified, decl ast.DeclImport) {
 		case keyword.Public:
 
 		case keyword.Weak:
-			p.Warnf("use of `import weak`").Apply(
+			p.Warnf("`import weak` is deprecated").Apply(
 				report.Snippet(report.Join(decl.KeywordToken(), mod)),
-				report.Helpf("`import weak` is deprecated and not supported correctly "+
-					"in most Protobuf implementations"),
+				report.Helpf("`import weak` is not implemented correctly in most Protobuf implementations"),
 			)
 
 		case keyword.Option:


### PR DESCRIPTION
This PR adds verification for the following features of a message set type:

1. No fields.
2. At least one extension range.
3. Extensions are singular messages.

It also fixes message set number ranges to exclude `0x7fff_ffff`, which is not part of the valid range.

This also fixes how we look up `message_set_wire_format` to be more robust (this also applies to `allow_alias`).