### PR TITLE
Append expressions when lowering options

### DIFF
--- a/experimental/ir/lower_options.go
+++ b/experimental/ir/lower_options.go
@@ -600,6 +600,7 @@ func (r optionRef) resolve() {
 
 		value := newMessage(r.Context, field.toRef(r.Context)).AsValue()
 		value.raw.optionPaths = append(value.raw.optionPaths, path)
+		value.raw.exprs = append(value.raw.exprs, ast.ExprPath{Path: path}.AsAny())
 
 		*raw = r.arenas.values.Compress(value.raw)
 		current = value


### PR DESCRIPTION
This fixes a bug when lowering options, we are appending the 
option paths, but not the expressions.