### PR TITLE
Fix partial name resolution

### DIFF
--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -433,7 +433,7 @@ func symtabProto(files []*ir.File) *compilerpb.SymbolSet {
 				Features:   dumpFeatures(sym.FeatureSet(), sym.Kind().OptionTarget()),
 			})
 		}
-		slices.SortFunc(symtab.Symbols,
+		slices.SortStableFunc(symtab.Symbols,
 			cmpx.Join(
 				cmpx.Key(func(x *compilerpb.Symbol) string { return x.File }),
 				cmpx.Key(func(x *compilerpb.Symbol) compilerpb.Symbol_Kind { return x.Kind }),

--- a/experimental/ir/ir_test.go
+++ b/experimental/ir/ir_test.go
@@ -433,11 +433,12 @@ func symtabProto(files []*ir.File) *compilerpb.SymbolSet {
 				Features:   dumpFeatures(sym.FeatureSet(), sym.Kind().OptionTarget()),
 			})
 		}
-		slices.SortStableFunc(symtab.Symbols,
+		slices.SortFunc(symtab.Symbols,
 			cmpx.Join(
 				cmpx.Key(func(x *compilerpb.Symbol) string { return x.File }),
 				cmpx.Key(func(x *compilerpb.Symbol) compilerpb.Symbol_Kind { return x.Kind }),
 				cmpx.Key(func(x *compilerpb.Symbol) uint32 { return x.Index }),
+				cmpx.Key(func(x *compilerpb.Symbol) string { return x.Fqn }),
 			),
 		)
 

--- a/experimental/ir/lower_symbols.go
+++ b/experimental/ir/lower_symbols.go
@@ -35,13 +35,24 @@ import (
 // buildLocalSymbols allocates new symbols for each definition in this file,
 // and places them in the local symbol table.
 func buildLocalSymbols(file *File) {
-	sym := file.arenas.symbols.NewCompressed(rawSymbol{
-		kind: SymbolKindPackage,
-		fqn:  file.InternedPackage(),
-	})
-	file.exported = append(file.exported, symbol{
-		ref: Ref[Symbol]{id: id.ID[Symbol](sym)},
-	})
+	// Register a package symbol for the full package name and each parent. For example,
+	// package a.b.c produces the following symbols:
+	//  - a.b.c
+	//  - a.b
+	//  - a
+	//
+	// This is necessary for resolving names that use a partial path, for example, b.c.Foo
+	// in package a.b.c. This would be resolved by checking the scope a, and appending the
+	// name b.c.Foo.
+	for pkg := file.Package(); pkg != ""; pkg = pkg.Parent() {
+		sym := file.arenas.symbols.NewCompressed(rawSymbol{
+			kind: SymbolKindPackage,
+			fqn:  file.session.intern.Intern(string(pkg)),
+		})
+		file.exported = append(file.exported, symbol{
+			ref: Ref[Symbol]{id: id.ID[Symbol](sym)},
+		})
+	}
 
 	for ty := range seq.Values(file.AllTypes()) {
 		newTypeSymbol(ty)

--- a/experimental/ir/lower_symbols.go
+++ b/experimental/ir/lower_symbols.go
@@ -35,15 +35,20 @@ import (
 // buildLocalSymbols allocates new symbols for each definition in this file,
 // and places them in the local symbol table.
 func buildLocalSymbols(file *File) {
-	// Register a package symbol for the full package name and each parent. For example,
-	// package a.b.c produces the following symbols:
+	// Register a package symbol for the full package name and each intermediate parent.
+	// For example, package a.b.c produces the following symbols:
 	//  - a.b.c
 	//  - a.b
 	//  - a
 	//
-	// This is necessary for resolving names that use a partial path, for example, b.c.Foo
-	// in package a.b.c. This would be resolved by checking the scope a, and appending the
-	// name b.c.Foo.
+	// This is necessary for supporting the resolution of partial names. As the comment in
+	// [symtab.resolve] explains, protoc does a two phase search for names: searching for the
+	// first component, and then appending the rest of the target.
+	//
+	// For example, to resolve the target c.v1.Foo in package a.b.c.v1, it first searches
+	// for c. This is found in the intermediate scope, a.b, resolving to the intermediate
+	// scope a.b.c, before resolving the rest, a.b.c.v1.Foo. So the intermediate scopes must
+	// be present to resolve the first component, since it may be an intermediate package scope.
 	for pkg := file.Package(); pkg != ""; pkg = pkg.Parent() {
 		sym := file.arenas.symbols.NewCompressed(rawSymbol{
 			kind: SymbolKindPackage,

--- a/experimental/ir/testdata/editions/incomplete_feature.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/incomplete_feature.proto.symtab.yaml
@@ -18,10 +18,10 @@ tables:
     - { extn: "buf.test.f", name: "f", value: "true" }
     - { extn: "buf.test.f", name: "g", value: "A" }
     symbols:
-    - fqn: "buf.test"
+    - fqn: "buf"
       kind: KIND_PACKAGE
       file: "testdata/editions/incomplete_feature.proto"
-    - fqn: "buf"
+    - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/incomplete_feature.proto"
     - fqn: "buf.test.Features"

--- a/experimental/ir/testdata/editions/incomplete_feature.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/incomplete_feature.proto.symtab.yaml
@@ -21,6 +21,9 @@ tables:
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/incomplete_feature.proto"
+    - fqn: "buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/incomplete_feature.proto"
     - fqn: "buf.test.Features"
       kind: KIND_MESSAGE
       file: "testdata/editions/incomplete_feature.proto"

--- a/experimental/ir/testdata/editions/inheritance.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/inheritance.proto.symtab.yaml
@@ -11,6 +11,9 @@ tables:
     - { extn: "pb.cpp", name: "enum_name_uses_string_view", value: "false" }
     - { extn: "pb.cpp", name: "string_type", value: "STRING" }
     symbols:
+    - fqn: "buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/inheritance.proto"
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/inheritance.proto"

--- a/experimental/ir/testdata/editions/lifetime.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/lifetime.proto.symtab.yaml
@@ -17,6 +17,9 @@ tables:
     - { name: "repeated_field_encoding", value: "PACKED" }
     - { name: "utf8_validation", value: "VERIFY" }
     symbols:
+    - fqn: "buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/lifetime.proto"
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/lifetime.proto"

--- a/experimental/ir/testdata/editions/naming_style_2024_bad.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/naming_style_2024_bad.proto.symtab.yaml
@@ -4,6 +4,9 @@ tables:
     - fqn: "Buf.Test"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_2024_bad.proto"
+    - fqn: "Buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/naming_style_2024_bad.proto"
     - fqn: "Buf.Test.my_message"
       kind: KIND_MESSAGE
       file: "testdata/editions/naming_style_2024_bad.proto"

--- a/experimental/ir/testdata/editions/naming_style_2024_bad.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/naming_style_2024_bad.proto.symtab.yaml
@@ -1,10 +1,10 @@
 tables:
   "testdata/editions/naming_style_2024_bad.proto":
     symbols:
-    - fqn: "Buf.Test"
+    - fqn: "Buf"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_2024_bad.proto"
-    - fqn: "Buf"
+    - fqn: "Buf.Test"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_2024_bad.proto"
     - fqn: "Buf.Test.my_message"

--- a/experimental/ir/testdata/editions/naming_style_2024_ok.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/naming_style_2024_ok.proto.symtab.yaml
@@ -4,6 +4,9 @@ tables:
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_2024_ok.proto"
+    - fqn: "buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/naming_style_2024_ok.proto"
     - fqn: "buf.test.MyMessage"
       kind: KIND_MESSAGE
       file: "testdata/editions/naming_style_2024_ok.proto"

--- a/experimental/ir/testdata/editions/naming_style_2024_ok.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/naming_style_2024_ok.proto.symtab.yaml
@@ -1,10 +1,10 @@
 tables:
   "testdata/editions/naming_style_2024_ok.proto":
     symbols:
-    - fqn: "buf.test"
+    - fqn: "buf"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_2024_ok.proto"
-    - fqn: "buf"
+    - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_2024_ok.proto"
     - fqn: "buf.test.MyMessage"

--- a/experimental/ir/testdata/editions/naming_style_legacy.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/naming_style_legacy.proto.symtab.yaml
@@ -1,6 +1,9 @@
 tables:
   "testdata/editions/naming_style_legacy.proto":
     symbols:
+    - fqn: "buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/naming_style_legacy.proto"
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/naming_style_legacy.proto"

--- a/experimental/ir/testdata/editions/ok.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/ok.proto.symtab.yaml
@@ -1,6 +1,7 @@
 tables:
   "testdata/editions/ok.proto":
     symbols:
+    - { fqn: "buf", kind: KIND_PACKAGE, file: "testdata/editions/ok.proto" }
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/ok.proto"

--- a/experimental/ir/testdata/editions/ok_2024.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/ok_2024.proto.symtab.yaml
@@ -24,6 +24,9 @@ tables:
       value: "false"
     - { extn: "pb.java", name: "utf8_validation", value: "DEFAULT" }
     symbols:
+    - fqn: "buf"
+      kind: KIND_PACKAGE
+      file: "testdata/editions/ok_2024.proto"
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/ok_2024.proto"

--- a/experimental/ir/testdata/editions/proto2.proto.symtab.yaml
+++ b/experimental/ir/testdata/editions/proto2.proto.symtab.yaml
@@ -11,6 +11,7 @@ tables:
     - { name: "repeated_field_encoding", value: "EXPANDED" }
     - { name: "utf8_validation", value: "NONE" }
     symbols:
+    - { fqn: "buf", kind: KIND_PACKAGE, file: "testdata/editions/proto2.proto" }
     - fqn: "buf.test"
       kind: KIND_PACKAGE
       file: "testdata/editions/proto2.proto"

--- a/experimental/ir/testdata/imports/option.proto.yaml.symtab.yaml
+++ b/experimental/ir/testdata/imports/option.proto.yaml.symtab.yaml
@@ -5,6 +5,7 @@ tables:
     - { path: "google/protobuf/descriptor.proto", transitive: true }
     - { path: "option.proto", visible: true }
     symbols:
+    - { fqn: "buf", kind: KIND_PACKAGE, file: "main.proto" }
     - { fqn: "buf.test", kind: KIND_PACKAGE, file: "main.proto" }
     - fqn: "buf.test.Bar"
       kind: KIND_MESSAGE
@@ -41,6 +42,7 @@ tables:
     - { path: "option.proto", visible: true }
     - { path: "public.proto", visible: true }
     symbols:
+    - { fqn: "buf", kind: KIND_PACKAGE, file: "main2.proto" }
     - { fqn: "buf.test", kind: KIND_PACKAGE, file: "main2.proto" }
     - fqn: "buf.test.Bar"
       kind: KIND_MESSAGE
@@ -76,6 +78,7 @@ tables:
     - { path: "google/protobuf/descriptor.proto", transitive: true }
     - { path: "option.proto", visible: true }
     symbols:
+    - { fqn: "buf", kind: KIND_PACKAGE, file: "main3.proto" }
     - { fqn: "buf.test", kind: KIND_PACKAGE, file: "main3.proto" }
     - fqn: "buf.test.Baz"
       kind: KIND_MESSAGE

--- a/experimental/ir/testdata/imports/partial.proto.yaml
+++ b/experimental/ir/testdata/imports/partial.proto.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020-2025 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests that multi-component relative name resolution works when the first
+# component resolves to an intermediate package prefix, not a full package name.
+#
+# For example, resolving "b.v1.Msg" from package "a.b.c.v1" requires "a.b" to
+# exist as a package scope, even though no file declares "package a.b;".
+descriptor: true
+exclude: "unused import"
+files:
+- path: "dep.proto"
+  import: true
+  text: |
+    syntax = "proto3";
+    package a.b.v1;
+
+    message Msg {}
+
+- path: "main.proto"
+  text: |
+    syntax = "proto3";
+    package a.b.c.v1;
+
+    import "dep.proto";
+
+    message Use {
+      b.v1.Msg m = 1;
+    }

--- a/experimental/ir/testdata/imports/partial.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/partial.proto.yaml.fds.yaml
@@ -1,0 +1,18 @@
+file:
+- name: "dep.proto"
+  package: "a.b.v1"
+  message_type: [{ name: "Msg" }]
+  syntax: "proto3"
+- name: "main.proto"
+  package: "a.b.c.v1"
+  dependency: ["dep.proto"]
+  message_type:
+  - name: "Use"
+    field:
+    - name: "m"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".a.b.v1.Msg"
+      json_name: "m"
+  syntax: "proto3"

--- a/experimental/ir/testdata/symtab/double_def.proto.yaml.symtab.yaml
+++ b/experimental/ir/testdata/symtab/double_def.proto.yaml.symtab.yaml
@@ -2,6 +2,7 @@ tables:
   "dep/foo.proto":
     imports: [{ path: "dep/priv.proto", visible: true }]
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - fqn: "dep.foo.Foo"
       kind: KIND_MESSAGE
@@ -15,6 +16,7 @@ tables:
       visible: true
   "dep/priv.proto":
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/priv.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/priv.proto" }
     - fqn: "dep.foo.Main"
       kind: KIND_MESSAGE
@@ -26,6 +28,7 @@ tables:
     - { path: "dep/foo.proto", visible: true }
     - { path: "dep/priv.proto", transitive: true }
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - fqn: "dep.foo.Foo"
       kind: KIND_MESSAGE
@@ -52,5 +55,6 @@ tables:
     - { path: "dep/foo.proto", visible: true }
     - { path: "dep/priv.proto", transitive: true }
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - { fqn: "dep.foo.Foo", kind: KIND_PACKAGE, file: "main2.proto" }

--- a/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
+++ b/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
@@ -28,10 +28,10 @@ tables:
   "dep/not_public.proto":
     symbols:
     - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
-    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
     - fqn: "dep.foo.not_public"
       kind: KIND_PACKAGE
       file: "dep/not_public.proto"
+    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
     - fqn: "dep.foo.not_public.X"
       kind: KIND_MESSAGE
       file: "dep/not_public.proto"
@@ -40,8 +40,8 @@ tables:
   "dep/public.proto":
     symbols:
     - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/public.proto" }
-    - { fqn: "dep.foo.public", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/public.proto" }
+    - { fqn: "dep.foo.public", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - fqn: "dep.foo.public.X"
       kind: KIND_MESSAGE
       file: "dep/public.proto"

--- a/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
+++ b/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
@@ -40,8 +40,8 @@ tables:
   "dep/public.proto":
     symbols:
     - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/public.proto" }
-    - { fqn: "dep.foo.public", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/public.proto" }
+    - { fqn: "dep.foo.public", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - fqn: "dep.foo.public.X"
       kind: KIND_MESSAGE
       file: "dep/public.proto"

--- a/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
+++ b/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
@@ -4,6 +4,7 @@ tables:
     - { path: "dep/not_public.proto", visible: true }
     - { path: "dep/public.proto", public: true, visible: true }
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - fqn: "dep.foo.Foo"
       kind: KIND_MESSAGE
@@ -26,6 +27,8 @@ tables:
       visible: true
   "dep/not_public.proto":
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
+    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
     - fqn: "dep.foo.not_public"
       kind: KIND_PACKAGE
       file: "dep/not_public.proto"
@@ -36,7 +39,9 @@ tables:
       visible: true
   "dep/public.proto":
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - { fqn: "dep.foo.public", kind: KIND_PACKAGE, file: "dep/public.proto" }
+    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - fqn: "dep.foo.public.X"
       kind: KIND_MESSAGE
       file: "dep/public.proto"
@@ -48,6 +53,7 @@ tables:
     - { path: "dep/not_public.proto", transitive: true }
     - { path: "dep/public.proto", transitive: true, visible: true }
     symbols:
+    - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/foo.proto" }
     - fqn: "dep.foo.Foo"
       kind: KIND_MESSAGE

--- a/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
+++ b/experimental/ir/testdata/symtab/public.proto.yaml.symtab.yaml
@@ -28,10 +28,10 @@ tables:
   "dep/not_public.proto":
     symbols:
     - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
+    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
     - fqn: "dep.foo.not_public"
       kind: KIND_PACKAGE
       file: "dep/not_public.proto"
-    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/not_public.proto" }
     - fqn: "dep.foo.not_public.X"
       kind: KIND_MESSAGE
       file: "dep/not_public.proto"
@@ -40,8 +40,8 @@ tables:
   "dep/public.proto":
     symbols:
     - { fqn: "dep", kind: KIND_PACKAGE, file: "dep/public.proto" }
-    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - { fqn: "dep.foo.public", kind: KIND_PACKAGE, file: "dep/public.proto" }
+    - { fqn: "dep.foo", kind: KIND_PACKAGE, file: "dep/public.proto" }
     - fqn: "dep.foo.public.X"
       kind: KIND_MESSAGE
       file: "dep/public.proto"


### PR DESCRIPTION
This fixes name resolution for partial names, e.g. `b.c.Foo`
in package `a.b.c`, by registering a symbol for each of the
parent components of the package path.

There is a churn in the golden files because of the added
package symbols.