### PR TITLE
Expose non-primary spans from diagnostic

### DIFF
--- a/experimental/report/diagnostic.go
+++ b/experimental/report/diagnostic.go
@@ -110,6 +110,19 @@ func (d *Diagnostic) Primary() source.Span {
 	return source.Span{}
 }
 
+// NonPrimary returns this diagnostic's non-primary spans, if it has any.
+//
+// If it doesn't have any, it returns nil.
+func (d *Diagnostic) NonPrimary() []source.Span {
+	var nonPrimarySpans []source.Span
+	for _, annotation := range d.snippets {
+		if !annotation.primary {
+			nonPrimarySpans = append(nonPrimarySpans, annotation.Span)
+		}
+	}
+	return nonPrimarySpans
+}
+
 // Level returns this diagnostic's level.
 func (d *Diagnostic) Level() Level {
 	return d.level

--- a/experimental/report/diagnostic.go
+++ b/experimental/report/diagnostic.go
@@ -110,17 +110,17 @@ func (d *Diagnostic) Primary() source.Span {
 	return source.Span{}
 }
 
-// NonPrimary returns this diagnostic's non-primary spans, if it has any.
-//
+// RelatedSpans returns any spans related to this diagnostic that are not the primary span, if it has any.
 // If it doesn't have any, it returns nil.
-func (d *Diagnostic) NonPrimary() []source.Span {
-	var nonPrimarySpans []source.Span
+// (To get the primary span, use [Diagnostic.Primary].)
+func (d *Diagnostic) RelatedSpans() []source.Span {
+	var relatedSpans []source.Span
 	for _, annotation := range d.snippets {
 		if !annotation.primary {
-			nonPrimarySpans = append(nonPrimarySpans, annotation.Span)
+			relatedSpans = append(relatedSpans, annotation.Span)
 		}
 	}
-	return nonPrimarySpans
+	return relatedSpans
 }
 
 // Level returns this diagnostic's level.


### PR DESCRIPTION
We currently don't have a way to access non-primary spans from a diagnostic. This adds a `NonPrimary` API that returns the slice of non-primary spans from the diagnostic.

This can be used by the LSP to populate the [protocol.Diagnostic][1]'s RelatedInformation field that references the other spans relating to this diagnostic.

No particular love for this name; I thought about `Secondary` but that didn't seem right either. Open to suggestions.

[1]: https://pkg.go.dev/go.lsp.dev/protocol#Diagnostic