### PR TITLE
Fix ordering of nested types

### DIFF
--- a/experimental/ir/lower_maps.go
+++ b/experimental/ir/lower_maps.go
@@ -15,6 +15,7 @@
 package ir
 
 import (
+	"cmp"
 	"slices"
 	"sync"
 
@@ -131,5 +132,21 @@ func generateMapEntries(file *File, r *report.Report) {
 				"define a message type with a map-typed field"),
 		)
 		lowerField(extn)
+	}
+
+	// Synthetic map-entry types are appended to the end of parent message's nested types.
+	// For conformance with protoc, the nested types are sorted by source-declaration order,
+	// based on the AST span.
+	for parent := range seq.Values(file.AllTypes()) {
+		if !parent.IsMessage() {
+			continue
+		}
+		nested := parent.Raw().nested
+		slices.SortStableFunc(nested, func(a, b id.ID[Type]) int {
+			return cmp.Compare(
+				id.Wrap(file, a).AST().Span().Start,
+				id.Wrap(file, b).AST().Span().Start,
+			)
+		})
 	}
 }

--- a/experimental/ir/testdata/fields/maps/collision.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/collision.proto.fds.yaml
@@ -12,7 +12,6 @@ file:
       json_name: "fooBar"
     nested_type:
     - name: "FooBarEntry"
-    - name: "FooBarEntry"
       field:
       - name: "key"
         number: 1
@@ -25,6 +24,7 @@ file:
         type: TYPE_INT32
         json_name: "value"
       options.map_entry: true
+    - name: "FooBarEntry"
   - name: "Underscores"
     field:
     - name: "_"

--- a/experimental/ir/testdata/fields/maps/ordering.proto
+++ b/experimental/ir/testdata/fields/maps/ordering.proto
@@ -1,0 +1,42 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Exercises the ordering of synthetic map entry types relative to
+// concrete nested message/enum declarations. Synthetic map entries must
+// appear at their originating map field's source position to match protoc.
+
+//% descriptor: true
+syntax = "proto3";
+
+package test;
+
+message MapBeforeNested {
+    map<string, string> my_map = 1;
+    message Nested {}
+}
+
+message NestedBeforeMap {
+    message Nested {}
+    map<string, string> my_map = 1;
+}
+
+message Interleaved {
+    message A {}
+    map<string, string> m1 = 1;
+    message B {}
+    map<int32, string> m2 = 2;
+    enum E { E_ZERO = 0; }
+    message C {}
+    map<string, int32> m3 = 3;
+}

--- a/experimental/ir/testdata/fields/maps/ordering.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/maps/ordering.proto.fds.yaml
@@ -1,0 +1,115 @@
+file:
+- name: "testdata/fields/maps/ordering.proto"
+  package: "test"
+  message_type:
+  - name: "MapBeforeNested"
+    field:
+    - name: "my_map"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.MapBeforeNested.MyMapEntry"
+      json_name: "myMap"
+    nested_type:
+    - name: "MyMapEntry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      options.map_entry: true
+    - name: "Nested"
+  - name: "NestedBeforeMap"
+    field:
+    - name: "my_map"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.NestedBeforeMap.MyMapEntry"
+      json_name: "myMap"
+    nested_type:
+    - name: "Nested"
+    - name: "MyMapEntry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      options.map_entry: true
+  - name: "Interleaved"
+    field:
+    - name: "m1"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Interleaved.M1Entry"
+      json_name: "m1"
+    - name: "m2"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Interleaved.M2Entry"
+      json_name: "m2"
+    - name: "m3"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".test.Interleaved.M3Entry"
+      json_name: "m3"
+    nested_type:
+    - name: "A"
+    - name: "M1Entry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      options.map_entry: true
+    - name: "B"
+    - name: "M2Entry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "key"
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      options.map_entry: true
+    - name: "C"
+    - name: "M3Entry"
+      field:
+      - name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      - name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "value"
+      options.map_entry: true
+    enum_type: [{ name: "E", value: [{ name: "E_ZERO", number: 0 }] }]
+  syntax: "proto3"


### PR DESCRIPTION
This PR makes a change to the lowering process. Before this change,
map entry types are generated after the walk for the rest of the type graph,
and so map entry types are appended after all other nested types, regardless
of declaration order.

This PR sorts the nested types by AST span ordering, since this is conformant
with `protoc` and the legacy compiler.