### PR TITLE
Propagate fatal error from Link query in FDS

### DIFF
--- a/experimental/incremental/queries/fds.go
+++ b/experimental/incremental/queries/fds.go
@@ -60,6 +60,9 @@ func (l FDS) Execute(t *incremental.Task) (*descriptorpb.FileDescriptorSet, erro
 	if err != nil {
 		return nil, err
 	}
+	if linkResult[0].Fatal != nil {
+		return nil, linkResult[0].Fatal
+	}
 
 	irs := linkResult[0].Value
 	irs = slices.DeleteFunc(irs, func(f *ir.File) bool { return f == nil })


### PR DESCRIPTION
`FDS.Execute` was not checking `linkResult[0].Fatal` before iterating over IR files. When `Link.Execute` fails fatally (e.g. due to a file-open error like `DuplicateProtoPathError`), its result value is nil, so FDS silently produced an empty `FileDescriptorSet` with no fatal error instead of propagating the underlying error to callers.

Add the same guard used elsewhere in this package — identical to the check in `IR.Execute` after its `AST` sub-query (`ir.go:62-64`), and to the `fdpResults` check already present later in `FDS.Execute` itself.