### PR TITLE
Quick cleanup of message set validation in preparation for other changes

### DIFF
--- a/experimental/ast/decl_def.go
+++ b/experimental/ast/decl_def.go
@@ -178,6 +178,13 @@ func (d DeclDef) Name() Path {
 	return d.raw.name.With(d.Context())
 }
 
+// Stem returns a span that contains both this definition's type and name.
+//
+// For e.g. a message, this is the "message Foo" part.
+func (d DeclDef) Stem() report.Span {
+	return report.Join(d.Type(), d.Name())
+}
+
 // Signature returns this definition's type signature, if it has one.
 //
 // Note that this is distinct from the type returned by [DeclDef.Type], which

--- a/experimental/ir/ir_value.go
+++ b/experimental/ir/ir_value.go
@@ -16,7 +16,6 @@ package ir
 
 import (
 	"cmp"
-	"fmt"
 	"iter"
 	"math"
 	"slices"
@@ -474,26 +473,6 @@ func (v Value) marshal(buf []byte, r *report.Report, ranges *[][2]int) ([]byte, 
 	}
 
 	return buf, n
-}
-
-func (v Value) suggestEdit(path, expr string, format string, args ...any) report.DiagnosticOption {
-	key := v.KeyAST()
-	value := v.ValueASTs().At(0)
-	joined := report.Join(key, value)
-
-	return report.SuggestEdits(
-		joined,
-		fmt.Sprintf(format, args...),
-		report.Edit{
-			Start: 0, End: key.Span().Len(),
-			Replace: path,
-		},
-		report.Edit{
-			Start:   value.Span().Start - joined.Start,
-			End:     value.Span().End - joined.Start,
-			Replace: expr,
-		},
-	)
 }
 
 func wrapValue(c *Context, p arena.Pointer[rawValue]) Value {

--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal/taxa"
-	"github.com/bufbuild/protocompile/experimental/ir/presence"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/experimental/token/keyword"
@@ -45,68 +44,109 @@ func diagnoseUnusedImports(f File, r *report.Report) {
 // validateConstraints validates miscellaneous constraints that depend on the
 // whole IR being constructed properly.
 func validateConstraints(f File, r *report.Report) {
-	builtins := f.Context().builtins()
-
-	for ty := range seq.Values(f.Types()) {
-		for member := range seq.Values(ty.Members()) {
-			if ty.IsMessageSet() {
-				r.Errorf("field declared in %s `%s`", taxa.MessageSet, ty.FullName()).Apply(
-					report.Snippet(member.AST()),
-					report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
-					report.Helpf("message set types may only declare extension ranges"),
-				)
-			}
-		}
-
+	for ty := range seq.Values(f.AllTypes()) {
 		if ty.IsMessageSet() {
-			if f.Syntax() == syntax.Proto3 {
-				r.Errorf("%s are not supported", taxa.MessageSet).Apply(
-					report.Snippet(ty.AST()),
-					report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
-					report.Snippetf(f.AST().Syntax().Value(), "\"proto3\" specified here"),
-					report.Helpf("%ss cannot be defined in \"proto3\" only", taxa.MessageSet),
-					report.Helpf("%ss are not implemented correctly in most Protobuf implementations", taxa.MessageSet),
-				)
-			} else {
-				r.Warnf("%ss are deprecated", taxa.MessageSet).Apply(
-					report.Snippet(ty.AST()),
-					report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
-					report.Helpf("%ss are not implemented correctly in most Protobuf implementations", taxa.MessageSet),
-				)
-			}
-
-			if ty.ExtensionRanges().Len() == 0 {
-				r.Errorf("%s `%s` declares no %ss", taxa.MessageSet, ty.FullName(), taxa.Extensions).Apply(
-					report.Snippet(ty.AST()),
-					report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
-				)
-			}
+			validateMessageSet(ty, r)
 		}
 	}
 
-	for extn := range seq.Values(f.AllExtensions()) {
-		extendee := extn.Container()
-		if extendee.IsMessageSet() && !extn.IsMap() {
-			// NOTE: extensions already cannot be map fields, so we don't need to diagnose them.
-
-			if extn.Presence() == presence.Repeated {
-				_, repeated := iterx.Find(extn.AST().Type().Prefixes(), func(ty ast.TypePrefixed) bool {
-					return ty.Prefix() == keyword.Repeated
-				})
-
-				r.Errorf("repeated message set extension").Apply(
-					report.Snippet(repeated.PrefixToken()),
-					report.Snippetf(extendee.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
-					report.Helpf("message set extensions must be singular message fields"),
-				)
-			}
-			if !extn.Element().IsMessage() {
-				r.Errorf("non-message message set extension").Apply(
-					report.Snippet(extn.AST().Type().RemovePrefixes()),
-					report.Snippetf(extendee.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
-					report.Helpf("message set extensions must be singular message fields"),
-				)
+	for m := range f.AllMembers() {
+		// NOTE: extensions already cannot be map fields, so we don't need to
+		// validate them.
+		if m.IsExtension() && !m.IsMap() {
+			extendee := m.Container()
+			if extendee.IsMessageSet() {
+				validateMessageSetExtension(m, r)
 			}
 		}
+	}
+}
+
+func validateMessageSet(ty Type, r *report.Report) {
+	if !ty.IsMessageSet() {
+		return
+	}
+
+	f := ty.Context().File()
+	builtins := ty.Context().builtins()
+
+	if f.Syntax() == syntax.Proto3 {
+		r.Errorf("%s are not supported", taxa.MessageSet).Apply(
+			report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Snippet(ty.AST().Stem()),
+			report.PageBreak,
+			report.Snippetf(f.AST().Syntax().Value(), "\"proto3\" specified here"),
+			report.Helpf("%ss cannot be defined in \"proto3\" only", taxa.MessageSet),
+			report.Helpf("%ss are not implemented correctly in most Protobuf implementations", taxa.MessageSet),
+		)
+		return
+	}
+
+	ok := true
+
+	for member := range seq.Values(ty.Members()) {
+		ok = false
+		r.Errorf("field declared in %s `%s`", taxa.MessageSet, ty.FullName()).Apply(
+			report.Snippet(member.AST()),
+			report.PageBreak,
+			report.Snippet(ty.AST().Stem()),
+			report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Helpf("message set types may only declare extension ranges"),
+		)
+	}
+
+	for oneof := range seq.Values(ty.Oneofs()) {
+		ok = false
+		r.Errorf("field declared in %s `%s`", taxa.MessageSet, ty.FullName()).Apply(
+			report.Snippet(oneof.AST()),
+			report.PageBreak,
+			report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Snippet(ty.AST().Stem()),
+			report.Helpf("message set types may only declare extension ranges"),
+		)
+	}
+
+	if ty.ExtensionRanges().Len() == 0 {
+		ok = false
+		r.Errorf("%s `%s` declares no %ss", taxa.MessageSet, ty.FullName(), taxa.Extensions).Apply(
+			report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Snippet(ty.AST().Stem()),
+		)
+	}
+
+	if ok {
+		r.Warnf("%ss are deprecated", taxa.MessageSet).Apply(
+			report.Snippetf(ty.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Snippet(ty.AST().Stem()),
+			report.Helpf("%ss are not implemented correctly in most Protobuf implementations", taxa.MessageSet),
+		)
+	}
+}
+
+func validateMessageSetExtension(extn Member, r *report.Report) {
+	builtins := extn.Context().builtins()
+	extendee := extn.Container()
+	if extn.IsRepeated() {
+		_, repeated := iterx.Find(extn.AST().Type().Prefixes(), func(ty ast.TypePrefixed) bool {
+			return ty.Prefix() == keyword.Repeated
+		})
+
+		r.Errorf("repeated message set extension").Apply(
+			report.Snippet(repeated.PrefixToken()),
+			report.PageBreak,
+			report.Snippetf(extendee.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Snippet(extendee.AST().Stem()),
+			report.Helpf("message set extensions must be singular message fields"),
+		)
+	}
+
+	if !extn.Element().IsMessage() {
+		r.Errorf("non-message message set extension").Apply(
+			report.Snippet(extn.AST().Type().RemovePrefixes()),
+			report.PageBreak,
+			report.Snippetf(extendee.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
+			report.Snippet(extendee.AST().Stem()),
+			report.Helpf("message set extensions must be singular message fields"),
+		)
 	}
 }

--- a/experimental/ir/testdata/extend/message_set.proto.stderr.txt
+++ b/experimental/ir/testdata/extend/message_set.proto.stderr.txt
@@ -1,48 +1,20 @@
 error: message set type `google.protobuf.test.M1` declares no extension ranges
-  --> testdata/extend/message_set.proto:22:1
+  --> testdata/extend/message_set.proto:23:12
    |
-22 | / message M1 {
-23 | |     option message_set_wire_format = true;
-   | |            ----------------------- declared as message set here
-24 | | }
-   | \_^
-
-warning: message set types are deprecated
-  --> testdata/extend/message_set.proto:22:1
-   |
-22 | / message M1 {
-23 | |     option message_set_wire_format = true;
-   | |            ----------------------- declared as message set here
-24 | | }
-   | \_^
-   = help: message set types are not implemented correctly in most Protobuf
-           implementations
+22 | message M1 {
+   | ----------
+23 |     option message_set_wire_format = true;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^ declared as message set here
 
 error: message set type `google.protobuf.test.M2` declares no extension ranges
-  --> testdata/extend/message_set.proto:26:1
+  --> testdata/extend/message_set.proto:27:12
    |
-26 | / message M2 {
-27 | |     option (MessageOptions.message_set_wire_format) = true;
-   | |            ----------------------------------------
-   | |             |
-   | |             declared as message set here
-28 | |     optional int32 x = 1;
-29 | | }
-   | \_^
-
-warning: message set types are deprecated
-  --> testdata/extend/message_set.proto:26:1
-   |
-26 | / message M2 {
-27 | |     option (MessageOptions.message_set_wire_format) = true;
-   | |            ----------------------------------------
-   | |             |
-   | |             declared as message set here
-28 | |     optional int32 x = 1;
-29 | | }
-   | \_^
-   = help: message set types are not implemented correctly in most Protobuf
-           implementations
+26 | message M2 {
+   | ----------
+27 |     option (MessageOptions.message_set_wire_format) = true;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             declared as message set here
 
 warning: redundant custom option setting syntax
    --> testdata/extend/message_set.proto:27:12
@@ -72,26 +44,29 @@ warning: redundant custom option setting syntax
 error: field declared in message set type `google.protobuf.test.M2`
   --> testdata/extend/message_set.proto:28:5
    |
+28 |     optional int32 x = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+  ::: testdata/extend/message_set.proto:26:1
+   |
+26 | message M2 {
+   | ----------
 27 |     option (MessageOptions.message_set_wire_format) = true;
    |            ----------------------------------------
    |             |
    |             declared as message set here
-28 |     optional int32 x = 1;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
    = help: message set types may only declare extension ranges
 
 warning: message set types are deprecated
-  --> testdata/extend/message_set.proto:31:1
+  --> testdata/extend/message_set.proto:32:12
    |
-31 | / message M3 {
-32 | |     option (protobuf.MessageOptions.message_set_wire_format) = true;
-   | |            -------------------------------------------------
-   | |             |
-   | |             declared as message set here
-33 | |     extensions 1 to max;
-34 | |     extensions 0x7fffffff;
-35 | | }
-   | \_^
+31 | message M3 {
+   | ----------
+32 |     option (protobuf.MessageOptions.message_set_wire_format) = true;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             declared as message set here
+   |
    = help: message set types are not implemented correctly in most Protobuf
            implementations
 
@@ -130,29 +105,33 @@ error: literal out of range for message set extension number
 error: repeated message set extension
   --> testdata/extend/message_set.proto:39:5
    |
+39 |     repeated M2 m2 = 2;
+   |     ^^^^^^^^
+  ::: testdata/extend/message_set.proto:32:12
+   |
+31 | message M3 {
+   | ----------
 32 |     option (protobuf.MessageOptions.message_set_wire_format) = true;
    |            -------------------------------------------------
    |             |
    |             declared as message set here
-33 |     extensions 1 to max;
-...
-38 |     optional M1 m1 = 1;
-39 |     repeated M2 m2 = 2;
-   |     ^^^^^^^^
+   |
    = help: message set extensions must be singular message fields
 
 error: non-message message set extension
   --> testdata/extend/message_set.proto:40:14
    |
+40 |     optional int32 m3 = 3;
+   |              ^^^^^
+  ::: testdata/extend/message_set.proto:32:12
+   |
+31 | message M3 {
+   | ----------
 32 |     option (protobuf.MessageOptions.message_set_wire_format) = true;
    |            -------------------------------------------------
    |             |
    |             declared as message set here
-33 |     extensions 1 to max;
-...
-39 |     repeated M2 m2 = 2;
-40 |     optional int32 m3 = 3;
-   |              ^^^^^
+   |
    = help: message set extensions must be singular message fields
 
 error: unsupported map-typed extension
@@ -178,4 +157,4 @@ error: literal out of range for message set extension number
    |                      ^^^^^^^^^^
    = note: the range for message set extension number is `0x0 to 0x7ffffffe`
 
-encountered 9 errors and 5 warnings
+encountered 9 errors and 3 warnings

--- a/experimental/ir/testdata/extend/message_set_proto3.proto.stderr.txt
+++ b/experimental/ir/testdata/extend/message_set_proto3.proto.stderr.txt
@@ -5,17 +5,18 @@ error: extension ranges are not permitted in proto3
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: message set type are not supported
-  --> testdata/extend/message_set_proto3.proto:19:1
+  --> testdata/extend/message_set_proto3.proto:20:12
    |
-15 |   syntax = "proto3";
-   |            -------- "proto3" specified here
-...
-19 | / message M1 {
-20 | |     option message_set_wire_format = true;
-   | |            ----------------------- declared as message set here
-21 | |     extensions 1 to max;
-22 | | }
-   | \_^
+19 | message M1 {
+   | ----------
+20 |     option message_set_wire_format = true;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^ declared as message set here
+   |
+  ::: testdata/extend/message_set_proto3.proto:15:10
+   |
+15 | syntax = "proto3";
+   |          -------- "proto3" specified here
+   |
    = help: message set types cannot be defined in "proto3" only
    = help: message set types are not implemented correctly in most Protobuf
            implementations


### PR DESCRIPTION
This pulls out some of the code involved in message set validation into its own functions, to make it easier to slot in changes from a working branch I have.