### PR TITLE
Fix comment loss from semicolon and empty decls

### DIFF
--- a/experimental/ast/printer/decl.go
+++ b/experimental/ast/printer/decl.go
@@ -47,6 +47,7 @@ func (p *printer) printDecl(decl ast.DeclAny, gap gapStyle) {
 	switch decl.Kind() {
 	case ast.DeclKindEmpty:
 		if p.options.Format {
+			p.emitEmptyDeclTrivia(decl.AsEmpty().Semicolon(), gap)
 			return
 		}
 		p.printToken(decl.AsEmpty().Semicolon(), gap)

--- a/experimental/ast/printer/printer.go
+++ b/experimental/ast/printer/printer.go
@@ -339,6 +339,21 @@ func (p *printer) emitCommaTrivia(comma token.Token) {
 	p.emitTrailing(att.trailing)
 }
 
+// emitEmptyDeclTrivia flushes an empty declaration's attached trivia
+// without emitting its `;`, which format mode elides entirely. A
+// comment can land on either side of the `;`, so both leading and
+// trailing are flushed, in token order.
+func (p *printer) emitEmptyDeclTrivia(semi token.Token, gap gapStyle) {
+	att, ok := p.trivia.tokenTrivia(semi.ID())
+	if !ok {
+		return
+	}
+
+	p.appendPending(att.leading)
+	p.emitTrivia(gap)
+	p.emitTrailing(att.trailing)
+}
+
 // appendPending buffers trivia tokens for later processing by emitTrivia.
 func (p *printer) appendPending(tokens []token.Token) {
 	p.pending = append(p.pending, tokens...)

--- a/experimental/ast/printer/testdata/format/empty_decl_trivia.proto
+++ b/experimental/ast/printer/testdata/format/empty_decl_trivia.proto
@@ -1,0 +1,44 @@
+// A comment attached to an empty decl (bare `;`) must survive even
+// though format mode elides the decl itself.
+
+syntax = "proto3";
+
+package test;
+
+// File-level, tight semicolons.
+;;;/* file-level */;;;;
+
+message Foo {
+  // Tight, no whitespace.
+  int32 a = 1;;;/* tight */;;;;
+
+  // Spaced, still no newlines.
+  int32 b = 2;; /* spaced */ ;;
+
+  // Own line, single newlines (not detached scope trivia).
+  int32 c = 3;;
+  /* own line */
+  ;;
+
+  // Glued to one semicolon on both sides.
+  int32 d = 4;/* before */;/* after */;
+
+  // Two comments stacked between empty decls.
+  int32 e = 5;;;/* first */;;/* second */;;;
+
+  // Line comment among tight semicolons.
+  int32 f = 6;;; // line comment
+  ;;;
+
+  // Blank-line separated (detached trivia; covered for parity).
+  int32 g = 7;;
+
+  /* blank-line separated */
+
+  ;;
+  int32 h = 8;
+
+  // No comment: should still collapse away cleanly.
+  int32 i = 9;;;;;;
+  int32 j = 10;
+}

--- a/experimental/ast/printer/testdata/format/empty_decl_trivia.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/empty_decl_trivia.proto.default.txt
@@ -1,0 +1,47 @@
+// A comment attached to an empty decl (bare `;`) must survive even
+// though format mode elides the decl itself.
+
+syntax = "proto3";
+
+package test;
+
+// File-level, tight semicolons.
+/* file-level */
+
+message Foo {
+  // Tight, no whitespace.
+  int32 a = 1;
+  /* tight */
+
+  // Spaced, still no newlines.
+  int32 b = 2;
+  /* spaced */
+
+  // Own line, single newlines (not detached scope trivia).
+  int32 c = 3;
+  /* own line */
+
+  // Glued to one semicolon on both sides.
+  int32 d = 4; /* before */
+  /* after */
+
+  // Two comments stacked between empty decls.
+  int32 e = 5;
+  /* first */
+  /* second */
+
+  // Line comment among tight semicolons.
+  int32 f = 6;
+  // line comment
+
+  // Blank-line separated (detached trivia; covered for parity).
+  int32 g = 7;
+
+  /* blank-line separated */
+
+  int32 h = 8;
+
+  // No comment: should still collapse away cleanly.
+  int32 i = 9;
+  int32 j = 10;
+}

--- a/experimental/ast/printer/testdata/format/empty_decl_trivia.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/empty_decl_trivia.proto.legacy.txt
@@ -1,0 +1,47 @@
+// A comment attached to an empty decl (bare `;`) must survive even
+// though format mode elides the decl itself.
+
+syntax = "proto3";
+
+package test;
+
+// File-level, tight semicolons.
+/* file-level */
+
+message Foo {
+  // Tight, no whitespace.
+  int32 a = 1;
+  /* tight */
+
+  // Spaced, still no newlines.
+  int32 b = 2;
+  /* spaced */
+
+  // Own line, single newlines (not detached scope trivia).
+  int32 c = 3;
+  /* own line */
+
+  // Glued to one semicolon on both sides.
+  int32 d = 4; /* before */
+  /* after */
+
+  // Two comments stacked between empty decls.
+  int32 e = 5;
+  /* first */
+  /* second */
+
+  // Line comment among tight semicolons.
+  int32 f = 6;
+  // line comment
+
+  // Blank-line separated (detached trivia; covered for parity).
+  int32 g = 7;
+
+  /* blank-line separated */
+
+  int32 h = 8;
+
+  // No comment: should still collapse away cleanly.
+  int32 i = 9;
+  int32 j = 10;
+}

--- a/experimental/ast/printer/testdata/format/literal_detached_comments.proto
+++ b/experimental/ast/printer/testdata/format/literal_detached_comments.proto
@@ -77,3 +77,14 @@ message CommaLess {
     entry {name: "two"}
   };
 }
+
+// `;` is also a legal message-literal field separator, and hits the
+// same slot shift a comma would.
+message SemicolonSeparated {
+  option (test.msg_item_list) = {
+    entry {name: "one"};
+    /* detached, semicolon separator */
+
+    entry {name: "two"}
+  };
+}

--- a/experimental/ast/printer/testdata/format/literal_detached_comments.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/literal_detached_comments.proto.default.txt
@@ -77,3 +77,15 @@ message CommaLess {
     entry: {name: "two"}
   };
 }
+
+// `;` is also a legal message-literal field separator, and hits the
+// same slot shift a comma would.
+message SemicolonSeparated {
+  option (test.msg_item_list) = {
+    entry: {name: "one"}
+
+    /* detached, semicolon separator */
+
+    entry: {name: "two"}
+  };
+}

--- a/experimental/ast/printer/testdata/format/literal_detached_comments.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/literal_detached_comments.proto.legacy.txt
@@ -77,3 +77,15 @@ message CommaLess {
     entry: {name: "two"}
   };
 }
+
+// `;` is also a legal message-literal field separator, and hits the
+// same slot shift a comma would.
+message SemicolonSeparated {
+  option (test.msg_item_list) = {
+    entry: {name: "one"}
+
+    /* detached, semicolon separator */
+
+    entry: {name: "two"}
+  };
+}

--- a/experimental/ast/printer/trivia.go
+++ b/experimental/ast/printer/trivia.go
@@ -202,6 +202,19 @@ func (m scopeMode) isLiteral() bool {
 	return m == scopeModeList || m == scopeModeDict
 }
 
+// isSeparator reports whether kw is a valid inter-element separator
+// for this scope mode: `,` in either literal flavor, `;` in dict only.
+func (m scopeMode) isSeparator(kw keyword.Keyword) bool {
+	switch kw {
+	case keyword.Comma:
+		return m.isLiteral()
+	case keyword.Semi:
+		return m == scopeModeDict
+	default:
+		return false
+	}
+}
+
 // walkScope processes all tokens within one scope.
 //
 // scopeID is 0 for the file-level scope, or the fused bracket's
@@ -372,27 +385,20 @@ func (idx *triviaIndex) walkDecl(cursor *token.Cursor, startToken token.Token, m
 		// and must not split it. Splitting at parens would cause the cursor
 		// to land on an interior close bracket after PrevSkippable, making
 		// walkScope register trivia under the wrong token ID.
-		//
-		// For `{...}`, the meaning depends on whether we have seen `=`:
-		// after `=` (e.g. `option x = {...};`), the braces are a value
-		// expression and the `;` closes the same decl, so we keep going.
-		// Without `=` (e.g. `message M {}`), the braces are a body that
-		// ends the decl; any following `;` is a separate empty decl.
 		atDeclBoundary := tok.Keyword() == keyword.Semi
 		if tok.Keyword() == keyword.Braces {
-			next := cursor.Peek().Keyword()
-			atDeclBoundary = !sawAssign || next != keyword.Semi
-			if mode.isLiteral() && next == keyword.Comma {
-				// This element has a `,` of its own coming up, so let
-				// that comma end it. Ending the element at the brace
-				// would leave the comma to open a slot of its own,
-				// shifting every later slot past the element index the
-				// printers use to look them up.
-				//
-				// Separators are optional between message literal
-				// fields, so a brace with no following comma must still
-				// end the element.
+			switch next := cursor.Peek().Keyword(); {
+			case mode.isSeparator(next):
+				// Let the upcoming separator end the element, not the
+				// brace, so it doesn't open a slot of its own.
 				atDeclBoundary = false
+			case sawAssign && next == keyword.Semi:
+				// `option x = {...};` -- the `;` closes this decl.
+				atDeclBoundary = false
+			default:
+				// A body ends here (`message M {}`), and so does a
+				// separator-less literal field/element.
+				atDeclBoundary = true
 			}
 		}
 		// In a literal scope, `,` is also a boundary so each element


### PR DESCRIPTION
Follow up to #745. Fixes two issues. Message literal fields separated by `;` instead of `,` hit the same slot-shift bug. Empty declarations `;` also didn't emit the trivia in format mode. 