### PR TITLE
Validate that enums and oneofs are nonempty (and enum zero values)

### DIFF
--- a/experimental/ir/testdata/fields/empty_oneof.proto
+++ b/experimental/ir/testdata/fields/empty_oneof.proto
@@ -1,0 +1,21 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package buf.test;
+
+message M {
+    oneof empty {}
+}

--- a/experimental/ir/testdata/fields/empty_oneof.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/empty_oneof.proto.stderr.txt
@@ -1,0 +1,7 @@
+error: oneof must define at least one member
+  --> testdata/fields/empty_oneof.proto:20:5
+   |
+20 |     oneof empty {}
+   |     ^^^^^^^^^^^^^^
+
+encountered 1 error

--- a/experimental/ir/testdata/tags/enum.proto
+++ b/experimental/ir/testdata/tags/enum.proto
@@ -1,0 +1,37 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package buf.test;
+
+enum Empty {}
+
+enum Open {
+    Z1 = 0;
+}
+
+enum Closed {
+    option features.enum_type = CLOSED;
+    Z2 = 1;
+}
+
+enum Open1 {
+    Z3 = 1;
+}
+
+enum Open2 {
+    option features.enum_type = OPEN;
+    Z4 = 1;
+}

--- a/experimental/ir/testdata/tags/enum.proto.stderr.txt
+++ b/experimental/ir/testdata/tags/enum.proto.stderr.txt
@@ -1,0 +1,33 @@
+error: enum type must define at least one value
+  --> testdata/tags/enum.proto:19:1
+   |
+19 | enum Empty {}
+   | ^^^^^^^^^^^^^
+
+error: first value of open enum must be zero
+  --> testdata/tags/enum.proto:31:10
+   |
+31 |     Z3 = 1;
+   |          ^
+  ::: testdata/tags/enum.proto:15:11
+   |
+15 | edition = "2023";
+   |           ------ this makes `buf.test.Open1` an open enum
+   |
+   = help: open enums must define a zero value, and it must be the first one
+
+error: first value of open enum must be zero
+  --> testdata/tags/enum.proto:36:10
+   |
+36 |     Z4 = 1;
+   |          ^
+  ::: testdata/tags/enum.proto:35:33
+   |
+35 |     option features.enum_type = OPEN;
+   |                                 ----
+   |                                  |
+   |                                  this makes `buf.test.Open2` an open enum
+   |
+   = help: open enums must define a zero value, and it must be the first one
+
+encountered 3 errors

--- a/experimental/ir/testdata/tags/enum_proto2.proto
+++ b/experimental/ir/testdata/tags/enum_proto2.proto
@@ -1,0 +1,22 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//% descriptor: true
+syntax = "proto2";
+
+package buf.test;
+
+enum Closed {
+    Z1 = 1;
+}

--- a/experimental/ir/testdata/tags/enum_proto2.proto.fds.yaml
+++ b/experimental/ir/testdata/tags/enum_proto2.proto.fds.yaml
@@ -1,0 +1,5 @@
+file:
+- name: "testdata/tags/enum_proto2.proto"
+  package: "buf.test"
+  enum_type: [{ name: "Closed", value: [{ name: "Z1", number: 1 }] }]
+  syntax: "proto2"


### PR DESCRIPTION
This PR adds validation for:

- Enums must contain one value.
- Oneofs must declare one member.
- Open enums' first value must have number zero.