### PR TITLE
Validate `features.field_presence` constraints

### DIFF
--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/ast/syntax"
 	"github.com/bufbuild/protocompile/experimental/internal/taxa"
+	"github.com/bufbuild/protocompile/experimental/ir/presence"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/experimental/token/keyword"
@@ -51,6 +52,9 @@ func validateConstraints(f File, r *report.Report) {
 	}
 
 	for m := range f.AllMembers() {
+		// https://protobuf.com/docs/language-spec#field-option-validation
+		validatePresence(m, r)
+
 		// NOTE: extensions already cannot be map fields, so we don't need to
 		// validate them.
 		if m.IsExtension() && !m.IsMap() {
@@ -147,6 +151,84 @@ func validateMessageSetExtension(extn Member, r *report.Report) {
 			report.Snippetf(extendee.Options().Field(builtins.MessageSet).KeyAST(), "declared as message set here"),
 			report.Snippet(extendee.AST().Stem()),
 			report.Helpf("message set extensions must be singular message fields"),
+		)
+	}
+}
+
+func validatePresence(m Member, r *report.Report) {
+	if m.IsEnumValue() {
+		return
+	}
+
+	builtins := m.Context().builtins()
+	feature := m.FeatureSet().Lookup(builtins.FeaturePresence)
+	if !feature.IsExplicit() {
+		return
+	}
+
+	switch {
+	case !m.IsSingular():
+		what := "repeated"
+		if m.IsMap() {
+			what = "map"
+		}
+
+		r.Errorf("expected singular field, found %s field", what).Apply(
+			report.Snippet(m.TypeAST()),
+			report.Snippetf(
+				feature.Value().KeyAST(),
+				"`%s` set here", feature.Field().Name(),
+			),
+			report.Helpf("`%s` can only be set on singular fields", feature.Field().Name()),
+		)
+
+	case m.Presence() == presence.Shared:
+		r.Errorf("expected singular field, found oneof member").Apply(
+			report.Snippet(m.AST()),
+			report.Snippetf(m.Oneof().AST(), "defined in this oneof"),
+			report.Snippetf(
+				feature.Value().KeyAST(),
+				"`%s` set here", feature.Field().Name(),
+			),
+			report.Helpf("`%s` cannot be set on oneof members", feature.Field().Name()),
+			report.Helpf("all oneof members have explicit presence"),
+		)
+
+	case m.IsExtension():
+		r.Errorf("expected singular field, found extension").Apply(
+			report.Snippet(m.AST()),
+			report.Snippetf(
+				feature.Value().KeyAST(),
+				"`%s` set here", feature.Field().Name(),
+			),
+			report.Helpf("`%s` cannot be set on extensions", feature.Field().Name()),
+			report.Helpf("all singular extensions have explicit presence"),
+		)
+	}
+
+	switch v, _ := feature.Value().AsInt(); v {
+	case 1: // EXPLICIT
+	case 2: // IMPLICIT
+		if m.Element().IsMessage() {
+			r.Error(errTypeConstraint{
+				want: taxa.MessageType,
+				got:  m.Element(),
+				decl: m.TypeAST(),
+			}).Apply(
+				report.Snippet(m.TypeAST()),
+				report.Snippetf(
+					feature.Value().ValueAST(),
+					"implicit presence set here",
+				),
+				report.Helpf("all message-typed fields explicit presence"),
+			)
+		}
+	case 3: // LEGACY_REQUIRED
+		r.Warnf("required fields are deprecated").Apply(
+			report.Snippet(feature.Value().ValueAST()),
+			report.Helpf(
+				"do not attempt to change this to `EXPLICIT` if the field is "+
+					"already in-use; doing so is a wire protocol break"),
 		)
 	}
 }

--- a/experimental/ir/testdata/editions/inheritance.proto.stderr.txt
+++ b/experimental/ir/testdata/editions/inheritance.proto.stderr.txt
@@ -12,4 +12,12 @@ warning: `legacy_closed_enum` is deprecated in Edition 2023
            is scheduled to be removed in edition 2025. See
            http://protobuf.dev/programming-guides/enum/#cpp for more information
 
-encountered 1 warning
+warning: required fields are deprecated
+  --> testdata/editions/inheritance.proto:28:44
+   |
+28 |     int32 y = 2 [features.field_presence = LEGACY_REQUIRED];
+   |                                            ^^^^^^^^^^^^^^^
+   = help: do not attempt to change this to `EXPLICIT` if the field is already
+           in-use; doing so is a wire protocol break
+
+encountered 2 warnings

--- a/experimental/ir/testdata/editions/ok.proto.stderr.txt
+++ b/experimental/ir/testdata/editions/ok.proto.stderr.txt
@@ -1,0 +1,9 @@
+warning: required fields are deprecated
+  --> testdata/editions/ok.proto:26:44
+   |
+26 |     int32 z = 3 [features.field_presence = LEGACY_REQUIRED];
+   |                                            ^^^^^^^^^^^^^^^
+   = help: do not attempt to change this to `EXPLICIT` if the field is already
+           in-use; doing so is a wire protocol break
+
+encountered 1 warning

--- a/experimental/ir/testdata/options/validate/presence.proto
+++ b/experimental/ir/testdata/options/validate/presence.proto
@@ -1,0 +1,39 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package buf.test;
+
+message Foo {
+    repeated int32 x = 1 [features.field_presence = EXPLICIT];
+    map<int32, int32> y = 2 [features.field_presence = EXPLICIT];
+
+    oneof o {
+        int32 z = 3 [features.field_presence = EXPLICIT];
+    }
+
+    extensions 4;
+    
+    Foo m = 5 [features.field_presence = IMPLICIT];
+
+    int32 r = 6 [features.field_presence = LEGACY_REQUIRED];
+
+    optional int32 a1 = 10;
+    required int32 a1 = 11;
+}
+
+extend Foo {
+    int32 e = 4 [features.field_presence = EXPLICIT];
+}

--- a/experimental/ir/testdata/options/validate/presence.proto.stderr.txt
+++ b/experimental/ir/testdata/options/validate/presence.proto.stderr.txt
@@ -1,0 +1,98 @@
+error: unexpected `optional`
+  --> testdata/options/validate/presence.proto:33:5
+   |
+33 |     optional int32 a1 = 10;
+   |     ^^^^^^^^ expected type name or `repeated`
+   |
+  help: delete it
+   |
+33 | -     optional int32 a1 = 10;
+33 | +     int32 a1 = 10;
+   |
+   |
+   = help: in editions mode, the presence behavior of a singular field is
+           controlled with `[feature.field_presence = ...]`, with the default
+           being equivalent to proto2 `optional`
+   = help: see <https://protobuf.com/docs/language-spec#field-presence>
+
+error: unexpected `required`
+  --> testdata/options/validate/presence.proto:34:5
+   |
+34 |     required int32 a1 = 11;
+   |     ^^^^^^^^ expected type name or `repeated`
+   |
+  help: delete it
+   |
+34 | -     required int32 a1 = 11;
+34 | +     int32 a1 = 11;
+   |
+   |
+   = help: required fields are only permitted in proto2; even then, their use is
+           strongly discouraged
+
+error: expected singular field, found repeated field
+  --> testdata/options/validate/presence.proto:20:5
+   |
+20 |     repeated int32 x = 1 [features.field_presence = EXPLICIT];
+   |     ^^^^^^^^^^^^^^        ----------------------- `field_presence` set here
+   |
+   = help: `field_presence` can only be set on singular fields
+
+error: expected singular field, found map field
+  --> testdata/options/validate/presence.proto:21:5
+   |
+21 |     map<int32, int32> y = 2 [features.field_presence = EXPLICIT];
+   |     ^^^^^^^^^^^^^^^^^        -----------------------
+   |                               |
+   |                               `field_presence` set here
+   |
+   = help: `field_presence` can only be set on singular fields
+
+error: expected singular field, found oneof member
+  --> testdata/options/validate/presence.proto:24:9
+   |
+23 | /     oneof o {
+24 | |         int32 z = 3 [features.field_presence = EXPLICIT];
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |                      ----------------------- `field_presence` set here
+25 | |     }
+   | \_____- defined in this oneof
+   |
+   = help: `field_presence` cannot be set on oneof members
+   = help: all oneof members have explicit presence
+
+error: expected message type, found message type `buf.test.Foo`
+  --> testdata/options/validate/presence.proto:29:5
+   |
+29 |     Foo m = 5 [features.field_presence = IMPLICIT];
+   |     ^^^                                  -------- implicit presence set here
+   |     ---
+   = help: all message-typed fields explicit presence
+
+warning: required fields are deprecated
+  --> testdata/options/validate/presence.proto:31:44
+   |
+31 |     int32 r = 6 [features.field_presence = LEGACY_REQUIRED];
+   |                                            ^^^^^^^^^^^^^^^
+   = help: do not attempt to change this to `EXPLICIT` if the field is already
+           in-use; doing so is a wire protocol break
+
+error: `a1` declared multiple times
+  --> testdata/options/validate/presence.proto:33:20
+   |
+33 |     optional int32 a1 = 10;
+   |                    ^^ first here, as a message field
+34 |     required int32 a1 = 11;
+   |                    -- ...also declared here
+
+error: expected singular field, found extension
+  --> testdata/options/validate/presence.proto:38:5
+   |
+38 |     int32 e = 4 [features.field_presence = EXPLICIT];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ----------------------- `field_presence` set here
+   |
+   = help: `field_presence` cannot be set on extensions
+   = help: all singular extensions have explicit presence
+
+encountered 8 errors and 1 warning

--- a/experimental/parser/legalize_type.go
+++ b/experimental/parser/legalize_type.go
@@ -150,6 +150,8 @@ func legalizeFieldType(p *parser, what taxa.Noun, ty ast.TypeAny, topLevel bool,
 				case keyword.Required:
 					switch p.syntax {
 					case syntax.Proto2:
+						// TODO: This appears verbatim in lower_validate. Move this check
+						// into IR lowering?
 						p.Warnf("required fields are deprecated").Apply(
 							report.Snippet(ty.PrefixToken()),
 							report.Helpf(


### PR DESCRIPTION
This PR adds complex validation logic for `features.field_presence`. This includes ensuring that the field is not repeated, that `IMPLICIT` presence is not set on message fields, warnings about `LEGACY_REQUIRED`, and behavior on extensions.