### PR TITLE
Set a `ZeroQuery` for invalid imports in IR query

### DIFF
--- a/experimental/incremental/queries/ir.go
+++ b/experimental/incremental/queries/ir.go
@@ -92,7 +92,11 @@ func (i IR) Execute(t *incremental.Task) (ir.File, error) {
 		path, ok := decl.ImportPath().AsLiteral().AsString()
 		path = ir.CanonicalizeFilePath(path)
 
-		if !ok { // Already legalized in parser.legalizeImport()
+		if !ok {
+			// The import path is already legalized in [parser.legalizeImport()], if it is not
+			// a valid path, we just set a [incremental.ZeroQuery] so that we don't get a nil
+			// query for index j.
+			queries[j] = incremental.ZeroQuery[ir.File]{}
 			continue
 		}
 


### PR DESCRIPTION
Currently, for invalid import paths (e.g. an empty import path),
we are not setting any queries in our IR query. This results in a
`nil` query, which causes panics in the query execution.

We should instead be setting a `ZeroQuery` for that case.