### PR TITLE
Fix trivia slot shift that drops comments in literals

### DIFF
--- a/experimental/ast/printer/testdata/format/literal_detached_comments.proto
+++ b/experimental/ast/printer/testdata/format/literal_detached_comments.proto
@@ -1,0 +1,79 @@
+syntax = "proto2";
+
+package test;
+
+import "google/protobuf/descriptor.proto";
+
+message Item {
+  optional string name = 1;
+}
+
+message ItemList {
+  repeated Item items = 1;
+  repeated Item entry = 2;
+}
+
+extend google.protobuf.FieldOptions {
+  optional ItemList item_list_field = 50003;
+}
+
+extend google.protobuf.MethodOptions {
+  optional ItemList item_list = 50001;
+}
+
+message Request {}
+message Response {}
+
+service ExampleService {
+  // A comment detached by a blank line from the element it annotates
+  // must stay with that element, and must survive repeated formatting.
+  rpc Get(Request) returns (Response) {
+    option (test.item_list) = {
+      items: [
+        {name: "first"},
+        /* detached block comment */
+
+        {name: "second"},
+        // detached line comment
+
+        {name: "third"},
+        /* leading one */
+        /* leading two */
+        {
+          name: "fourth"
+        },
+
+        {name: "fifth"}
+      ]
+    };
+  }
+}
+
+// Compact options are the other literal scope with per-element trivia
+// slots, and a brace-valued option there is the same shape.
+message Compact {
+  optional string field = 1 [
+    (test.item_list_field) = {entry {name: "a"}},
+    /* detached before deprecated */
+
+    deprecated = true,
+    json_name = "field"
+  ];
+}
+
+// Separators are optional between message literal fields, so a
+// brace-valued field with no comma of its own must still get its own
+// trivia slot.
+extend google.protobuf.MessageOptions {
+  optional ItemList msg_item_list = 50002;
+}
+
+message CommaLess {
+  option (test.msg_item_list) = {
+    entry {name: "one"}
+
+    /* detached, no separators anywhere */
+
+    entry {name: "two"}
+  };
+}

--- a/experimental/ast/printer/testdata/format/literal_detached_comments.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/literal_detached_comments.proto.default.txt
@@ -1,0 +1,79 @@
+syntax = "proto2";
+
+package test;
+
+import "google/protobuf/descriptor.proto";
+
+message Item {
+  optional string name = 1;
+}
+
+message ItemList {
+  repeated Item items = 1;
+  repeated Item entry = 2;
+}
+
+extend google.protobuf.FieldOptions {
+  optional ItemList item_list_field = 50003;
+}
+
+extend google.protobuf.MethodOptions {
+  optional ItemList item_list = 50001;
+}
+
+message Request {}
+message Response {}
+
+service ExampleService {
+  // A comment detached by a blank line from the element it annotates
+  // must stay with that element, and must survive repeated formatting.
+  rpc Get(Request) returns (Response) {
+    option (test.item_list) = {
+      items: [
+        {name: "first"},
+        /* detached block comment */
+
+        {name: "second"},
+        // detached line comment
+
+        {name: "third"},
+        /* leading one */
+        /* leading two */
+        {
+          name: "fourth"
+        },
+
+        {name: "fifth"}
+      ]
+    };
+  }
+}
+
+// Compact options are the other literal scope with per-element trivia
+// slots, and a brace-valued option there is the same shape.
+message Compact {
+  optional string field = 1 [
+    (test.item_list_field) = {entry: {name: "a"}},
+    /* detached before deprecated */
+
+    deprecated = true,
+    json_name = "field"
+  ];
+}
+
+// Separators are optional between message literal fields, so a
+// brace-valued field with no comma of its own must still get its own
+// trivia slot.
+extend google.protobuf.MessageOptions {
+  optional ItemList msg_item_list = 50002;
+}
+
+message CommaLess {
+  option (test.msg_item_list) = {
+    entry: {name: "one"}
+
+    /* detached, no separators anywhere */
+
+    entry: {name: "two"}
+  };
+}

--- a/experimental/ast/printer/testdata/format/literal_detached_comments.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/literal_detached_comments.proto.legacy.txt
@@ -1,0 +1,79 @@
+syntax = "proto2";
+
+package test;
+
+import "google/protobuf/descriptor.proto";
+
+message Item {
+  optional string name = 1;
+}
+
+message ItemList {
+  repeated Item items = 1;
+  repeated Item entry = 2;
+}
+
+extend google.protobuf.FieldOptions {
+  optional ItemList item_list_field = 50003;
+}
+
+extend google.protobuf.MethodOptions {
+  optional ItemList item_list = 50001;
+}
+
+message Request {}
+message Response {}
+
+service ExampleService {
+  // A comment detached by a blank line from the element it annotates
+  // must stay with that element, and must survive repeated formatting.
+  rpc Get(Request) returns (Response) {
+    option (test.item_list) = {
+      items: [
+        {name: "first"},
+        /* detached block comment */
+
+        {name: "second"},
+        // detached line comment
+
+        {name: "third"},
+        /* leading one */
+        /* leading two */
+        {name: "fourth"},
+
+        {name: "fifth"}
+      ]
+    };
+  }
+}
+
+// Compact options are the other literal scope with per-element trivia
+// slots, and a brace-valued option there is the same shape.
+message Compact {
+  optional string field = 1 [
+    (test.item_list_field) = {
+      entry: {name: "a"}
+    },
+    /* detached before deprecated */
+
+    deprecated = true,
+    json_name = "field"
+  ];
+}
+
+// Separators are optional between message literal fields, so a
+// brace-valued field with no comma of its own must still get its own
+// trivia slot.
+extend google.protobuf.MessageOptions {
+  optional ItemList msg_item_list = 50002;
+}
+
+message CommaLess {
+  option (test.msg_item_list) = {
+    entry: {name: "one"}
+
+    /* detached, no separators anywhere */
+
+    entry: {name: "two"}
+  };
+}

--- a/experimental/ast/printer/trivia.go
+++ b/experimental/ast/printer/trivia.go
@@ -188,9 +188,9 @@ type scopeMode int
 
 const (
 	scopeModeDecl scopeMode = iota
-	// scopeModeLiteral is a bracketed list: `[...]`, whether a compact
+	// scopeModeList is a bracketed list: `[...]`, whether a compact
 	// option list or an array literal. Commas are printed.
-	scopeModeLiteral
+	scopeModeList
 	// scopeModeDict is a message literal body: `{...}` or `<...>` used
 	// as a value. Commas are elided when printing.
 	scopeModeDict
@@ -199,7 +199,7 @@ const (
 // isLiteral reports whether the scope holds a comma-separated element
 // list, in either of the two literal flavors.
 func (m scopeMode) isLiteral() bool {
-	return m == scopeModeLiteral || m == scopeModeDict
+	return m == scopeModeList || m == scopeModeDict
 }
 
 // walkScope processes all tokens within one scope.
@@ -269,9 +269,9 @@ func (idx *triviaIndex) walkScope(cursor *token.Cursor, scopeID token.ID, mode s
 // walkFused processes a fused (non-leaf) token by recursing into its
 // children with a [scopeMode] chosen by bracket kind:
 //
-//   - `[...]` (brackets): always [scopeModeLiteral] — compact options
+//   - `[...]` (brackets): always [scopeModeList] — compact options
 //     or array literal.
-//   - `{...}` / `<...>` (braces, angles): [scopeModeLiteral] when the
+//   - `{...}` / `<...>` (braces, angles): [scopeModeDict] when the
 //     enclosing decl already saw `=` (a value expression like
 //     `option x = {...}`); otherwise [scopeModeDecl] (a decl-bearing
 //     body).
@@ -285,19 +285,10 @@ func (idx *triviaIndex) walkScope(cursor *token.Cursor, scopeID token.ID, mode s
 // endToken cursor.
 func (idx *triviaIndex) walkFused(leafToken token.Token, parentSawAssign bool) token.Token {
 	openToken, closeToken := leafToken.StartEnd()
-	// Determine the child scope's mode based on the bracket kind and
-	// the parent's `=` state:
-	//   - [...]   : literal (compact options or array). Always.
-	//   - {...}/<>: dict literal (literal mode) when the parent saw
-	//               `=` (e.g. `option foo = {...}`); otherwise a body.
-	//   - (...)   : parens — typically extension names like
-	//               `(ext.name)`; treat as decl mode (no comma
-	//               boundary since the contents are paths, not
-	//               element lists).
 	childMode := scopeModeDecl
 	switch leafToken.Keyword() {
 	case keyword.Brackets:
-		childMode = scopeModeLiteral
+		childMode = scopeModeList
 	case keyword.Braces, keyword.Angles:
 		if parentSawAssign {
 			childMode = scopeModeDict
@@ -508,28 +499,6 @@ func (idx *triviaIndex) walkDecl(cursor *token.Cursor, startToken token.Token, m
 		idx.attached[endToken.ID()] = att
 	}
 	return hasBlankLine
-}
-
-// nextNonSkippableIs peeks ahead in the cursor to check whether the next
-// non-skippable token has the given keyword. With `;` it distinguishes
-// definition bodies (message Foo { ... }) from value expressions
-// (option x = { ... };); with `,` it detects whether a literal element
-// has a separator of its own. The cursor is restored to its original
-// position after peeking.
-func (*triviaIndex) nextNonSkippableIs(cursor *token.Cursor, kw keyword.Keyword) bool {
-	var count int
-	matches := false
-	for next := cursor.NextSkippable(); !next.IsZero(); next = cursor.NextSkippable() {
-		count++
-		if !next.Kind().IsSkippable() {
-			matches = next.Keyword() == kw
-			break
-		}
-	}
-	for range count {
-		cursor.PrevSkippable()
-	}
-	return matches
 }
 
 // splitDetached splits a trivia token slice at the last blank line boundary.

--- a/experimental/ast/printer/trivia.go
+++ b/experimental/ast/printer/trivia.go
@@ -179,12 +179,28 @@ func buildTriviaIndex(stream *token.Stream) *triviaIndex {
 // `{...}`. Literal scopes (compact options `[...]`, array literals,
 // dict literals) additionally end "elements" at `,`, so per-element
 // trivia slots and blankBefore indicators get recorded.
+//
+// The two literal modes differ only in what happens to their commas
+// when printing: a dict's separators are elided, so trivia may not be
+// left attached to them, while a bracketed list prints its commas and
+// their trivia along with them.
 type scopeMode int
 
 const (
 	scopeModeDecl scopeMode = iota
+	// scopeModeLiteral is a bracketed list: `[...]`, whether a compact
+	// option list or an array literal. Commas are printed.
 	scopeModeLiteral
+	// scopeModeDict is a message literal body: `{...}` or `<...>` used
+	// as a value. Commas are elided when printing.
+	scopeModeDict
 )
+
+// isLiteral reports whether the scope holds a comma-separated element
+// list, in either of the two literal flavors.
+func (m scopeMode) isLiteral() bool {
+	return m == scopeModeLiteral || m == scopeModeDict
+}
 
 // walkScope processes all tokens within one scope.
 //
@@ -284,7 +300,7 @@ func (idx *triviaIndex) walkFused(leafToken token.Token, parentSawAssign bool) t
 		childMode = scopeModeLiteral
 	case keyword.Braces, keyword.Angles:
 		if parentSawAssign {
-			childMode = scopeModeLiteral
+			childMode = scopeModeDict
 		}
 	}
 	idx.walkScope(leafToken.Children(), openToken.ID(), childMode)
@@ -329,7 +345,18 @@ func (idx *triviaIndex) walkDecl(cursor *token.Cursor, startToken token.Token, m
 			// elided during formatting -- without this, the comment
 			// on the comma's line would be lost or misplaced.
 			firstNewline := firstNewlineIndex(leading)
-			if sliceHasComment(leading[:firstNewline]) && firstNewline < len(leading) {
+			// Normally an inline run only hoists when a newline follows
+			// it. A brace-valued dict element is the exception: the
+			// element deliberately runs through to its own comma (see
+			// the boundary rules below), and a dict's commas are elided
+			// when printing, so a comment sitting between the closing
+			// brace and that comma has nowhere to go unless it hoists
+			// here.
+			hoistInline := firstNewline < len(leading) ||
+				(mode == scopeModeDict &&
+					tok.Keyword() == keyword.Comma &&
+					endToken.Keyword() == keyword.Braces)
+			if sliceHasComment(leading[:firstNewline]) && hoistInline {
 				att := idx.attached[endToken.ID()]
 				att.trailing = leading[:firstNewline]
 				idx.attached[endToken.ID()] = att
@@ -362,11 +389,24 @@ func (idx *triviaIndex) walkDecl(cursor *token.Cursor, startToken token.Token, m
 		// ends the decl; any following `;` is a separate empty decl.
 		atDeclBoundary := tok.Keyword() == keyword.Semi
 		if tok.Keyword() == keyword.Braces {
-			atDeclBoundary = !sawAssign || !idx.nextNonSkippableIsSemi(cursor)
+			next := cursor.Peek().Keyword()
+			atDeclBoundary = !sawAssign || next != keyword.Semi
+			if mode.isLiteral() && next == keyword.Comma {
+				// This element has a `,` of its own coming up, so let
+				// that comma end it. Ending the element at the brace
+				// would leave the comma to open a slot of its own,
+				// shifting every later slot past the element index the
+				// printers use to look them up.
+				//
+				// Separators are optional between message literal
+				// fields, so a brace with no following comma must still
+				// end the element.
+				atDeclBoundary = false
+			}
 		}
 		// In a literal scope, `,` is also a boundary so each element
 		// gets its own trivia slot and blankBefore indicator.
-		if mode == scopeModeLiteral && tok.Keyword() == keyword.Comma {
+		if mode.isLiteral() && tok.Keyword() == keyword.Comma {
 			atDeclBoundary = true
 		}
 		if atDeclBoundary {
@@ -470,24 +510,26 @@ func (idx *triviaIndex) walkDecl(cursor *token.Cursor, startToken token.Token, m
 	return hasBlankLine
 }
 
-// nextNonSkippableIsSemi peeks ahead in the cursor to check if the next
-// non-skippable token is `;`. Used to distinguish definition bodies
-// (message Foo { ... }) from value expressions (option x = { ... };).
-// The cursor is restored to its original position after peeking.
-func (*triviaIndex) nextNonSkippableIsSemi(cursor *token.Cursor) bool {
+// nextNonSkippableIs peeks ahead in the cursor to check whether the next
+// non-skippable token has the given keyword. With `;` it distinguishes
+// definition bodies (message Foo { ... }) from value expressions
+// (option x = { ... };); with `,` it detects whether a literal element
+// has a separator of its own. The cursor is restored to its original
+// position after peeking.
+func (*triviaIndex) nextNonSkippableIs(cursor *token.Cursor, kw keyword.Keyword) bool {
 	var count int
-	isSemi := false
+	matches := false
 	for next := cursor.NextSkippable(); !next.IsZero(); next = cursor.NextSkippable() {
 		count++
 		if !next.Kind().IsSkippable() {
-			isSemi = next.Keyword() == keyword.Semi
+			matches = next.Keyword() == kw
 			break
 		}
 	}
 	for range count {
 		cursor.PrevSkippable()
 	}
-	return isSemi
+	return matches
 }
 
 // splitDetached splits a trivia token slice at the last blank line boundary.


### PR DESCRIPTION
Fixes a case where `buf format` silently deletes a comment, and a related case where it silently moves or deletes blank lines. Reported downstream as bufbuild/buf#4620.

## The bug

The trivia walker records one detached-trivia slot per element in a literal scope, and the printers look those slots up by element index. An element whose value is a brace ends at the brace rather than at its own comma, so that comma opens a slot of its own and shifts every later slot by one.

Dumping the trivia index for the repro below, a two-element array produces **four** slots, with the comment in `slot[2]` — the index the printer treats as "final slot, emit before `]`". On the next pass it lands in `slot[3]`, which no printer path reads, so it is dropped. Each brace-valued element adds one slot, so a longer list delays the loss by a pass.

```protobuf
syntax = "proto3";

package example.v1;

import "google/protobuf/descriptor.proto";

message Item {
  optional string name = 1;
}

message ItemList {
  repeated Item items = 1;
}

extend google.protobuf.MessageOptions {
  optional ItemList item_list = 50001;
}

message Example {
  option (example.v1.item_list) = {
    items: [
      {name: "first"},
      /* detached comment */

      {name: "second"}
    ]
  };
}
```

Pass 1 moves the comment past the element it annotated, down to the closing bracket and dedented to the bracket's level. Pass 2 deletes it. Pass 3 onward is stable, so the file settles with the comment permanently gone. `buf format -d` on the unmodified input shows the first step:

```diff
@@
     items: [
       {name: "first"},
-      /* detached comment */
-
       {name: "second"}
+    /* detached comment */
+
     ]
```

## Same defect, no comments involved

Blank lines are tracked by the same shifted index. With the blank line before `{name: "b"}`:

```protobuf
    items: [
      {name: "a"},

      {name: "b"},
      {name: "c"},
      {name: "d"}
    ]
```

the blank line comes back before `{name: "c"}`. Move it one element further down in the input and it is deleted outright, because it shifts past the last element. This needs no repeated passes and no comments — a single `buf format` reflows the file.

## The fix

End the element at its comma when it has one. Separators are optional between message literal fields, so a brace with no following comma must still end the element.

Because the element now runs through to its comma, trivia that previously landed on the closing brace can land on the comma instead. A dict elides its commas when printing and emits only their trailing trivia, so an inline comment between the brace and the comma would be dropped; it is hoisted onto the brace, which is where it was attached before. Bracketed lists print their commas and keep emitting that trivia themselves, so the two literal flavors are now distinguished by scope mode.

I also replaced the local peek-and-rewind helper with the existing `Cursor.Peek()`. The hand-rolled rewind advanced with `NextSkippable` and unwound with `PrevSkippable`, which returns the *close* token for a fused token and parks the cursor there — `Peek()` copies the cursor by value and has no such state.

## Testing

`TestFormat` already asserts two-pass idempotence, so the new fixture is enough to catch this class of shift; with the `trivia.go` change reverted it fails on both the `legacy` and `default` goldens. It covers array elements, compact options, and separator-less fields.

I also formatted every `.proto` in this repo and in `bufbuild/buf` (~1,500 files) with a stock `v1.72.0` binary and a patched one. Three files differ, and in all three the patched output matches the *source's* blank-line structure where the current output shifts every blank line in a message literal down by one element. Comparing comment-marker counts before and after, the set of files that lose a marker is byte-identical between the two binaries, so this introduces no new loss.

## Noted but not fixed here

- A semicolon is also a legal message-literal separator, so the same slot shift is still reachable with `;` in place of `,`. Pre-existing and unchanged by this PR.
- `testdata/bufformat/proto2/option/v1/option_message_field.proto` has a comment named `Leading comment on ','` that the current golden drops: an elided comma's *leading* trivia is never emitted. An earlier revision of this patch repaired that incidentally, but not idempotently, so I narrowed the change to only what it disturbed. Happy to file it separately.
- `emitTriviaSlot` returns silently when the slot index exceeds the slot count, which is why this desync lost comments instead of failing a test. An assertion at the printer's scope entry points, where the element count is known, would turn any future desync into a loud failure.
