### PR TITLE
Expand arrays with attached comments in the formatter

### DIFF
--- a/experimental/ast/printer/expr.go
+++ b/experimental/ast/printer/expr.go
@@ -225,7 +225,7 @@ func (p *printer) printArray(expr ast.ExprArray, gap gapStyle) {
 
 	hasComments := triviaHasComments(slots)
 	// Also check for comments attached to any token in the scope
-	// (trailing on open brace, leading on close brace, or on any
+	// (trailing on open bracket, leading on close bracket, or on any
 	// interior token). These force multi-line expansion.
 	if !hasComments {
 		hasComments = p.scopeHasAttachedComments(brackets)

--- a/experimental/ast/printer/expr.go
+++ b/experimental/ast/printer/expr.go
@@ -224,6 +224,12 @@ func (p *printer) printArray(expr ast.ExprArray, gap gapStyle) {
 	}
 
 	hasComments := triviaHasComments(slots)
+	// Also check for comments attached to any token in the scope
+	// (trailing on open brace, leading on close brace, or on any
+	// interior token). These force multi-line expansion.
+	if !hasComments {
+		hasComments = p.scopeHasAttachedComments(brackets)
+	}
 
 	if elements.Len() == 0 && !hasComments {
 		p.printToken(openTok, gap)

--- a/experimental/ast/printer/testdata/bufformat/proto2/option/v1/option_message_field.golden
+++ b/experimental/ast/printer/testdata/bufformat/proto2/option/v1/option_message_field.golden
@@ -63,7 +63,11 @@ message Test {
         foo: "goo" // Trailing comment on foo
 
         // Leading comment on extension name.
-        [/* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */] /* Three */ : "boo" // Trailing comment on extension name.
+        [
+          /* One */
+          foo.bar.Test.Nested._NestedNested._garblez
+          /* Two */
+        ] /* Three */ : "boo" // Trailing comment on extension name.
 
         // Leading comment on '}'.
       };

--- a/experimental/ast/printer/testdata/format/array_comment.proto
+++ b/experimental/ast/printer/testdata/format/array_comment.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option (any) = {
+  array: [
+    "x" // comment
+  ]
+};

--- a/experimental/ast/printer/testdata/format/array_comment.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/array_comment.proto.default.txt
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option (any) = {
+  array: [
+    "x" // comment
+  ]
+};

--- a/experimental/ast/printer/testdata/format/array_comment.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/array_comment.proto.legacy.txt
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option (any) = {
+  array: [
+    "x" // comment
+  ]
+};

--- a/experimental/ast/printer/testdata/format/option_message_field.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/option_message_field.proto.default.txt
@@ -32,7 +32,10 @@ message Foo {
     foo: "goo" // Trailing comment on foo
 
     // Leading comment on extension name.
-    [/* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */] /* Three */ : "boo" // Trailing comment on extension name.
+    [
+      /* One */
+      foo.bar.Test.Nested._NestedNested._garblez /* Two */
+    ] /* Three */ : "boo" // Trailing comment on extension name.
 
     // Leading comment on '}'.
   };

--- a/experimental/ast/printer/testdata/format/option_message_field.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/option_message_field.proto.legacy.txt
@@ -32,7 +32,11 @@ message Foo {
     foo: "goo" // Trailing comment on foo
 
     // Leading comment on extension name.
-    [/* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */] /* Three */ : "boo" // Trailing comment on extension name.
+    [
+      /* One */
+      foo.bar.Test.Nested._NestedNested._garblez
+      /* Two */
+    ] /* Three */ : "boo" // Trailing comment on extension name.
 
     // Leading comment on '}'.
   };


### PR DESCRIPTION
Expand arrays with attached comments in the formatter. This matches the logic in print dict and fixes the trailing `//` comments corrupting the output when collapsed onto one line. Goldens updated to match new behavior. 

Issue https://github.com/bufbuild/buf/issues/4593