### PR TITLE
Validate `packed` and its editions equivalent

### DIFF
--- a/experimental/ir/ir_value.go
+++ b/experimental/ir/ir_value.go
@@ -16,6 +16,7 @@ package ir
 
 import (
 	"cmp"
+	"fmt"
 	"iter"
 	"math"
 	"slices"
@@ -473,6 +474,26 @@ func (v Value) marshal(buf []byte, r *report.Report, ranges *[][2]int) ([]byte, 
 	}
 
 	return buf, n
+}
+
+func (v Value) suggestEdit(path, expr string, format string, args ...any) report.DiagnosticOption {
+	key := v.KeyAST()
+	value := v.ValueASTs().At(0)
+	joined := report.Join(key, value)
+
+	return report.SuggestEdits(
+		joined,
+		fmt.Sprintf(format, args...),
+		report.Edit{
+			Start: 0, End: key.Span().Len(),
+			Replace: path,
+		},
+		report.Edit{
+			Start:   value.Span().Start - joined.Start,
+			End:     value.Span().End - joined.Start,
+			Replace: expr,
+		},
+	)
 }
 
 func wrapValue(c *Context, p arena.Pointer[rawValue]) Value {

--- a/experimental/ir/testdata/options/validate/packed_2023.proto
+++ b/experimental/ir/testdata/options/validate/packed_2023.proto
@@ -1,0 +1,36 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package buf.test;
+
+message M {
+    enum E { Z = 0; }
+
+    int32 o1 = 1 [features.repeated_field_encoding = PACKED];
+    int32 o2 = 2 [features.repeated_field_encoding = EXPANDED];
+    
+    repeated M m1 = 3 [features.repeated_field_encoding = PACKED];
+    repeated M m2 = 4 [features.repeated_field_encoding = EXPANDED];
+
+    repeated E e1 = 5 [features.repeated_field_encoding = PACKED];
+    repeated E e2 = 6 [features.repeated_field_encoding = EXPANDED];
+
+    repeated float f1 = 7 [features.repeated_field_encoding = PACKED];
+    repeated float f2 = 8 [features.repeated_field_encoding = EXPANDED];
+
+    repeated float f3 = 9 [packed = true];
+    repeated float f4 = 10 [packed = false];
+}

--- a/experimental/ir/testdata/options/validate/packed_2023.proto.stderr.txt
+++ b/experimental/ir/testdata/options/validate/packed_2023.proto.stderr.txt
@@ -1,0 +1,72 @@
+error: expected repeated field, found singular field
+  --> testdata/options/validate/packed_2023.proto:22:5
+   |
+22 |     int32 o1 = 1 [features.repeated_field_encoding = PACKED];
+   |     ^^^^^         -------------------------------- packed encoding set here
+   |
+   = help: packed encoding encoding can only be set on repeated fields of
+           integer, float, `bool`, or enum type
+
+error: expected repeated field, found singular field
+  --> testdata/options/validate/packed_2023.proto:23:5
+   |
+23 |     int32 o2 = 2 [features.repeated_field_encoding = EXPANDED];
+   |     ^^^^^         -------------------------------- packed encoding set here
+   |
+   = help: packed encoding encoding can only be set on repeated fields of
+           integer, float, `bool`, or enum type
+
+error: expected packable type, found message type `buf.test.M`
+  --> testdata/options/validate/packed_2023.proto:25:14
+   |
+25 |     repeated M m1 = 3 [features.repeated_field_encoding = PACKED];
+   |              ^         --------------------------------
+   |                         |
+   |                         packed encoding set here
+   |
+   = help: packed encoding encoding can only be set on repeated fields of
+           integer, float, `bool`, or enum type
+
+error: expected packable type, found message type `buf.test.M`
+  --> testdata/options/validate/packed_2023.proto:26:14
+   |
+26 |     repeated M m2 = 4 [features.repeated_field_encoding = EXPANDED];
+   |              ^         --------------------------------
+   |                         |
+   |                         packed encoding set here
+   |
+   = help: packed encoding encoding can only be set on repeated fields of
+           integer, float, `bool`, or enum type
+
+error: `packed` is not supported in Edition 2023
+  --> testdata/options/validate/packed_2023.proto:34:28
+   |
+15 | edition = "2023";
+   |           ------ edition specified here
+...
+34 |     repeated float f3 = 9 [packed = true];
+   |                            ^^^^^^
+  help: replace with `repeated_field_encoding`
+   |
+34 | -     repeated float f3 = 9 [packed = true];
+34 | +     repeated float f3 = 9 [repeated_field_encoding = PACKED];
+   |
+   = help: removed in Edition 2023
+
+error: `packed` is not supported in Edition 2023
+  --> testdata/options/validate/packed_2023.proto:35:29
+   |
+15 | edition = "2023";
+   |           ------ edition specified here
+...
+34 |     repeated float f3 = 9 [packed = true];
+35 |     repeated float f4 = 10 [packed = false];
+   |                             ^^^^^^
+  help: replace with `repeated_field_encoding`
+   |
+35 | -     repeated float f4 = 10 [packed = false];
+35 | +     repeated float f4 = 10 [repeated_field_encoding = EXPANDED];
+   |
+   = help: removed in Edition 2023
+
+encountered 6 errors

--- a/experimental/ir/testdata/options/validate/packed_proto2.proto
+++ b/experimental/ir/testdata/options/validate/packed_proto2.proto
@@ -1,0 +1,33 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.test;
+
+message M {
+    enum E { Z = 0; }
+
+    optional int32 o1 = 1 [packed = true];
+    optional int32 o2 = 2 [packed = false];
+    
+    repeated M m1 = 3 [packed = true];
+    repeated M m2 = 4 [packed = false];
+
+    repeated E e1 = 5 [packed = true];
+    repeated E e2 = 6 [packed = false];
+
+    repeated float f1 = 7 [packed = true];
+    repeated float f2 = 8 [packed = false];
+}

--- a/experimental/ir/testdata/options/validate/packed_proto2.proto.stderr.txt
+++ b/experimental/ir/testdata/options/validate/packed_proto2.proto.stderr.txt
@@ -1,0 +1,19 @@
+error: expected repeated field, found singular field
+  --> testdata/options/validate/packed_proto2.proto:22:5
+   |
+22 |     optional int32 o1 = 1 [packed = true];
+   |     ^^^^^^^^^^^^^^                  ---- packed encoding set here
+   |
+   = help: packed encoding encoding can only be set on repeated fields of
+           integer, float, `bool`, or enum type
+
+error: expected packable type, found message type `buf.test.M`
+  --> testdata/options/validate/packed_proto2.proto:25:14
+   |
+25 |     repeated M m1 = 3 [packed = true];
+   |              ^                  ---- packed encoding set here
+   |
+   = help: packed encoding encoding can only be set on repeated fields of
+           integer, float, `bool`, or enum type
+
+encountered 2 errors


### PR DESCRIPTION
This PR adds validation for `packed` and `features.repeated_field_encoding`. They cannot coexist, and restricted to certain kinds of repeated fields, and are specific to syntax or editions mode.