### PR TITLE
CI drop custom cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ on:
 permissions:
   contents: read
 jobs:
-  ci:
-    name: ci (go:${{ matrix.go-version.name }})
+  test:
+    name: test (go:${{ matrix.go-version.name }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,6 +21,7 @@ jobs:
             version: 1.26.x
           - name: previous
             version: 1.25.x
+        goarch: [amd64, 386]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -30,18 +31,47 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version.version }}
-      - name: Test (64-bit)
-        run: make test
+      - name: Test
+        run: go test ${{ matrix.goarch == 'amd64' && '-race' || '' }} -cover ./...
+        env:
+          GOARCH: ${{ matrix.goarch }}
+      - name: Test (protolegacy)
+        run: go test -tags protolegacy ./...
+        env:
+          GOARCH: ${{ matrix.goarch }}
+  benchmarks:
+    name: benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.x
       - name: Benchmarks
-        # no need to run benchmarks for every Go version
-        if: matrix.go-version.name == 'latest'
-        run: make benchmarks
-      - name: Test (32-bit)
-        run: GOARCH=386 make test
+        run: |
+          go test -bench=. -benchmem -v ./experimental/benchmark
+          cd internal/benchmarks && go test -bench=. -benchmem -v ./...
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.x
+      # Lint & gofmt guidelines depend on the Go version. Only check generated
+      # code and lint on the most recent supported version.
+      - name: Generate
+        run: make generate
+      - name: Check generate
+        run: make checkgenerate
       - name: Lint
-        # Often, lint & gofmt guidelines depend on the Go version. To prevent
-        # conflicting guidance, run only on the most recent supported version.
-        # For the same reason, only check generated code on the most recent
-        # supported version.
-        if: matrix.go-version.name == 'latest'
-        run: make checkgenerate lint
+        run: make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,4 +47,8 @@ jobs:
           go-version: 1.26.x
       - run: make generate
       - run: make checkgenerate
+      # Often, lint & gofmt guidelines depend on the Go version. To prevent
+      # conflicting guidance, run only on the most recent supported version.
+      # For the same reason, only check generated code on the most recent
+      # supported version.
       - run: make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version.version }}
       - name: Test
-        run: go test ${{ matrix.goarch == 'amd64' && '-race' || '' }} -cover ./...
-        env:
-          GOARCH: ${{ matrix.goarch }}
-      - name: Test (protolegacy)
-        run: go test -tags protolegacy ./...
+        run: make test
         env:
           GOARCH: ${{ matrix.goarch }}
   benchmarks:
@@ -52,9 +48,7 @@ jobs:
         with:
           go-version: 1.26.x
       - name: Benchmarks
-        run: |
-          go test -bench=. -benchmem -v ./experimental/benchmark
-          cd internal/benchmarks && go test -bench=. -benchmem -v ./...
+        run: make benchmarks
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,49 +23,28 @@ jobs:
             version: 1.25.x
         goarch: [amd64, 386]
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version.version }}
-      - name: Test
-        run: make test
+      - run: make test
         env:
           GOARCH: ${{ matrix.goarch }}
   benchmarks:
-    name: benchmarks
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
-      - name: Benchmarks
-        run: make benchmarks
+      - run: make benchmarks
   lint:
-    name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
-      # Lint & gofmt guidelines depend on the Go version. Only check generated
-      # code and lint on the most recent supported version.
-      - name: Generate
-        run: make generate
-      - name: Check generate
-        run: make checkgenerate
-      - name: Lint
-        run: make lint
+      - run: make generate
+      - run: make checkgenerate
+      - run: make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,12 +30,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version.version }}
-      - name: Cache
-        uses: actions/cache@v5
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-protocompile-ci-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-protocompile-ci-
       - name: Test (64-bit)
         run: make test
       - name: Benchmarks

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -37,15 +37,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version.version }}
-      - id: go-cache-paths
-        shell: bash
-        run: |
-          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-      - name: Mod Cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-protocompile-ci-${{ hashFiles('**/go.sum') }}
       - name: Test
         shell: bash
         run: make protoc && go test ./...

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -29,14 +29,11 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - name: Checkout Code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version.version }}
-      - name: Test
-        shell: bash
+      - shell: bash
         run: make protoc && go test ./...

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,12 @@ clean: ## Delete intermediate build artifacts
 	git clean -Xdf
 
 .PHONY: test
-test: build ## Run unit tests
+test: ## Run unit tests
 	$(GO) test $(if $(filter 386,$(GOARCH)),,-race) -cover ./...
 	$(GO) test -tags protolegacy ./...
 
 .PHONY: benchmarks
-benchmarks: build ## Run benchmarks
+benchmarks: ## Run benchmarks
 	$(GO) test -bench=. -benchmem -v ./experimental/benchmark
 	cd internal/benchmarks && $(GO) test -bench=. -benchmem -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,12 @@ clean: ## Delete intermediate build artifacts
 	git clean -Xdf
 
 .PHONY: test
-test: ## Run unit tests
+test: $(PROTOC) ## Run unit tests
 	$(GO) test $(if $(filter 386,$(GOARCH)),,-race) -cover ./...
 	$(GO) test -tags protolegacy ./...
 
 .PHONY: benchmarks
-benchmarks: ## Run benchmarks
+benchmarks: $(PROTOC) ## Run benchmarks
 	$(GO) test -bench=. -benchmem -v ./experimental/benchmark
 	cd internal/benchmarks && $(GO) test -bench=. -benchmem -v ./...
 


### PR DESCRIPTION
The actions/setup-go@v6 defaults to cache: true, which restores ~/go/pkg/mod (GOMODCACHE) and ~/.cache/go-build (GOCACHE) before the explicit actions/cache@v5 step runs. When the explicit cache step then tries to extract its archive into the same ~/go/pkg/mod, tar fails because Go module files are read-only.