### PR TITLE
Fix extension validation for proto2 required fields

### DIFF
--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -758,6 +758,24 @@ func validatePresence(m Member, r *report.Report) {
 		return
 	}
 
+	// Extensions cannot be required. In non-editions files this comes from the
+	// `required` keyword, which is not an editions feature, so it bypasses the
+	// feature-gated checks below; catch it here. (In editions, `LEGACY_REQUIRED`
+	// on an extension is expressed as a feature and is caught by the
+	// `case m.IsExtension()` branch below instead.)
+	if m.IsExtension() && m.Presence() == presence.Required {
+		d := r.Errorf("%s cannot be required", taxa.Extension)
+		if _, required := iterx.Find(m.AST().Type().Prefixes(), func(ty ast.TypePrefixed) bool {
+			return ty.Prefix() == keyword.Required
+		}); !required.IsZero() {
+			d.Apply(report.Snippet(required.PrefixToken()))
+		} else {
+			d.Apply(report.Snippet(m.AST()))
+		}
+		d.Apply(report.Helpf("extensions cannot use the `required` label"))
+		return
+	}
+
 	builtins := m.Context().builtins()
 	feature := m.FeatureSet().Lookup(builtins.FeaturePresence)
 	if !feature.IsExplicit() {

--- a/experimental/ir/testdata/extend/required.proto
+++ b/experimental/ir/testdata/extend/required.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package example;
+
+message Widget {
+    extensions 100 to 200;
+}
+
+extend Widget {
+    // Rejected: extensions cannot be required.
+    required string color = 100;
+
+    // Accepted: an optional extension is fine.
+    optional string label = 101;
+}

--- a/experimental/ir/testdata/extend/required.proto.stderr.txt
+++ b/experimental/ir/testdata/extend/required.proto.stderr.txt
@@ -1,0 +1,16 @@
+warning: required fields are deprecated
+  --> testdata/extend/required.proto:11:5
+   |
+11 |     required string color = 100;
+   |     ^^^^^^^^
+   = help: do not attempt to change this to `optional` if the field is already
+           in-use; doing so is a wire protocol break
+
+error: message extension cannot be required
+  --> testdata/extend/required.proto:11:5
+   |
+11 |     required string color = 100;
+   |     ^^^^^^^^
+   = help: extensions cannot use the `required` label
+
+encountered 1 error and 1 warning


### PR DESCRIPTION
This PR adds validation for non-editions features required
fields on extensions.