### PR TITLE
Add validation code for built-in file options

### DIFF
--- a/experimental/ir/ir_value.go
+++ b/experimental/ir/ir_value.go
@@ -16,6 +16,7 @@ package ir
 
 import (
 	"cmp"
+	"fmt"
 	"iter"
 	"math"
 	"slices"
@@ -473,6 +474,26 @@ func (v Value) marshal(buf []byte, r *report.Report, ranges *[][2]int) ([]byte, 
 	}
 
 	return buf, n
+}
+
+func (v Value) suggestEdit(path, expr string, format string, args ...any) report.DiagnosticOption {
+	key := v.KeyAST()
+	value := v.ValueASTs().At(0)
+	joined := report.Join(key, value)
+
+	return report.SuggestEdits(
+		joined,
+		fmt.Sprintf(format, args...),
+		report.Edit{
+			Start: 0, End: key.Span().Len(),
+			Replace: path,
+		},
+		report.Edit{
+			Start:   value.Span().Start - joined.Start,
+			End:     value.Span().End - joined.Start,
+			Replace: expr,
+		},
+	)
 }
 
 func wrapValue(c *Context, p arena.Pointer[rawValue]) Value {

--- a/experimental/ir/testdata/options/validate/java_utf8.proto
+++ b/experimental/ir/testdata/options/validate/java_utf8.proto
@@ -1,0 +1,19 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package buf.test;
+
+option java_string_check_utf8 = true;

--- a/experimental/ir/testdata/options/validate/java_utf8.proto.stderr.txt
+++ b/experimental/ir/testdata/options/validate/java_utf8.proto.stderr.txt
@@ -1,0 +1,11 @@
+error: cannot set `java_string_check_utf8` in editions mode
+  --> testdata/options/validate/java_utf8.proto:19:8
+   |
+19 | option java_string_check_utf8 = true;
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+  help: replace with `features.(pb.java).utf8_validation`
+   |
+19 | - option java_string_check_utf8 = true;
+19 | + option features.(pb.java).utf8_validation = VERIFY;
+
+encountered 1 error

--- a/experimental/ir/testdata/options/validate/optimize_lite.proto.yaml
+++ b/experimental/ir/testdata/options/validate/optimize_lite.proto.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020-2025 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+errors_only: true
+filters: ["unused import"]
+files:
+- path: "lite1.proto"
+  text: |
+    syntax = "proto2";
+    package test;
+
+    option optimize_for = LITE_RUNTIME;
+
+    import "heavy1.proto";
+
+- path: "lite2.proto"
+  text: |
+    syntax = "proto2";
+    package test;
+
+    option optimize_for = LITE_RUNTIME;
+
+    import "lite1.proto";
+
+- path: "heavy1.proto"
+  text: |
+    syntax = "proto2";
+    package test;
+
+- path: "heavy2.proto"
+  text: |
+    syntax = "proto2";
+    package test;
+
+    import "heavy1.proto";
+    import "lite1.proto";

--- a/experimental/ir/testdata/options/validate/optimize_lite.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/options/validate/optimize_lite.proto.yaml.stderr.txt
@@ -1,0 +1,45 @@
+warning: unused import "heavy2.proto"
+  --> heavy2.proto:4:8
+   |
+ 4 | import "heavy1.proto";
+   |        ^^^^^^^^^^^^^^
+  help: delete it
+   |
+ 4 | - import "heavy1.proto";
+   |
+   = help: no symbols from this file are referenced
+
+warning: unused import "heavy2.proto"
+  --> heavy2.proto:5:8
+   |
+ 5 | import "lite1.proto";
+   |        ^^^^^^^^^^^^^
+  help: delete it
+   |
+ 5 | - import "lite1.proto";
+   |
+   = help: no symbols from this file are referenced
+
+warning: unused import "lite1.proto"
+  --> lite1.proto:6:8
+   |
+ 6 | import "heavy1.proto";
+   |        ^^^^^^^^^^^^^^
+  help: delete it
+   |
+ 6 | - import "heavy1.proto";
+   |
+   = help: no symbols from this file are referenced
+
+warning: unused import "lite2.proto"
+  --> lite2.proto:6:8
+   |
+ 6 | import "lite1.proto";
+   |        ^^^^^^^^^^^^^
+  help: delete it
+   |
+ 6 | - import "lite1.proto";
+   |
+   = help: no symbols from this file are referenced
+
+encountered 4 warnings

--- a/experimental/ir/testdata/options/validate/presence.proto
+++ b/experimental/ir/testdata/options/validate/presence.proto
@@ -1,0 +1,19 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package buf.test;
+
+option features.field_presence = LEGACY_REQUIRED;

--- a/experimental/ir/testdata/options/validate/presence.proto.stderr.txt
+++ b/experimental/ir/testdata/options/validate/presence.proto.stderr.txt
@@ -1,0 +1,7 @@
+error: cannot set `LEGACY_REQUIRED` at the file level
+  --> testdata/options/validate/presence.proto:19:34
+   |
+19 | option features.field_presence = LEGACY_REQUIRED;
+   |                                  ^^^^^^^^^^^^^^^
+
+encountered 1 error


### PR DESCRIPTION
This PR adds validation for:

- `FileOptions.java_string_check_utf8`, which is replaced in editions mode.
- `FileOptions.optimize_for = LITE_RUNTIME`, which has restrictions on what files can import it.
- `FileOptions.features.field_presence = LEGACY_REQUIRED`, which is not allowed. 