### PR TITLE
Preserve vertical whitespace in block comments in `experimental`

### DIFF
--- a/experimental/fdp/comments.go
+++ b/experimental/fdp/comments.go
@@ -38,6 +38,13 @@ type commentTracker struct {
 	firstCommentOnSameLine bool
 }
 
+// isNonNewlineSpace reports whether r is whitespace other than a newline.
+// Used when trimming block-comment line prefixes so a blank line (which is
+// just "\n") keeps its newline.
+func isNonNewlineSpace(r rune) bool {
+	return r != '\n' && unicode.IsSpace(r)
+}
+
 // A paragraph is a group of comment and whitespace tokens that make up a single paragraph comment.
 type paragraph []token.Token
 
@@ -67,8 +74,9 @@ func (p paragraph) stringify() string {
 			for i, line := range strings.SplitAfter(text, "\n") {
 				// The block opening prefix has already been trimmed for the first line.
 				if i != 0 {
-					// Trim the leading whitespace and then check for a leading "*" prefix.
-					line = strings.TrimPrefix(strings.TrimLeftFunc(line, unicode.IsSpace), "*")
+					// Trim leading whitespace except "\n" itself, so a blank line keeps
+					// its newline instead of collapsing to an empty string.
+					line = strings.TrimPrefix(strings.TrimLeftFunc(line, isNonNewlineSpace), "*")
 				}
 
 				str.WriteString(line)

--- a/experimental/fdp/comments_test.go
+++ b/experimental/fdp/comments_test.go
@@ -91,6 +91,17 @@ func TestBlockComments(t *testing.T) {
 		"\n Line 1\n",
 		18,
 	)
+	testBlockComments(
+		t,
+		"multi-line block with blank line",
+		`/*
+  A block comment
+
+  with new lines preserved.
+*/`,
+		"\nA block comment\n\nwith new lines preserved.\n",
+		52,
+	)
 }
 
 func testBlockComments(t *testing.T, test, text, expectedComments string, blockLen int) {

--- a/experimental/ir/testdata/comments/attribution.proto
+++ b/experimental/ir/testdata/comments/attribution.proto
@@ -84,6 +84,13 @@ enum Baz { // This is a trailing comment for enum Baz.
   BAZ_ONE = 0;
 } // This is NOT a trailing comment for Baz. It is discarded.
 
+/*
+  A block comment
+
+  with new lines preserved.
+*/
+message Qux {}
+
 // This is the leading comment for service FooService.
 service FooService { // This is a trailing comment for service FooService.
   // Leading comment for method FooForBar.

--- a/experimental/ir/testdata/comments/attribution.proto.fds.yaml
+++ b/experimental/ir/testdata/comments/attribution.proto.fds.yaml
@@ -37,6 +37,7 @@ file:
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       json_name: "barbar"
+  - name: "Qux"
   enum_type: [{ name: "Baz", value: [{ name: "BAZ_ONE", number: 0 }] }]
   service:
   - name: "FooService"

--- a/experimental/ir/testdata/comments/attribution.proto.sci.yaml
+++ b/experimental/ir/testdata/comments/attribution.proto.sci.yaml
@@ -1,5 +1,5 @@
 "testdata/comments/attribution.proto":
-- { path: "", start: { line: 16, column: 0 }, end: { line: 102, column: 1 } }
+- { path: "", start: { line: 16, column: 0 }, end: { line: 109, column: 1 } }
 - path: ".syntax"
   start: { line: 16, column: 0 }
   end: { line: 16, column: 17 }
@@ -191,81 +191,88 @@
 - path: ".enum_type[Baz].value[BAZ_ONE].number"
   start: { line: 83, column: 12 }
   end: { line: 83, column: 13 }
+- path: ".message_type[Qux]"
+  start: { line: 91, column: 0 }
+  end: { line: 91, column: 14 }
+  leading: "\nA block comment\n\nwith new lines preserved.\n"
+- path: ".message_type[Qux].name"
+  start: { line: 91, column: 8 }
+  end: { line: 91, column: 11 }
 - path: ".service[FooService]"
-  start: { line: 87, column: 0 }
-  end: { line: 94, column: 1 }
+  start: { line: 94, column: 0 }
+  end: { line: 101, column: 1 }
   leading: " This is the leading comment for service FooService.\n"
   trailing: " This is a trailing comment for service FooService."
 - path: ".service[FooService].name"
-  start: { line: 87, column: 8 }
-  end: { line: 87, column: 18 }
+  start: { line: 94, column: 8 }
+  end: { line: 94, column: 18 }
 - path: ".service[FooService].method[FooForBar]"
-  start: { line: 89, column: 2 }
-  end: { line: 89, column: 35 }
+  start: { line: 96, column: 2 }
+  end: { line: 96, column: 35 }
   leading: " Leading comment for method FooForBar.\n"
   trailing: " Trailing comment for FooForBar."
 - path: ".service[FooService].method[FooForBar].name"
-  start: { line: 89, column: 6 }
-  end: { line: 89, column: 15 }
+  start: { line: 96, column: 6 }
+  end: { line: 96, column: 15 }
 - path: ".service[FooService].method[FooForBar].input_type"
-  start: { line: 89, column: 16 }
-  end: { line: 89, column: 19 }
+  start: { line: 96, column: 16 }
+  end: { line: 96, column: 19 }
 - path: ".service[FooService].method[FooForBar].output_type"
-  start: { line: 89, column: 30 }
-  end: { line: 89, column: 33 }
+  start: { line: 96, column: 30 }
+  end: { line: 96, column: 33 }
 - path: ".service[FooService].method[BarForBar]"
-  start: { line: 92, column: 2 }
-  end: { line: 93, column: 3 }
+  start: { line: 99, column: 2 }
+  end: { line: 100, column: 3 }
   leading: " Leading comment for method BarForBar.\n"
   trailing: " Trailing comment for BarForBar."
 - path: ".service[FooService].method[BarForBar].name"
-  start: { line: 92, column: 6 }
-  end: { line: 92, column: 15 }
+  start: { line: 99, column: 6 }
+  end: { line: 99, column: 15 }
 - path: ".service[FooService].method[BarForBar].input_type"
-  start: { line: 92, column: 16 }
-  end: { line: 92, column: 19 }
+  start: { line: 99, column: 16 }
+  end: { line: 99, column: 19 }
 - path: ".service[FooService].method[BarForBar].output_type"
-  start: { line: 92, column: 30 }
-  end: { line: 92, column: 33 }
+  start: { line: 99, column: 30 }
+  end: { line: 99, column: 33 }
 - path: ".extension"
-  start: { line: 96, column: 0 }
-  end: { line: 98, column: 1 }
+  start: { line: 103, column: 0 }
+  end: { line: 105, column: 1 }
 - path: ".extension[c].extendee"
-  start: { line: 96, column: 7 }
-  end: { line: 96, column: 35 }
+  start: { line: 103, column: 7 }
+  end: { line: 103, column: 35 }
 - path: ".extension[c].label"
-  start: { line: 97, column: 2 }
-  end: { line: 97, column: 10 }
+  start: { line: 104, column: 2 }
+  end: { line: 104, column: 10 }
 - path: ".extension[c]"
-  start: { line: 97, column: 2 }
-  end: { line: 97, column: 26 }
+  start: { line: 104, column: 2 }
+  end: { line: 104, column: 26 }
 - path: ".extension[c].type"
-  start: { line: 97, column: 11 }
-  end: { line: 97, column: 16 }
+  start: { line: 104, column: 11 }
+  end: { line: 104, column: 16 }
 - path: ".extension[c].name"
-  start: { line: 97, column: 17 }
-  end: { line: 97, column: 18 }
+  start: { line: 104, column: 17 }
+  end: { line: 104, column: 18 }
 - path: ".extension[c].number"
-  start: { line: 97, column: 21 }
-  end: { line: 97, column: 25 }
+  start: { line: 104, column: 21 }
+  end: { line: 104, column: 25 }
 - path: ".extension"
-  start: { line: 100, column: 0 }
-  end: { line: 102, column: 1 }
+  start: { line: 107, column: 0 }
+  end: { line: 109, column: 1 }
 - path: ".extension[a].extendee"
-  start: { line: 100, column: 7 }
-  end: { line: 100, column: 37 }
+  start: { line: 107, column: 7 }
+  end: { line: 107, column: 37 }
 - path: ".extension[a].label"
-  start: { line: 101, column: 2 }
-  end: { line: 101, column: 10 }
+  start: { line: 108, column: 2 }
+  end: { line: 108, column: 10 }
 - path: ".extension[a]"
-  start: { line: 101, column: 2 }
-  end: { line: 101, column: 26 }
+  start: { line: 108, column: 2 }
+  end: { line: 108, column: 26 }
 - path: ".extension[a].type"
-  start: { line: 101, column: 11 }
-  end: { line: 101, column: 16 }
+  start: { line: 108, column: 11 }
+  end: { line: 108, column: 16 }
 - path: ".extension[a].name"
-  start: { line: 101, column: 17 }
-  end: { line: 101, column: 18 }
+  start: { line: 108, column: 17 }
+  end: { line: 108, column: 18 }
 - path: ".extension[a].number"
-  start: { line: 101, column: 21 }
-  end: { line: 101, column: 25 }
+  start: { line: 108, column: 21 }
+  end: { line: 108, column: 25 }


### PR DESCRIPTION
Multi-line block comments without leading `*` that are empty are stripped in the `experimental` compiler, a regression in the compiled `source_code_info` for comments of this form across compiler version.

This changes was shipped in the `buf` CLI in `1.68.0`.

This change avoids stripping `\n` in these scenarios.

Closes: #717