### PR TITLE
Check for extension tag duplicates among imports

### DIFF
--- a/experimental/incremental/queries/link.go
+++ b/experimental/incremental/queries/link.go
@@ -15,8 +15,12 @@
 package queries
 
 import (
+	"maps"
+	"slices"
+
 	"github.com/bufbuild/protocompile/experimental/incremental"
 	"github.com/bufbuild/protocompile/experimental/ir"
+	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/experimental/source"
 	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 )
@@ -66,7 +70,19 @@ func (l Link) Execute(t *incremental.Task) ([]*ir.File, error) {
 		return nil, err
 	}
 
+	// Symbols are already deduplicated among imported files during the IR queries.
 	ir.DedupExportedSymbols(t.Report(), files...)
-	ir.DedupExtensions(t.Report(), files...)
+	// Extension numbers are not deduped among imports during the IR queries, so all imported
+	// files are added to this check. We avoid adding duplicated imported files.
+	seen := make(map[string]*ir.File)
+	for _, file := range files {
+		for imp := range seq.Values(file.Imports()) {
+			if exists := seen[imp.Path()]; exists == nil {
+				seen[imp.Path()] = imp.File
+			}
+		}
+	}
+	allFiles := append(files, slices.Collect(maps.Values(seen))...)
+	ir.DedupExtensions(t.Report(), allFiles...)
 	return files, nil
 }

--- a/experimental/incremental/queries/link.go
+++ b/experimental/incremental/queries/link.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/ir"
 	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/experimental/source"
+	"github.com/bufbuild/protocompile/internal/ext/mapsx"
 	"github.com/bufbuild/protocompile/internal/ext/slicesx"
 )
 
@@ -77,13 +78,14 @@ func (l Link) Execute(t *incremental.Task) ([]*ir.File, error) {
 	var requiredImports []*ir.File
 	for _, file := range files {
 		// We will already include all linked files
+		mapsx.Add(seen, file.Path(), file)
 		if exists := seen[file.Path()]; exists == nil {
 			seen[file.Path()] = file
 		}
 		for imp := range seq.Values(file.Imports()) {
-			if exists := seen[imp.Path()]; exists == nil {
-				seen[imp.Path()] = imp.File
-				requiredImports = append(requiredImports, imp.File)
+			file, inserted := mapsx.Add(seen, imp.Path(), imp.File)
+			if inserted {
+				requiredImports = append(requiredImports, file)
 			}
 		}
 	}

--- a/experimental/incremental/queries/link.go
+++ b/experimental/incremental/queries/link.go
@@ -82,7 +82,7 @@ func (l Link) Execute(t *incremental.Task) ([]*ir.File, error) {
 			}
 		}
 	}
-	allFiles := append(files, slices.Collect(maps.Values(seen))...)
-	ir.DedupExtensions(t.Report(), allFiles...)
+	// Make a copy of the files slice
+	ir.DedupExtensions(t.Report(), slices.Concat(files, slices.Collect(maps.Values(seen)))...)
 	return files, nil
 }

--- a/experimental/incremental/queries/link.go
+++ b/experimental/incremental/queries/link.go
@@ -15,7 +15,6 @@
 package queries
 
 import (
-	"maps"
 	"slices"
 
 	"github.com/bufbuild/protocompile/experimental/incremental"
@@ -75,14 +74,20 @@ func (l Link) Execute(t *incremental.Task) ([]*ir.File, error) {
 	// Extension numbers are not deduped among imports during the IR queries, so all imported
 	// files are added to this check. We avoid adding duplicated imported files.
 	seen := make(map[string]*ir.File)
+	var requiredImports []*ir.File
 	for _, file := range files {
+		// We will already include all linked files
+		if exists := seen[file.Path()]; exists == nil {
+			seen[file.Path()] = file
+		}
 		for imp := range seq.Values(file.Imports()) {
 			if exists := seen[imp.Path()]; exists == nil {
 				seen[imp.Path()] = imp.File
+				requiredImports = append(requiredImports, imp.File)
 			}
 		}
 	}
 	// Make a copy of the files slice
-	ir.DedupExtensions(t.Report(), slices.Concat(files, slices.Collect(maps.Values(seen)))...)
+	ir.DedupExtensions(t.Report(), slices.Concat(files, requiredImports)...)
 	return files, nil
 }

--- a/experimental/ir/testdata/extend/duplicate.proto.yaml
+++ b/experimental/ir/testdata/extend/duplicate.proto.yaml
@@ -52,3 +52,28 @@ files:
       optional int32 d = 3;
     }
 
+# d.proto is not part of the workspace but its extension should still participate
+# in the duplicate check because it is a direct import of e.proto.
+- path: "d.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package test;
+
+    import public "a.proto";
+
+    extend M {
+      optional int32 e = 4;
+    }
+
+- path: "e.proto"
+  text: |
+    syntax = "proto2";
+    package test;
+
+    import "d.proto";
+
+    extend M {
+      optional int32 f = 4;
+    }
+

--- a/experimental/ir/testdata/extend/duplicate.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/extend/duplicate.proto.yaml.stderr.txt
@@ -9,4 +9,15 @@ error: field number `1` used more than once
  7 |   optional int32 a = 1;
    |                      - previously used here
 
-encountered 1 error
+error: field number `4` used more than once
+  --> d.proto:7:22
+   |
+ 7 |   optional int32 e = 4;
+   |                      ^ used here
+   |
+  ::: e.proto:7:22
+   |
+ 7 |   optional int32 f = 4;
+   |                      - previously used here
+
+encountered 2 errors


### PR DESCRIPTION
Currently, in the `Link` query, we check for duplicated extension tags
across the linked files. However, unlike symbols, the duplicate extension
tags are not checked among imports in the lowering process, so this PR
adds imported files to the duplicate extension tags check.