### PR TITLE
Fix leading dot references marked unused

### DIFF
--- a/experimental/ir/lower_resolve.go
+++ b/experimental/ir/lower_resolve.go
@@ -299,6 +299,9 @@ func (r symbolRef) resolve() Symbol {
 	case r.name.Absolute():
 		if id, ok := r.session.intern.Query(string(r.name.ToRelative())); ok {
 			found = r.imported.lookup(id)
+			if foundFile := found.Context(r.File); foundFile != r.File {
+				r.File.imports.MarkUsed(foundFile)
+			}
 		}
 	case r.allowScalars:
 		// TODO: if symbol resolution would provide a different answer for

--- a/experimental/ir/testdata/imports/unused.proto.yaml
+++ b/experimental/ir/testdata/imports/unused.proto.yaml
@@ -99,6 +99,35 @@ files:
       E e = 2;
     }
 
+- path: "a7.proto"
+  text: |
+    syntax = "proto3";
+    package buf.test;
+
+    import "b.proto";
+    import "c.proto";
+    import "d.proto";
+
+    message A7 {
+      .buf.test.B b = 1;
+      .buf.test.C c = 2;
+      .buf.test.D d = 3;
+    }
+
+- path: "a8.proto"
+  text: |
+    syntax = "proto3";
+    package buf.test;
+
+    import "b.proto";
+    import "c.proto";
+    import "d.proto";
+
+    message A8 {
+      .buf.test.B b = 1;
+      .buf.test.D d = 3;
+    }
+
 - path: "b.proto"
   import: true
   text: |

--- a/experimental/ir/testdata/imports/unused.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/unused.proto.yaml.fds.yaml
@@ -159,3 +159,50 @@ file:
       type_name: ".buf.test.E"
       json_name: "e"
   syntax: "proto3"
+- name: "a7.proto"
+  package: "buf.test"
+  dependency: ["b.proto", "c.proto", "d.proto"]
+  message_type:
+  - name: "A7"
+    field:
+    - name: "b"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.B"
+      json_name: "b"
+    - name: "c"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.C"
+      json_name: "c"
+    - name: "d"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.D"
+      json_name: "d"
+  syntax: "proto3"
+- name: "a8.proto"
+  package: "buf.test"
+  dependency: ["b.proto", "c.proto", "d.proto"]
+  message_type:
+  - name: "A8"
+    field:
+    - name: "b"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.B"
+      json_name: "b"
+    - name: "d"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.D"
+      json_name: "d"
+  source_code_info:
+    (buf.descriptor.v1.buf_source_code_info_extension):
+      unused_dependency: [1]
+  syntax: "proto3"

--- a/experimental/ir/testdata/imports/unused.proto.yaml.sci.yaml
+++ b/experimental/ir/testdata/imports/unused.proto.yaml.sci.yaml
@@ -277,6 +277,108 @@
 - path: ".message_type[A6].field[e].number"
   start: { line: 8, column: 8 }
   end: { line: 8, column: 9 }
+"a7.proto":
+- { path: "", start: { line: 0, column: 0 }, end: { line: 11, column: 1 } }
+- { path: ".syntax", start: { line: 0, column: 0 }, end: { line: 0, column: 18 } }
+- path: ".package"
+  start: { line: 1, column: 0 }
+  end: { line: 1, column: 17 }
+- path: ".dependency.0"
+  start: { line: 3, column: 0 }
+  end: { line: 3, column: 17 }
+- path: ".dependency.0"
+  start: { line: 4, column: 0 }
+  end: { line: 4, column: 17 }
+- path: ".dependency.0"
+  start: { line: 5, column: 0 }
+  end: { line: 5, column: 17 }
+- path: ".message_type[A7]"
+  start: { line: 7, column: 0 }
+  end: { line: 11, column: 1 }
+- path: ".message_type[A7].name"
+  start: { line: 7, column: 8 }
+  end: { line: 7, column: 10 }
+- path: ".message_type[A7].field[b].type_name"
+  start: { line: 8, column: 2 }
+  end: { line: 8, column: 13 }
+- path: ".message_type[A7].field[b]"
+  start: { line: 8, column: 2 }
+  end: { line: 8, column: 20 }
+- path: ".message_type[A7].field[b].name"
+  start: { line: 8, column: 14 }
+  end: { line: 8, column: 15 }
+- path: ".message_type[A7].field[b].number"
+  start: { line: 8, column: 18 }
+  end: { line: 8, column: 19 }
+- path: ".message_type[A7].field[c].type_name"
+  start: { line: 9, column: 2 }
+  end: { line: 9, column: 13 }
+- path: ".message_type[A7].field[c]"
+  start: { line: 9, column: 2 }
+  end: { line: 9, column: 20 }
+- path: ".message_type[A7].field[c].name"
+  start: { line: 9, column: 14 }
+  end: { line: 9, column: 15 }
+- path: ".message_type[A7].field[c].number"
+  start: { line: 9, column: 18 }
+  end: { line: 9, column: 19 }
+- path: ".message_type[A7].field[d].type_name"
+  start: { line: 10, column: 2 }
+  end: { line: 10, column: 13 }
+- path: ".message_type[A7].field[d]"
+  start: { line: 10, column: 2 }
+  end: { line: 10, column: 20 }
+- path: ".message_type[A7].field[d].name"
+  start: { line: 10, column: 14 }
+  end: { line: 10, column: 15 }
+- path: ".message_type[A7].field[d].number"
+  start: { line: 10, column: 18 }
+  end: { line: 10, column: 19 }
+"a8.proto":
+- { path: "", start: { line: 0, column: 0 }, end: { line: 10, column: 1 } }
+- { path: ".syntax", start: { line: 0, column: 0 }, end: { line: 0, column: 18 } }
+- path: ".package"
+  start: { line: 1, column: 0 }
+  end: { line: 1, column: 17 }
+- path: ".dependency.0"
+  start: { line: 3, column: 0 }
+  end: { line: 3, column: 17 }
+- path: ".dependency.0"
+  start: { line: 4, column: 0 }
+  end: { line: 4, column: 17 }
+- path: ".dependency.0"
+  start: { line: 5, column: 0 }
+  end: { line: 5, column: 17 }
+- path: ".message_type[A8]"
+  start: { line: 7, column: 0 }
+  end: { line: 10, column: 1 }
+- path: ".message_type[A8].name"
+  start: { line: 7, column: 8 }
+  end: { line: 7, column: 10 }
+- path: ".message_type[A8].field[b].type_name"
+  start: { line: 8, column: 2 }
+  end: { line: 8, column: 13 }
+- path: ".message_type[A8].field[b]"
+  start: { line: 8, column: 2 }
+  end: { line: 8, column: 20 }
+- path: ".message_type[A8].field[b].name"
+  start: { line: 8, column: 14 }
+  end: { line: 8, column: 15 }
+- path: ".message_type[A8].field[b].number"
+  start: { line: 8, column: 18 }
+  end: { line: 8, column: 19 }
+- path: ".message_type[A8].field[d].type_name"
+  start: { line: 9, column: 2 }
+  end: { line: 9, column: 13 }
+- path: ".message_type[A8].field[d]"
+  start: { line: 9, column: 2 }
+  end: { line: 9, column: 20 }
+- path: ".message_type[A8].field[d].name"
+  start: { line: 9, column: 14 }
+  end: { line: 9, column: 15 }
+- path: ".message_type[A8].field[d].number"
+  start: { line: 9, column: 18 }
+  end: { line: 9, column: 19 }
 "b.proto":
 - { path: "", start: { line: 0, column: 0 }, end: { line: 5, column: 24 } }
 - { path: ".syntax", start: { line: 0, column: 0 }, end: { line: 0, column: 18 } }

--- a/experimental/ir/testdata/imports/unused.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/unused.proto.yaml.stderr.txt
@@ -53,4 +53,15 @@ warning: unused import "c.proto"
    |
    = help: no symbols from this file are referenced
 
-encountered 5 warnings
+warning: unused import "c.proto"
+  --> a8.proto:5:8
+   |
+ 5 | import "c.proto";
+   |        ^^^^^^^^^
+  help: delete it
+   |
+ 5 | - import "c.proto";
+   |
+   = help: no symbols from this file are referenced
+
+encountered 6 warnings

--- a/reporting_test.go
+++ b/reporting_test.go
@@ -411,8 +411,8 @@ func TestWarningReporting(t *testing.T) {
 			// leading-dot fully-qualified references should count as using the import
 			name: "used import with leading dot cross-package reference",
 			sources: map[string]string{
-				"test.proto":                       `syntax = "proto3"; import "shared/address.proto"; message Foo { .shared.USAddress addr = 1; }`,
-				"shared/address.proto":             `syntax = "proto3"; package shared; message USAddress { string street = 1; }`,
+				"test.proto":           `syntax = "proto3"; import "shared/address.proto"; message Foo { .shared.USAddress addr = 1; }`,
+				"shared/address.proto": `syntax = "proto3"; package shared; message USAddress { string street = 1; }`,
 			},
 		},
 	}

--- a/reporting_test.go
+++ b/reporting_test.go
@@ -407,6 +407,14 @@ func TestWarningReporting(t *testing.T) {
 				"google/protobuf/descriptor.proto": `syntax = "proto2"; package google.protobuf; message MessageOptions { optional fixed32 foobar = 99; }`,
 			},
 		},
+		{
+			// leading-dot fully-qualified references should count as using the import
+			name: "used import with leading dot cross-package reference",
+			sources: map[string]string{
+				"test.proto":                       `syntax = "proto3"; import "shared/address.proto"; message Foo { .shared.USAddress addr = 1; }`,
+				"shared/address.proto":             `syntax = "proto3"; package shared; message USAddress { string street = 1; }`,
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Fix marking leading-dot references like `.shared.location.v1.USAAddress` as used for diagnostics.  In the experimental IR path, `symbolRef.resolve()` has a fast path for absolute names.  This path never marks the import as used causing diagnoseUnusedImports to report false positives. Adds a testcase and address the issue.
