### PR TITLE
Fix literal behaviour for legacy formatting options

### DIFF
--- a/experimental/ast/printer/decl.go
+++ b/experimental/ast/printer/decl.go
@@ -484,10 +484,10 @@ func (p *printer) printCompactOptions(co ast.CompactOptions) {
 			p.scopeHasLineTrailingComments(brackets) {
 			forceExpand = true
 		}
-		// Compact options do not apply the nested-composite break rule:
-		// the legacy formatter keeps a single-entry `[opt = {...}]` bracket
-		// inline and lets the value expand within.
-		wantBroken := forceExpand || p.literalShouldBreak(openTok, closeTok, entries.Len(), false)
+		// Compact options do not apply the nested-composite break rule
+		// (nil values): the legacy formatter keeps a single-entry
+		// `[opt = {...}]` bracket inline and lets the value expand within.
+		wantBroken := forceExpand || p.literalShouldBreak(openTok, closeTok, entries.Len(), nil)
 
 		switch {
 		case !wantBroken && entries.Len() == 1:

--- a/experimental/ast/printer/decl.go
+++ b/experimental/ast/printer/decl.go
@@ -484,7 +484,10 @@ func (p *printer) printCompactOptions(co ast.CompactOptions) {
 			p.scopeHasLineTrailingComments(brackets) {
 			forceExpand = true
 		}
-		wantBroken := forceExpand || p.literalShouldBreak(openTok, closeTok, entries.Len())
+		// Compact options do not apply the nested-composite break rule:
+		// the legacy formatter keeps a single-entry `[opt = {...}]` bracket
+		// inline and lets the value expand within.
+		wantBroken := forceExpand || p.literalShouldBreak(openTok, closeTok, entries.Len(), false)
 
 		switch {
 		case !wantBroken && entries.Len() == 1:

--- a/experimental/ast/printer/expr.go
+++ b/experimental/ast/printer/expr.go
@@ -239,7 +239,17 @@ func (p *printer) printArray(expr ast.ExprArray, gap gapStyle) {
 		return
 	}
 
-	wantBroken := hasComments || p.literalShouldBreak(openTok, closeTok, elements.Len())
+	// Under LayoutStrict the legacy formatter expands a single-element
+	// array whose element is itself a message or array literal.
+	hasNestedComposite := false
+	for i := range elements.Len() {
+		if kind := elements.At(i).Kind(); kind == ast.ExprKindDict || kind == ast.ExprKindArray {
+			hasNestedComposite = true
+			break
+		}
+	}
+
+	wantBroken := hasComments || p.literalShouldBreak(openTok, closeTok, elements.Len(), hasNestedComposite)
 
 	if !wantBroken {
 		// Flat path: emit the elements inside a group with softbreak
@@ -379,7 +389,17 @@ func (p *printer) printDict(expr ast.ExprDict, gap gapStyle) {
 		return
 	}
 
-	wantBroken := hasComments || p.literalShouldBreak(openTok, closeTok, elements.Len())
+	// Under LayoutStrict the legacy formatter expands a single-field
+	// message literal whose value is itself a message or array literal.
+	hasNestedComposite := false
+	for i := range elements.Len() {
+		if kind := elements.At(i).Value().Kind(); kind == ast.ExprKindDict || kind == ast.ExprKindArray {
+			hasNestedComposite = true
+			break
+		}
+	}
+
+	wantBroken := hasComments || p.literalShouldBreak(openTok, closeTok, elements.Len(), hasNestedComposite)
 
 	if !wantBroken {
 		// Flat path: emit fields inside a group with softbreak padding

--- a/experimental/ast/printer/expr.go
+++ b/experimental/ast/printer/expr.go
@@ -17,6 +17,7 @@ package printer
 import (
 	"github.com/bufbuild/protocompile/experimental/ast"
 	"github.com/bufbuild/protocompile/experimental/dom"
+	"github.com/bufbuild/protocompile/experimental/seq"
 	"github.com/bufbuild/protocompile/experimental/token"
 	"github.com/bufbuild/protocompile/experimental/token/keyword"
 )
@@ -239,17 +240,8 @@ func (p *printer) printArray(expr ast.ExprArray, gap gapStyle) {
 		return
 	}
 
-	// Under LayoutStrict the legacy formatter expands a single-element
-	// array whose element is itself a message or array literal.
-	hasNestedComposite := false
-	for i := range elements.Len() {
-		if kind := elements.At(i).Kind(); kind == ast.ExprKindDict || kind == ast.ExprKindArray {
-			hasNestedComposite = true
-			break
-		}
-	}
-
-	wantBroken := hasComments || p.literalShouldBreak(openTok, closeTok, elements.Len(), hasNestedComposite)
+	wantBroken := hasComments ||
+		p.literalShouldBreak(openTok, closeTok, elements.Len(), seq.Values(elements))
 
 	if !wantBroken {
 		// Flat path: emit the elements inside a group with softbreak
@@ -389,17 +381,8 @@ func (p *printer) printDict(expr ast.ExprDict, gap gapStyle) {
 		return
 	}
 
-	// Under LayoutStrict the legacy formatter expands a single-field
-	// message literal whose value is itself a message or array literal.
-	hasNestedComposite := false
-	for i := range elements.Len() {
-		if kind := elements.At(i).Value().Kind(); kind == ast.ExprKindDict || kind == ast.ExprKindArray {
-			hasNestedComposite = true
-			break
-		}
-	}
-
-	wantBroken := hasComments || p.literalShouldBreak(openTok, closeTok, elements.Len(), hasNestedComposite)
+	wantBroken := hasComments ||
+		p.literalShouldBreak(openTok, closeTok, elements.Len(), seq.Map(elements, ast.ExprField.Value))
 
 	if !wantBroken {
 		// Flat path: emit fields inside a group with softbreak padding

--- a/experimental/ast/printer/format.go
+++ b/experimental/ast/printer/format.go
@@ -16,6 +16,7 @@ package printer
 
 import (
 	"cmp"
+	"iter"
 	"slices"
 
 	"github.com/bufbuild/protocompile/experimental/ast"
@@ -111,19 +112,35 @@ func sourceBlankLineBetweenFields(prev, curr ast.ExprField) bool {
 //   - [LayoutDynamic]: broken if and only if source had a newline between open
 //     and close, deferring width-driven breaks to [dom.Group].
 //
-// hasNestedComposite reports whether the scope has an element whose value
-// is itself a message or array literal; it is consulted only under
-// [LayoutStrict] (the legacy formatter keeps a single scalar element flat
-// but expands a single composite element).
+// values yields the element values consulted for the nested-composite
+// rule under [LayoutStrict]: the scope breaks when any value is itself a
+// message or array literal (the legacy formatter keeps a single scalar
+// element flat but expands a single composite element). It may be nil for
+// scopes that do not apply the rule (e.g. compact options, which keep
+// `[opt = {...}]` inline and expand the value within).
 //
 // Callers should OR the result with their own forceBroken signal
 // (e.g. for scope-attached comments that require expansion).
-func (p *printer) literalShouldBreak(openTok, closeTok token.Token, count int, hasNestedComposite bool) bool {
+func (p *printer) literalShouldBreak(
+	openTok, closeTok token.Token,
+	count int,
+	values iter.Seq[ast.ExprAny],
+) bool {
 	switch p.options.Formatting.LiteralLayout {
 	case LayoutDynamic:
 		return !sourceWasFlat(openTok, closeTok)
 	default: // LayoutStrict
-		return count >= 2 || hasNestedComposite
+		if count >= 2 {
+			return true
+		}
+		if values != nil {
+			for value := range values {
+				if kind := value.Kind(); kind == ast.ExprKindDict || kind == ast.ExprKindArray {
+					return true
+				}
+			}
+		}
+		return false
 	}
 }
 

--- a/experimental/ast/printer/format.go
+++ b/experimental/ast/printer/format.go
@@ -105,19 +105,25 @@ func sourceBlankLineBetweenFields(prev, curr ast.ExprField) bool {
 // literal):
 //
 //   - [LayoutStrict]: broken if and only if the scope has 2 or more elements,
-//     matching the legacy formatter's "expand if non-trivial" rule.
+//     or has a single element that is itself a nested message or array
+//     literal, matching the legacy formatter's "expand if non-trivial" rule.
 //
 //   - [LayoutDynamic]: broken if and only if source had a newline between open
 //     and close, deferring width-driven breaks to [dom.Group].
 //
+// hasNestedComposite reports whether the scope has an element whose value
+// is itself a message or array literal; it is consulted only under
+// [LayoutStrict] (the legacy formatter keeps a single scalar element flat
+// but expands a single composite element).
+//
 // Callers should OR the result with their own forceBroken signal
 // (e.g. for scope-attached comments that require expansion).
-func (p *printer) literalShouldBreak(openTok, closeTok token.Token, count int) bool {
+func (p *printer) literalShouldBreak(openTok, closeTok token.Token, count int, hasNestedComposite bool) bool {
 	switch p.options.Formatting.LiteralLayout {
 	case LayoutDynamic:
 		return !sourceWasFlat(openTok, closeTok)
 	default: // LayoutStrict
-		return count >= 2
+		return count >= 2 || hasNestedComposite
 	}
 }
 

--- a/experimental/ast/printer/testdata/format/message_literals.proto
+++ b/experimental/ast/printer/testdata/format/message_literals.proto
@@ -26,3 +26,11 @@ option (custom.array_of_dicts) = {
 // Issue 9: Message literal with inline block comments should expand
 // to multi-line.
 option (custom.commented_option) = {/*leading*/ foo: 1 /*trailing*/};
+
+// A single-field literal whose value is itself a message or array
+// literal expands under the legacy (strict) layout even when the source
+// is flat, matching the legacy formatter; a single scalar field stays
+// inline (see custom.message_thing_option above). Under the dynamic
+// layout the flat source is preserved.
+option (custom.single_nested_message) = {gt: {}};
+option (custom.single_nested_array) = {not_in: [1]};

--- a/experimental/ast/printer/testdata/format/message_literals.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/message_literals.proto.default.txt
@@ -25,3 +25,10 @@ option (custom.file_thing_option) = {
 };
 option (custom.message_thing_option) = {foo: 5};
 option (custom.service_thing_option) = {foo: 1 bar: 2};
+option (custom.single_nested_array) = {not_in: [1]};
+// A single-field literal whose value is itself a message or array
+// literal expands under the legacy (strict) layout even when the source
+// is flat, matching the legacy formatter; a single scalar field stays
+// inline (see custom.message_thing_option above). Under the dynamic
+// layout the flat source is preserved.
+option (custom.single_nested_message) = {gt: {}};

--- a/experimental/ast/printer/testdata/format/message_literals.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/message_literals.proto.legacy.txt
@@ -29,3 +29,14 @@ option (custom.service_thing_option) = {
   foo: 1
   bar: 2
 };
+option (custom.single_nested_array) = {
+  not_in: [1]
+};
+// A single-field literal whose value is itself a message or array
+// literal expands under the legacy (strict) layout even when the source
+// is flat, matching the legacy formatter; a single scalar field stays
+// inline (see custom.message_thing_option above). Under the dynamic
+// layout the flat source is preserved.
+option (custom.single_nested_message) = {
+  gt: {}
+};


### PR DESCRIPTION
This fixes the behaviour of legacy formatting for option
literals so that it properly matches the legacy formatter.

This was found through comparing the legacy and new
formatter against a large external set of protos.