### PR TITLE
Use ring buffer queue for cycle check

### DIFF
--- a/experimental/incremental/executor.go
+++ b/experimental/incremental/executor.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/internal/ext/mapsx"
+	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 )
 
 // Executor is a caching executor for incremental queries.
@@ -39,6 +40,7 @@ type Executor struct {
 	// It also protects access to tasks and their dependency relationships during updates.
 	lock  sync.Mutex
 	tasks map[any]*task
+	queue slicesx.Queue[*task] // queue is scratch space for cycle detection.
 
 	sema *semaphore.Weighted
 

--- a/internal/ext/bitsx/bitsx.go
+++ b/internal/ext/bitsx/bitsx.go
@@ -1,0 +1,48 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bitsx contains extensions to Go's package math/bits.
+package bitsx
+
+import (
+	"math"
+	"math/bits"
+)
+
+// IsPowerOfTwo returns whether n is a power of 2.
+func IsPowerOfTwo(n uint) bool {
+	// See https://github.com/mcy/best/blob/2d94f6b23aecddc46f792edb4c45800aa58074ca/best/math/bit.h#L147
+	return bits.OnesCount(n) == 1
+}
+
+// NextPowerOfTwo returns the next power of 2 after n, or zero if n is greater
+// than the largest power of 2.
+func NextPowerOfTwo(n uint) uint {
+	// For n == 0, LeadingZeros returns 64, and Go does not mask the shift
+	// amount, so -1 >> 64 is zero, which produces the correct answer.
+	//
+	// If LeadingZeros produces 0 (i.e., the highest bit is set, so it's
+	// larger than the largest power of 2) this addition will overflow back to
+	// 0 as desired.
+	return uint(math.MaxUint)>>uint(bits.LeadingZeros(n)) + 1
+}
+
+// MakePowerOfTwo snaps n to a power of 2: i.e., if it isn't already one,
+// replaces it with the next power of two.
+func MakePowerOfTwo(n uint) uint {
+	if IsPowerOfTwo(n) {
+		return n
+	}
+	return NextPowerOfTwo(n)
+}

--- a/internal/ext/slicesx/queue.go
+++ b/internal/ext/slicesx/queue.go
@@ -1,0 +1,247 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slicesx
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+
+	"github.com/bufbuild/protocompile/internal/ext/bitsx"
+	"github.com/bufbuild/protocompile/internal/ext/iterx"
+)
+
+// Set to true to enable debug printing for queues.
+const debugQueue = false
+
+// Queue is a ring buffer.
+//
+// Values can be pushed and popped from either the front or the back of the
+// buffer, making it usable as a double-ended queue.
+//
+// A zero [Queue] is empty and ready to use.
+type Queue[E any] struct {
+	buf        []E // Invariant: cap(buf) is always a power of 2, or zero.
+	start, end int
+}
+
+// NewRing returns a [Queue] with the given capacity.
+func NewRing[E any](capacity int) *Queue[E] {
+	if capacity == 0 {
+		return &Queue[E]{}
+	}
+
+	capacity = int(bitsx.MakePowerOfTwo(uint(capacity)))
+	return &Queue[E]{buf: make([]E, capacity)}
+}
+
+// Len returns the number of elements currently in the buffer.
+func (r *Queue[E]) Len() int {
+	// The in-use part wraps around the end of the buffer.
+	//
+	// |xxx------xxxx|     len: 13
+	//     ^end  ^start    start: 9
+	//                     end: 3
+	//
+	// Len() = len - start + end = 13 - 9 + 3 = 7
+	if r.start > r.end {
+		return len(r.buf) - r.start + r.end
+	}
+
+	// The in-use part doesn't wrap around.
+	//
+	// |---xxxxxxx---|     len: 13
+	//     ^start ^end     start: 3
+	//                     end: 10
+	//
+	// Len() = end - start = 10 - 3 = 7
+	return r.end - r.start
+}
+
+// Cap returns the capacity of the buffer, i.e., the number of elements it can
+// hold before being resized.
+func (r *Queue[E]) Cap() int {
+	if len(r.buf) == 0 {
+		return 0
+	}
+	return len(r.buf) - 1
+}
+
+// Reserve ensures that the capacity is large enough to push an additional n
+// elements.
+func (r *Queue[E]) Reserve(n int) {
+	if r.Len()+n <= r.Cap() {
+		return
+	}
+	r.resize(int(bitsx.MakePowerOfTwo(uint(r.Cap() + n))))
+}
+
+// Front returns a pointer to the element at the front of the queue.
+func (r *Queue[E]) Front() *E {
+	if r.start == r.end {
+		return nil
+	}
+	return &r.buf[r.start]
+}
+
+// Back returns a pointer to the element at the back of the queue.
+func (r *Queue[E]) Back() *E {
+	if r.start == r.end {
+		return nil
+	}
+	return &r.buf[r.end-1]
+}
+
+// PushFront pushes elements to the front of the queue.
+func (r *Queue[E]) PushFront(v ...E) {
+	r.Reserve(len(v))
+
+	end := r.start
+	start := end - len(v)
+	r.start = start & (len(r.buf) - 1)
+	if start < r.start {
+		// We overflowed, so we need to do two copies.
+		copy(r.buf[r.start:], v)
+		copy(r.buf, v[len(r.buf[r.start:]):])
+	} else {
+		copy(r.buf[r.start:end], v)
+	}
+}
+
+// PushBack pushes elements to the back of the queue.
+func (r *Queue[E]) PushBack(v ...E) {
+	r.Reserve(len(v))
+
+	start := r.end
+	end := start + len(v)
+	r.end = end & (len(r.buf) - 1)
+	if r.end < end {
+		// We overflowed, so we need to do two copies.
+		copy(r.buf[start:], v)
+		copy(r.buf, v[len(r.buf[start:]):])
+	} else {
+		copy(r.buf[start:r.end], v)
+	}
+}
+
+// Front pops the element at the front of the queue.
+func (r *Queue[E]) PopFront() (E, bool) {
+	if r.start == r.end {
+		var z E
+		return z, false
+	}
+	v, _ := Take(r.buf, r.start)
+	r.start++
+	r.start &= len(r.buf) - 1
+	return v, true
+}
+
+// Front pops the element at the back of the queue.
+func (r *Queue[E]) PopBack() (E, bool) {
+	if r.start == r.end {
+		var z E
+		return z, false
+	}
+	r.end--
+	r.end &= len(r.buf) - 1
+	return Take(r.buf, r.end)
+}
+
+// Values returns an iterator over the elements of the queue.
+func (r *Queue[E]) Values() iter.Seq[E] {
+	return func(yield func(E) bool) {
+		if r.start <= r.end {
+			for _, v := range r.buf[r.start:r.end] {
+				if !yield(v) {
+					return
+				}
+			}
+			return
+		}
+		for _, v := range r.buf[r.start:] {
+			if !yield(v) {
+				return
+			}
+		}
+		for _, v := range r.buf[:r.end] {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// Format implements [fmt.Formatter].
+func (r Queue[E]) Format(out fmt.State, verb rune) {
+	if out.Flag('#') {
+		fmt.Fprintf(out, "%T{", r)
+	} else {
+		fmt.Fprint(out, "[")
+	}
+
+	if debugQueue {
+		for i, v := range slices.All(r.buf) {
+			if i > 0 {
+				if out.Flag('#') {
+					fmt.Fprint(out, ", ")
+				} else {
+					fmt.Fprint(out, " ")
+				}
+			}
+			if i == r.start {
+				fmt.Fprint(out, ">")
+				if i == r.end {
+					fmt.Fprint(out, "< ")
+				}
+			}
+			fmt.Fprintf(out, fmt.FormatString(out, verb), v)
+			if r.start != r.end && i == r.end-1 {
+				fmt.Fprint(out, "<")
+			}
+		}
+	} else {
+		for i, v := range iterx.Enumerate(r.Values()) {
+			if i > 0 {
+				if out.Flag('#') {
+					fmt.Fprint(out, ", ")
+				} else {
+					fmt.Fprint(out, " ")
+				}
+			}
+			fmt.Fprintf(out, fmt.FormatString(out, verb), v)
+		}
+	}
+
+	if out.Flag('#') {
+		fmt.Fprint(out, "}", r)
+	} else {
+		fmt.Fprint(out, "]")
+	}
+}
+
+func (r *Queue[E]) resize(n int) {
+	count := r.Len()
+
+	old := r.buf
+	r.buf = make([]E, n)
+	if r.start > r.end {
+		copy(r.buf, old[r.start:])
+		copy(r.buf[r.start:], old[:r.end])
+	} else {
+		copy(r.buf, old[r.start:r.end])
+	}
+	r.start = 0
+	r.end = count
+}

--- a/internal/ext/slicesx/queue.go
+++ b/internal/ext/slicesx/queue.go
@@ -43,8 +43,9 @@ func NewRing[E any](capacity int) *Queue[E] {
 		return &Queue[E]{}
 	}
 
-	capacity = int(bitsx.MakePowerOfTwo(uint(capacity)))
-	return &Queue[E]{buf: make([]E, capacity)}
+	// Buffer length must be capacity + 1 (one slot kept empty) and power of 2.
+	bufLen := int(bitsx.MakePowerOfTwo(uint(capacity + 1)))
+	return &Queue[E]{buf: make([]E, bufLen)}
 }
 
 // Len returns the number of elements currently in the buffer.
@@ -85,7 +86,9 @@ func (r *Queue[E]) Reserve(n int) {
 	if r.Len()+n <= r.Cap() {
 		return
 	}
-	r.resize(int(bitsx.MakePowerOfTwo(uint(r.Cap() + n))))
+	// Buffer length must be capacity + 1 (one slot kept empty) and power of 2.
+	newCap := r.Len() + n
+	r.resize(int(bitsx.MakePowerOfTwo(uint(newCap + 1))))
 }
 
 // Front returns a pointer to the element at the front of the queue.
@@ -229,6 +232,12 @@ func (r Queue[E]) Format(out fmt.State, verb rune) {
 	} else {
 		fmt.Fprint(out, "]")
 	}
+}
+
+// Clear clears the queue.
+func (r *Queue[_]) Clear() {
+	clear(r.buf)
+	r.start, r.end = 0, 0
 }
 
 func (r *Queue[E]) resize(n int) {

--- a/internal/ext/slicesx/queue_test.go
+++ b/internal/ext/slicesx/queue_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slicesx_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bufbuild/protocompile/internal/ext/slicesx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue(t *testing.T) {
+	t.Parallel()
+
+	type p struct {
+		v  int
+		ok bool
+	}
+	pack := func(v int, ok bool) p { return p{v, ok} }
+
+	var q slicesx.Queue[int]
+	q.PushBack(1, 2, 3)
+	assert.Equal(t, []int{1, 2, 3}, slices.Collect(q.Values()))
+	assert.Equal(t, 3, *q.Back())
+	assert.Equal(t, p{1, true}, pack(q.PopFront()))
+	assert.Equal(t, []int{2, 3}, slices.Collect(q.Values()))
+	assert.Equal(t, p{3, true}, pack(q.PopBack()))
+
+	q.PushFront(1, 2)
+	assert.Equal(t, []int{1, 2, 2}, slices.Collect(q.Values()))
+	assert.Equal(t, 2, *q.Back())
+	assert.Equal(t, p{1, true}, pack(q.PopFront()))
+	assert.Equal(t, []int{2, 2}, slices.Collect(q.Values()))
+	assert.Equal(t, p{2, true}, pack(q.PopBack()))
+	assert.Equal(t, p{2, true}, pack(q.PopBack()))
+}

--- a/internal/ext/slicesx/queue_test.go
+++ b/internal/ext/slicesx/queue_test.go
@@ -32,6 +32,14 @@ func TestQueue(t *testing.T) {
 	pack := func(v int, ok bool) p { return p{v, ok} }
 
 	var q slicesx.Queue[int]
+	q.PushBack(1)
+	assert.Equal(t, []int{1}, slices.Collect(q.Values()))
+	x, ok := q.PopFront()
+	assert.True(t, ok)
+	assert.Equal(t, 1, x)
+	_, ok = q.PopFront()
+	assert.False(t, ok)
+
 	q.PushBack(1, 2, 3)
 	assert.Equal(t, []int{1, 2, 3}, slices.Collect(q.Values()))
 	assert.Equal(t, 3, *q.Back())

--- a/internal/ext/slicesx/slicesx.go
+++ b/internal/ext/slicesx/slicesx.go
@@ -102,6 +102,20 @@ func LastIndexFunc[S ~[]E, E any](s S, p func(E) bool) int {
 	return -1
 }
 
+// Take is like Get, but zeros s[i] before returning.
+//
+// This is useful for cases where we are popping from a slice and we want
+// the popped value to be garbage collected once the caller drops it on the
+// ground.
+func Take[S ~[]E, E any, I SliceIndex](s S, i I) (element E, ok bool) {
+	p := GetPointer(s, i)
+	if p == nil {
+		return element, false
+	}
+	element, *p = *p, element
+	return element, true
+}
+
 // BoundsCheck performs a generic bounds check as efficiently as possible.
 //
 // This function assumes that len is the length of a slice, i.e, it is


### PR DESCRIPTION
Uses https://github.com/bufbuild/protocompile/pull/469 for cycle check. Fix "off by one" error in capacity calculation. The empty slot is used to distinguish between full and empty. Add a `Clear` method to reset the queue. 