### PR TITLE
Add 2024 parsing test case back

### DIFF
--- a/experimental/parser/testdata/parser/syntax/2024.proto
+++ b/experimental/parser/testdata/parser/syntax/2024.proto
@@ -1,0 +1,3 @@
+edition = "2024";
+
+package test;

--- a/experimental/parser/testdata/parser/syntax/2024.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/syntax/2024.proto.stderr.txt
@@ -1,7 +1,0 @@
-error: sorry, Edition 2024 is not fully implemented
-  --> testdata/parser/syntax/2024.proto:15:11
-   |
-15 | edition = "2024";
-   |           ^^^^^^
-
-encountered 1 error


### PR DESCRIPTION
This adds the parsing test case back, and we now no longer
error on Editions 2024, so it removes the stale `stderr` golden.