### PR TITLE
Fix enum canoncial name validation

### DIFF
--- a/experimental/ir/lower_json.go
+++ b/experimental/ir/lower_json.go
@@ -21,7 +21,6 @@ import (
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/internal"
-	"github.com/bufbuild/protocompile/internal/cases"
 	"github.com/bufbuild/protocompile/internal/intern"
 	"github.com/bufbuild/protocompile/internal/tags"
 )
@@ -31,6 +30,14 @@ func populateJSONNames(file *File, r *report.Report) {
 	names := intern.Map[Member]{}
 
 	for ty := range seq.Values(file.AllTypes()) {
+		if ty.IsEnum() {
+			// Enum values don't have JSON names in the protobuf spec;
+			// their JSON representation uses the proto name directly.
+			// Canonical name collision checking is handled separately
+			// in validateEnum.
+			continue
+		}
+
 		clear(names)
 
 		jsonFormat, _ := ty.FeatureSet().Lookup(builtins.FeatureJSON).Value().AsInt()
@@ -39,13 +46,7 @@ func populateJSONNames(file *File, r *report.Report) {
 		// First, populate the default names, and check for collisions among
 		// them.
 		for field := range seq.Values(ty.Members()) {
-			var name string
-			if ty.IsEnum() {
-				name = internal.TrimPrefix(field.Name(), ty.Name())
-				name = cases.Enum.Convert(name)
-			} else {
-				name = internal.JSONName(field.Name())
-			}
+			name := internal.JSONName(field.Name())
 
 			field.Raw().jsonName = file.session.intern.Intern(name)
 
@@ -62,12 +63,6 @@ func populateJSONNames(file *File, r *report.Report) {
 					first: prev, second: field,
 				})
 			}
-		}
-
-		if ty.IsEnum() {
-			// Don't bother iterating again, since enums cannot have custom
-			// JSON names.
-			continue
 		}
 
 		clear(names)

--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -219,6 +219,7 @@ func validateEnumValueNames(ty Type, r *report.Report) {
 
 		r.SoftError(strict, errEnumValueConflict{
 			first: prev.member, second: member,
+			enumName:      ty.Name(),
 			canonicalName: name,
 		})
 	}
@@ -237,11 +238,13 @@ func canonicalEnumValueName(enumValueName, enumName string) string {
 // are the same.
 type errEnumValueConflict struct {
 	first, second Member
+	enumName      string
 	canonicalName string
 }
 
 func (e errEnumValueConflict) Diagnose(d *report.Diagnostic) {
-	d.Apply(report.Message("%ss have the same canonical name", e.first.noun()))
+	d.Apply(report.Message("%ss have the same name with the `%s` prefix removed",
+		e.first.noun(), e.enumName))
 	d.Apply(
 		report.Snippetf(e.second.AST().Name(), "this also implies that name"),
 		report.Snippetf(e.first.AST().Name(), "this implies canonical name `%s`", e.canonicalName),

--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -36,6 +36,8 @@ import (
 	"github.com/bufbuild/protocompile/experimental/source"
 	"github.com/bufbuild/protocompile/experimental/token"
 	"github.com/bufbuild/protocompile/experimental/token/keyword"
+	"github.com/bufbuild/protocompile/internal"
+	"github.com/bufbuild/protocompile/internal/cases"
 	"github.com/bufbuild/protocompile/internal/ext/cmpx"
 	"github.com/bufbuild/protocompile/internal/ext/iterx"
 	"github.com/bufbuild/protocompile/internal/ext/mapsx"
@@ -183,6 +185,67 @@ func validateEnum(ty Type, r *report.Report) {
 			report.Helpf("open enums must define a zero value, and it must be the first one"),
 		)
 	}
+
+	validateEnumValueNames(ty, r)
+}
+
+// validateEnumValueNames checks that enum values don't collide after
+// prefix stripping and case normalization. Protoc strips the enum type
+// name prefix and normalizes to PascalCase to ensure generated code
+// in languages with proper enum scoping (Java, Swift, C#) won't have
+// duplicate names.
+func validateEnumValueNames(ty Type, r *report.Report) {
+	builtins := ty.Context().builtins()
+	jsonFormat, _ := ty.FeatureSet().Lookup(builtins.FeatureJSON).Value().AsInt()
+	strict := jsonFormat == tags.FeatureSet_JsonFormat_Allow
+
+	type seen struct {
+		member Member
+		canon  string
+	}
+	canonical := make(map[string]seen)
+
+	for member := range seq.Values(ty.Members()) {
+		name := canonicalEnumValueName(member.Name(), ty.Name())
+		prev, ok := canonical[name]
+		if !ok {
+			canonical[name] = seen{member, name}
+			continue
+		}
+		if prev.member.Number() == member.Number() {
+			// allow_alias: same number means not a real collision.
+			continue
+		}
+
+		r.SoftError(strict, errEnumValueConflict{
+			first: prev.member, second: member,
+			canonicalName: name,
+		})
+	}
+}
+
+// canonicalEnumValueName computes the canonical name for an enum value
+// by stripping the enum type name prefix and converting to PascalCase
+// with naive (underscore-only) word splitting.
+func canonicalEnumValueName(enumValueName, enumName string) string {
+	suffix := internal.TrimPrefix(enumValueName, enumName)
+	return cases.Converter{Case: cases.Pascal, NaiveSplit: true}.Convert(suffix)
+}
+
+// errEnumValueConflict diagnoses a collision between two enum values
+// whose canonical names (after prefix stripping and case normalization)
+// are the same.
+type errEnumValueConflict struct {
+	first, second Member
+	canonicalName string
+}
+
+func (e errEnumValueConflict) Diagnose(d *report.Diagnostic) {
+	d.Apply(report.Message("%ss have the same canonical name", e.first.noun()))
+	d.Apply(
+		report.Snippetf(e.second.AST().Name(), "this also implies that name"),
+		report.Snippetf(e.first.AST().Name(), "this implies canonical name `%s`", e.canonicalName),
+	)
 }
 
 func validateFileOptions(f *File, r *report.Report) {

--- a/experimental/ir/testdata/editions/naming_style_2024_bad.proto.stderr.txt
+++ b/experimental/ir/testdata/editions/naming_style_2024_bad.proto.stderr.txt
@@ -115,7 +115,7 @@ error: enum value name should be SCREAMING_SNAKE_CASE
    = help: STYLE2024 requires enum value names to be SCREAMING_SNAKE_CASE (e.g.,
            MY_VALUE)
 
-error: enum values have the same canonical name
+error: enum values have the same name with the `my_enum` prefix removed
   --> testdata/editions/naming_style_2024_bad.proto:37:3
    |
 36 |   _VALUE = 2;      // Leading underscore

--- a/experimental/ir/testdata/editions/naming_style_2024_bad.proto.stderr.txt
+++ b/experimental/ir/testdata/editions/naming_style_2024_bad.proto.stderr.txt
@@ -115,11 +115,11 @@ error: enum value name should be SCREAMING_SNAKE_CASE
    = help: STYLE2024 requires enum value names to be SCREAMING_SNAKE_CASE (e.g.,
            MY_VALUE)
 
-error: enum values have the same JSON name
+error: enum values have the same canonical name
   --> testdata/editions/naming_style_2024_bad.proto:37:3
    |
 36 |   _VALUE = 2;      // Leading underscore
-   |   ------ this implies JSON name `VALUE`
+   |   ------ this implies canonical name `Value`
 37 |   VALUE_ = 3;      // Trailing underscore
    |   ^^^^^^ this also implies that name
 

--- a/experimental/ir/testdata/options/json.proto
+++ b/experimental/ir/testdata/options/json.proto
@@ -47,6 +47,12 @@ enum Bar {
     FOO_BAR = 3;
     FOOBAR = 4;
     BarFooBar = 5;
+
+    _BAR__ZERO2 = 6;
+    _BAR_ZERO2 = 7;
+
+    BAR_Z_ERO = 8;
+    BAR_Z__ERO = 9;
 }
 
 extend Foo {

--- a/experimental/ir/testdata/options/json.proto.stderr.txt
+++ b/experimental/ir/testdata/options/json.proto.stderr.txt
@@ -42,7 +42,7 @@ warning: message fields have the same (default) JSON name
            conflict, because `google.protobuf.FieldMask`'s JSON syntax
            erroneously does not account for custom JSON names
 
-error: enum values have the same canonical name
+error: enum values have the same name with the `Bar` prefix removed
   --> testdata/options/json.proto:44:5
    |
 43 |     ZERO = 0;
@@ -50,7 +50,7 @@ error: enum values have the same canonical name
 44 |     BAR_ZERO = 1;
    |     ^^^^^^^^ this also implies that name
 
-error: enum values have the same canonical name
+error: enum values have the same name with the `Bar` prefix removed
   --> testdata/options/json.proto:45:5
    |
 43 |     ZERO = 0;
@@ -59,7 +59,7 @@ error: enum values have the same canonical name
 45 |     b_a_r_zero = 2;
    |     ^^^^^^^^^^ this also implies that name
 
-error: enum values have the same canonical name
+error: enum values have the same name with the `Bar` prefix removed
   --> testdata/options/json.proto:49:5
    |
 48 |     FOOBAR = 4;
@@ -67,7 +67,7 @@ error: enum values have the same canonical name
 49 |     BarFooBar = 5;
    |     ^^^^^^^^^ this also implies that name
 
-error: enum values have the same canonical name
+error: enum values have the same name with the `Bar` prefix removed
   --> testdata/options/json.proto:52:5
    |
 51 |     _BAR__ZERO2 = 6;
@@ -75,7 +75,7 @@ error: enum values have the same canonical name
 52 |     _BAR_ZERO2 = 7;
    |     ^^^^^^^^^^ this also implies that name
 
-error: enum values have the same canonical name
+error: enum values have the same name with the `Bar` prefix removed
   --> testdata/options/json.proto:55:5
    |
 54 |     BAR_Z_ERO = 8;

--- a/experimental/ir/testdata/options/json.proto.stderr.txt
+++ b/experimental/ir/testdata/options/json.proto.stderr.txt
@@ -42,48 +42,63 @@ warning: message fields have the same (default) JSON name
            conflict, because `google.protobuf.FieldMask`'s JSON syntax
            erroneously does not account for custom JSON names
 
-error: enum values have the same JSON name
+error: enum values have the same canonical name
   --> testdata/options/json.proto:44:5
    |
 43 |     ZERO = 0;
-   |     ---- this implies JSON name `ZERO`
+   |     ---- this implies canonical name `Zero`
 44 |     BAR_ZERO = 1;
    |     ^^^^^^^^ this also implies that name
 
-error: enum values have the same JSON name
+error: enum values have the same canonical name
   --> testdata/options/json.proto:45:5
    |
 43 |     ZERO = 0;
-   |     ---- this implies JSON name `ZERO`
+   |     ---- this implies canonical name `Zero`
 44 |     BAR_ZERO = 1;
 45 |     b_a_r_zero = 2;
    |     ^^^^^^^^^^ this also implies that name
 
-error: enum values have the same JSON name
+error: enum values have the same canonical name
   --> testdata/options/json.proto:49:5
    |
-47 |     FOO_BAR = 3;
-   |     ------- this implies JSON name `FOO_BAR`
 48 |     FOOBAR = 4;
+   |     ------ this implies canonical name `Foobar`
 49 |     BarFooBar = 5;
    |     ^^^^^^^^^ this also implies that name
 
-error: message extension cannot specify `json_name`
-  --> testdata/options/json.proto:53:20
+error: enum values have the same canonical name
+  --> testdata/options/json.proto:52:5
    |
-53 |     int32 x = 100 [json_name = "foo"];
+51 |     _BAR__ZERO2 = 6;
+   |     ----------- this implies canonical name `Zero2`
+52 |     _BAR_ZERO2 = 7;
+   |     ^^^^^^^^^^ this also implies that name
+
+error: enum values have the same canonical name
+  --> testdata/options/json.proto:55:5
+   |
+54 |     BAR_Z_ERO = 8;
+   |     --------- this implies canonical name `ZEro`
+55 |     BAR_Z__ERO = 9;
+   |     ^^^^^^^^^^ this also implies that name
+
+error: message extension cannot specify `json_name`
+  --> testdata/options/json.proto:59:20
+   |
+59 |     int32 x = 100 [json_name = "foo"];
    |                    ^^^^^^^^^^^^^^^^^
    = note: JSON format for extensions always uses the extension's
            fully-qualified name
 
 warning: message extension cannot specify `json_name`
-  --> testdata/options/json.proto:54:20
+  --> testdata/options/json.proto:60:20
    |
-54 |     int32 y = 101 [json_name = "y"];
+60 |     int32 y = 101 [json_name = "y"];
    |                    ^^^^^^^^^^^^^^^
    = note: JSON format for extensions always uses the extension's
            fully-qualified name
    = help: protoc erroneously accepts `json_name` on an extension if it happens
            to match the default JSON name exactly
 
-encountered 7 errors and 3 warnings
+encountered 9 errors and 3 warnings

--- a/experimental/ir/testdata/options/validate/enum_names.proto
+++ b/experimental/ir/testdata/options/validate/enum_names.proto
@@ -1,0 +1,30 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//% descriptor: true
+
+// Regression: camelCase and snake_case enum values that look similar
+// must not collide. Canonical name uses underscore-only word splitting,
+// so "fooBar" stays one word ("Foobar") while "foo_bar" splits into
+// two ("FooBar").
+
+syntax = "proto3";
+
+package buf.test;
+
+enum E {
+    E_UNSPECIFIED = 0;
+    foo_bar = 1;
+    fooBar = 2;
+}

--- a/experimental/ir/testdata/options/validate/enum_names.proto.fds.yaml
+++ b/experimental/ir/testdata/options/validate/enum_names.proto.fds.yaml
@@ -1,0 +1,10 @@
+file:
+- name: "testdata/options/validate/enum_names.proto"
+  package: "buf.test"
+  enum_type:
+  - name: "E"
+    value:
+    - { name: "E_UNSPECIFIED", number: 0 }
+    - { name: "foo_bar", number: 1 }
+    - { name: "fooBar", number: 2 }
+  syntax: "proto3"

--- a/internal/cases/words.go
+++ b/internal/cases/words.go
@@ -24,69 +24,57 @@ import (
 // https://docs.rs/heck/latest/heck/#definition-of-a-word-boundary.
 func Words(str string) iter.Seq[string] {
 	return func(yield func(string) bool) {
-		input := str // Not yet yielded.
-
+		start := -1
 		var prev rune
-		first := true
-		for str != "" {
-			next, n := utf8.DecodeRuneInString(str)
-			str = str[n:]
+
+		for i := 0; i < len(str); {
+			curr, size := utf8.DecodeRuneInString(str[i:])
+			alnum := unicode.IsLetter(curr) || unicode.IsDigit(curr)
 
 			switch {
-			case !unicode.IsLetter(next) && !unicode.IsDigit(next):
-				// This is punctuation. Split the string around next and
-				// yield the result if it's nonempty.
-				word := input[:len(input)-len(str)-n]
-				input = input[len(input)-len(str):]
-				if word != "" && !yield(word) {
-					return
-				}
-
-			case unicode.IsUpper(prev) && unicode.IsLower(next):
-				// If the previous rune is uppercase and the next is lowercase,
-				// we want to insert a boundary before prev.
-				idx := len(input) - len(str) - n - utf8.RuneLen(prev)
-
-				word := input[:idx]
-				input = input[idx:]
-				if word != "" && !yield(word) {
-					return
-				}
-				// If next was also the last rune, yield the remaining word and
-				// return. Without this, the last-rune case below never fires
-				// for 2-char [A-Z][a-z] strings (e.g. "Ab"), because the loop
-				// exits after this iteration without yielding input.
-				if str == "" {
-					yield(input)
-					return
-				}
-
-			case str == "":
-				if first { // Single-rune string.
-					yield(input)
-					return
-				}
-
-				// This is the last rune, which gets special handling. We want
-				// FooBAR and FooBar to become foo_bar but FooX to become foo_x.
-				// Hence, if next is uppercase and prev is not, then we insert a
-				// boundary between them.
-
-				if !unicode.IsUpper(prev) && unicode.IsUpper(next) {
-					idx := len(input) - len(str) - n
-					word := input[:idx]
-					input = input[idx:]
-					if word != "" && !yield(word) {
+			case !alnum:
+				// Punctuation and spaces act as hard boundaries.
+				// Yield the current word and reset the tracker.
+				if start != -1 {
+					if !yield(str[start:i]) {
 						return
 					}
+					start = -1
 				}
 
-				yield(input)
-				return
+			case start == -1:
+				// We found an alphanumeric character, start tracking a new word.
+				start = i
+
+			default:
+				// We are inside a word. Look ahead to check for case-transition boundaries.
+				var next rune
+				if i+size < len(str) {
+					next, _ = utf8.DecodeRuneInString(str[i+size:])
+				}
+
+				splitHere :=
+					// Rule A: Transition from lowercase/digit to uppercase (e.g., camelCase -> camel, Case)
+					(!unicode.IsUpper(prev) && unicode.IsUpper(curr)) ||
+						// Rule B: Uppercase sequence followed by lowercase (e.g., XMLHttp -> XML, Http)
+						(unicode.IsUpper(prev) && unicode.IsUpper(curr) && unicode.IsLower(next))
+
+				if splitHere {
+					if !yield(str[start:i]) {
+						return
+					}
+					// The current uppercase character becomes the start of the next word.
+					start = i
+				}
 			}
 
-			prev = next
-			first = false
+			prev = curr
+			i += size
+		}
+
+		// Yield any remaining alphanumeric characters as the final word.
+		if start != -1 {
+			yield(str[start:])
 		}
 	}
 }

--- a/internal/cases/words_test.go
+++ b/internal/cases/words_test.go
@@ -45,7 +45,7 @@ func TestWords(t *testing.T) {
 		{str: "FOOBar", want: []string{"FOO", "Bar"}},
 		{str: "FooX", want: []string{"Foo", "X"}},
 		{str: "FOO", want: []string{"FOO"}},
-		{str: "FooBARBaz", want: []string{"FooBAR", "Baz"}},
+		{str: "FooBARBaz", want: []string{"Foo", "BAR", "Baz"}},
 
 		// Regression: 2-char [A-Z][a-z] strings produced an empty word list
 		// because the upper+lower boundary case and the last-rune case both


### PR DESCRIPTION
This separates out the enum value validation from its JSON representation. Enum values don't have JSON names in the protobuf spec; their JSON encoding uses the proto name directly. Moved the collision check out of `populateJSONNames` into `validateEnum`.

The canonicalization matches protoc: strip the enum type prefix, then PascalCase with underscore-only word splitting. For example:
```protobuf
enum Bar {
  BAR_Z_ERO = 0;   // canonical: "ZEro"
  BAR_Z__ERO = 1;  // canonical: "ZEro" -- collision
  notApplicable = 2;  // canonical: "Notapplicable"
  not_applicable = 3; // canonical: "NotApplicable" -- no collision
}
```

Rewrote `Words()` for clarity (fixes FooBARBaz splitting).