### PR TITLE
Disallow setting enum features to UNKNOWN

### DIFF
--- a/experimental/ir/lower_features.go
+++ b/experimental/ir/lower_features.go
@@ -380,6 +380,17 @@ func validateFeatures(features MessageValue, r *report.Report) {
 			continue
 		}
 
+		// A base feature must never resolve to its `*_UNKNOWN` sentinel (zero).
+		if field := feature.Field(); field.Container() == builtins.FeatureSet && !field.IsExtension() {
+			if sentinel := feature.AsEnum(); !sentinel.IsZero() && sentinel.Number() == 0 {
+				r.Errorf("feature field `%s` must resolve to a known value", field.Name()).Apply(
+					report.Snippet(feature.ValueAST()),
+					report.Helpf("`%s` is only a placeholder for an unset feature", sentinel.Name()),
+				)
+				continue
+			}
+		}
+
 		// We check these in reverse order, because the user might have set
 		// introduced == deprecated == removed, and protoc doesn't enforce
 		// any relationship between these.

--- a/experimental/ir/testdata/editions/unknown_features.proto
+++ b/experimental/ir/testdata/editions/unknown_features.proto
@@ -1,0 +1,14 @@
+edition = "2023";
+
+package buf.test;
+
+// A feature explicitly set to its `*_UNKNOWN` sentinel (the zero value) is a
+// placeholder that must never survive feature resolution. protoc rejects it;
+// so should we. `json_format` is used here because, unlike `enum_type`, it
+// feeds no other validation, so the sentinel is all that is under test.
+enum Color {
+  option features.json_format = JSON_FORMAT_UNKNOWN;
+
+  COLOR_UNSPECIFIED = 0;
+  COLOR_RED = 1;
+}

--- a/experimental/ir/testdata/editions/unknown_features.proto.stderr.txt
+++ b/experimental/ir/testdata/editions/unknown_features.proto.stderr.txt
@@ -1,0 +1,8 @@
+error: feature field `json_format` must resolve to a known value
+  --> testdata/editions/unknown_features.proto:10:33
+   |
+10 |   option features.json_format = JSON_FORMAT_UNKNOWN;
+   |                                 ^^^^^^^^^^^^^^^^^^^
+   = help: `JSON_FORMAT_UNKNOWN` is only a placeholder for an unset feature
+
+encountered 1 error


### PR DESCRIPTION
`protoc` disallows you from setting enum features to the UNKNOWN variant, e.g.

```protobuf
features.json_format = JSON_FORMAT_UNKNOWN;
```

This PR adds this validation to the `experimental` package.