### PR TITLE
Fix setting of PACKED value validation

### DIFF
--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -769,7 +769,7 @@ func validatePresence(m Member, r *report.Report) {
 func validatePacked(m Member, r *report.Report) {
 	builtins := m.Context().builtins()
 
-	validate := func(span source.Span) {
+	validate := func(span source.Span, isPacked bool) {
 		switch {
 		case m.IsSingular() || m.IsMap():
 			r.Errorf("expected repeated field, found singular field").Apply(
@@ -777,7 +777,7 @@ func validatePacked(m Member, r *report.Report) {
 				report.Snippetf(span, "packed encoding set here"),
 				report.Helpf("packed encoding can only be set on repeated fields of integer, float, `bool`, or enum type"),
 			)
-		case !m.Element().IsPackable():
+		case isPacked && !m.Element().IsPackable():
 			r.Error(errTypeConstraint{
 				want: "packable type",
 				got:  m.Element(),
@@ -791,8 +791,8 @@ func validatePacked(m Member, r *report.Report) {
 
 	option := m.Options().Field(builtins.Packed)
 	if !option.IsZero() {
+		packed, _ := option.AsBool()
 		if m.Context().Syntax().IsEdition() {
-			packed, _ := option.AsBool()
 			want := "PACKED"
 			if !packed {
 				want = "EXPANDED"
@@ -808,15 +808,17 @@ func validatePacked(m Member, r *report.Report) {
 				builtins.FeaturePacked.Name(), want,
 				"replace with `%s`", builtins.FeaturePacked.Name(),
 			))
-		} else if v, _ := option.AsBool(); v {
+		} else if packed {
 			// Don't validate [packed = false], protoc accepts that.
-			validate(option.ValueAST().Span())
+			validate(option.ValueAST().Span(), true)
 		}
 	}
 
 	feature := m.FeatureSet().Lookup(builtins.FeaturePacked)
 	if feature.IsExplicit() {
-		validate(feature.Value().KeyAST().Span())
+		value, _ := feature.Value().AsInt()
+		isPacked := value == tags.FeatureSet_RepeatedFieldEncoding_Packed
+		validate(feature.Value().KeyAST().Span(), isPacked)
 	}
 }
 

--- a/experimental/ir/testdata/options/validate/packed_2023.proto
+++ b/experimental/ir/testdata/options/validate/packed_2023.proto
@@ -33,4 +33,7 @@ message M {
 
     repeated float f3 = 9 [packed = true];
     repeated float f4 = 10 [packed = false];
+
+    repeated string s1 = 11 [features.repeated_field_encoding = PACKED];
+    repeated string s2 = 12 [features.repeated_field_encoding = EXPANDED];
 }

--- a/experimental/ir/testdata/options/validate/packed_2023.proto.stderr.txt
+++ b/experimental/ir/testdata/options/validate/packed_2023.proto.stderr.txt
@@ -27,17 +27,6 @@ error: expected packable type, found message type `buf.test.M`
    = help: packed encoding can only be set on repeated fields of integer, float,
            `bool`, or enum type
 
-error: expected packable type, found message type `buf.test.M`
-  --> testdata/options/validate/packed_2023.proto:26:14
-   |
-26 |     repeated M m2 = 4 [features.repeated_field_encoding = EXPANDED];
-   |              ^         --------------------------------
-   |                         |
-   |                         packed encoding set here
-   |
-   = help: packed encoding can only be set on repeated fields of integer, float,
-           `bool`, or enum type
-
 error: `packed` is not supported in Edition 2023
   --> testdata/options/validate/packed_2023.proto:34:28
    |
@@ -68,5 +57,16 @@ error: `packed` is not supported in Edition 2023
 35 | +     repeated float f4 = 10 [repeated_field_encoding = EXPANDED];
    |
    = help: removed in Edition 2023
+
+error: expected packable type, found scalar type `string`
+  --> testdata/options/validate/packed_2023.proto:37:14
+   |
+37 |     repeated string s1 = 11 [features.repeated_field_encoding = PACKED];
+   |              ^^^^^^          --------------------------------
+   |                               |
+   |                               packed encoding set here
+   |
+   = help: packed encoding can only be set on repeated fields of integer, float,
+           `bool`, or enum type
 
 encountered 6 errors


### PR DESCRIPTION
This allows setting the `repeated_field_encoding` feature to `EXPANDED` even if the type can't be set to `PACKED`. Fixes protovalidate testcase: see https://github.com/bufbuild/modules/actions/runs/24458011683/job/71463979097