### PR TITLE
Disallow closed enums in zero-default contexts

### DIFF
--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -863,13 +863,13 @@ func validateClosedEnumUse(m Member, r *report.Report) {
 	switch syn := m.Context().Syntax(); {
 	case syn == syntax.Proto3:
 		r.Errorf("closed enum `%s` cannot be used in a \"proto3\" message", enum.FullName()).Apply(
-			report.Snippet(m.TypeAST()),
+			report.Snippet(m.TypeAST().RemovePrefixes()),
 			closedEnumNote(enum),
 			report.Helpf("fields in a \"proto3\" message must use open enums, which always define a zero value"),
 		)
 	case hasImplicitPresence(m):
 		r.Errorf("closed enum `%s` cannot be used in an implicit-presence field", enum.FullName()).Apply(
-			report.Snippet(m.TypeAST()),
+			report.Snippet(m.TypeAST().RemovePrefixes()),
 			closedEnumNote(enum),
 			report.Helpf("an unset implicit-presence field falls back to the enum's zero value, which a closed enum need not define"),
 		)

--- a/experimental/ir/lower_validate.go
+++ b/experimental/ir/lower_validate.go
@@ -104,6 +104,7 @@ func validateConstraints(f *File, r *report.Report) {
 		validateDefault(m, r)
 
 		validatePresence(m, r)
+		validateClosedEnumUse(m, r)
 		validateUTF8(m, r)
 		validateMessageEncoding(m, r)
 
@@ -847,6 +848,56 @@ func validatePresence(m Member, r *report.Report) {
 					"already in-use; doing so is a wire protocol break"),
 		)
 	}
+}
+
+// validateClosedEnumUse rejects fields that use a closed enum where the field
+// would fall back to the enum's zero value, which a closed enum need not
+// define. A "proto3" message may not reference a closed enum at all; editions
+// restricts this to implicit-presence fields.
+func validateClosedEnumUse(m Member, r *report.Report) {
+	enum := m.Element()
+	if !enum.IsClosedEnum() {
+		return
+	}
+
+	switch syn := m.Context().Syntax(); {
+	case syn == syntax.Proto3:
+		r.Errorf("closed enum `%s` cannot be used in a \"proto3\" message", enum.FullName()).Apply(
+			report.Snippet(m.TypeAST()),
+			closedEnumNote(enum),
+			report.Helpf("fields in a \"proto3\" message must use open enums, which always define a zero value"),
+		)
+	case hasImplicitPresence(m):
+		r.Errorf("closed enum `%s` cannot be used in an implicit-presence field", enum.FullName()).Apply(
+			report.Snippet(m.TypeAST()),
+			closedEnumNote(enum),
+			report.Helpf("an unset implicit-presence field falls back to the enum's zero value, which a closed enum need not define"),
+		)
+	}
+}
+
+// hasImplicitPresence reports whether m is a singular field with implicit
+// presence. Editions field-presence features are not reflected by
+// [Member.Presence], so the resolved feature value is consulted directly.
+func hasImplicitPresence(m Member) bool {
+	if !m.IsSingular() || m.Presence() == presence.Shared {
+		return false // repeated, map, or oneof member
+	}
+	builtins := m.Context().builtins()
+	v, _ := m.FeatureSet().Lookup(builtins.FeaturePresence).Value().AsInt()
+	return v == tags.FeatureSet_FieldPresence_Implicit
+}
+
+// closedEnumNote points at whatever makes an enum closed: its proto2 syntax
+// keyword, or its explicit `enum_type` feature.
+func closedEnumNote(enum Type) report.DiagnosticOption {
+	builtins := enum.Context().builtins()
+	feature := enum.FeatureSet().Lookup(builtins.FeatureEnum)
+	why := feature.Value().ValueAST().Span()
+	if feature.IsDefault() {
+		why = enum.Context().AST().Syntax().Value().Span()
+	}
+	return report.Snippetf(why, "`%s` is a closed enum", enum.FullName())
 }
 
 // validatePacked validates constraints on the packed option and feature.

--- a/experimental/ir/testdata/fields/enum_field_presence.proto.yaml
+++ b/experimental/ir/testdata/fields/enum_field_presence.proto.yaml
@@ -1,0 +1,107 @@
+# An enum field that has no explicit presence falls back to the enum's zero
+# value when unset, so it may only use an OPEN enum (open enums always define a
+# zero value). Closedness, not the absence of a zero value, is what matters:
+# every enum below defines a zero value, yet the closed ones are still rejected.
+#
+# Open enums are accepted everywhere, but the rule for closed enums differs by
+# syntax:
+#
+# - proto2: fields are always explicit-presence, so closed enums are fine.
+# - proto3: every singular field is rejected for a closed enum, even the
+#   explicit-presence `optional` ones.
+# - editions: only implicit-presence fields are rejected; explicit is fine.
+#
+exclude:
+- "unused import"
+- "required fields are deprecated"
+files:
+# Enum definitions (leaf files, imported by the messages below).
+- path: "proto2_enum.proto"
+  import: true
+  text: |
+    syntax = "proto2"; // proto2 enums are always closed
+    package example;
+    enum Proto2Enum {
+      PROTO2_ENUM_UNKNOWN = 0;
+      PROTO2_ENUM_A = 1;
+    }
+- path: "proto3_enum.proto"
+  import: true
+  text: |
+    syntax = "proto3"; // proto3 enums are always open
+    package example;
+    enum Proto3Enum {
+      PROTO3_ENUM_UNKNOWN = 0;
+      PROTO3_ENUM_A = 1;
+    }
+- path: "editions_enums.proto"
+  import: true
+  text: |
+    edition = "2023";
+    package example;
+    enum ClosedEnum {
+      option features.enum_type = CLOSED;
+      CLOSED_ENUM_UNKNOWN = 0;
+      CLOSED_ENUM_A = 1;
+    }
+    enum OpenEnum {
+      OPEN_ENUM_UNKNOWN = 0;
+      OPEN_ENUM_A = 1;
+    }
+
+# proto2 message: all fields explicit-presence, so all are accepted.
+- path: "proto2_message.proto"
+  text: |
+    syntax = "proto2";
+    package example;
+    import "proto2_enum.proto";
+    import "proto3_enum.proto";
+    import "editions_enums.proto";
+    message Proto2Message {
+      required Proto2Enum required_proto2 = 1; // accept
+      optional Proto2Enum optional_proto2 = 2; // accept
+      required Proto3Enum required_proto3 = 3; // accept
+      optional Proto3Enum optional_proto3 = 4; // accept
+      required ClosedEnum required_closed = 5; // accept
+      optional ClosedEnum optional_closed = 6; // accept
+      required OpenEnum   required_open   = 7; // accept
+      optional OpenEnum   optional_open   = 8; // accept
+    }
+
+# proto3 message: every singular closed-enum field is rejected.
+- path: "proto3_message.proto"
+  text: |
+    syntax = "proto3";
+    package example;
+    import "proto2_enum.proto";
+    import "proto3_enum.proto";
+    import "editions_enums.proto";
+    message Proto3Message {
+      Proto2Enum          regular_proto2  = 1; // reject: closed
+      optional Proto2Enum optional_proto2 = 2; // reject: closed, even optional
+      Proto3Enum          regular_proto3  = 3; // accept: open
+      optional Proto3Enum optional_proto3 = 4; // accept: open
+      ClosedEnum          regular_closed  = 5; // reject: closed
+      optional ClosedEnum optional_closed = 6; // reject: closed, even optional
+      OpenEnum            regular_open    = 7; // accept: open
+      optional OpenEnum   optional_open   = 8; // accept: open
+    }
+
+# editions message: only implicit-presence closed-enum fields rejected.
+- path: "editions_message.proto"
+  text: |
+    edition = "2023";
+    package example;
+    import "proto2_enum.proto";
+    import "proto3_enum.proto";
+    import "editions_enums.proto";
+    message EditionsMessage {
+      Proto2Enum explicit_proto2 = 1 [features.field_presence = EXPLICIT]; // accept
+      Proto2Enum implicit_proto2 = 2 [features.field_presence = IMPLICIT]; // reject: closed
+      Proto3Enum explicit_proto3 = 3 [features.field_presence = EXPLICIT]; // accept: open
+      Proto3Enum implicit_proto3 = 4 [features.field_presence = IMPLICIT]; // accept: open
+      ClosedEnum explicit_closed = 5 [features.field_presence = EXPLICIT]; // accept
+      ClosedEnum implicit_closed = 6 [features.field_presence = IMPLICIT]; // reject: closed
+      OpenEnum   explicit_open   = 7 [features.field_presence = EXPLICIT]; // accept: open
+      OpenEnum   implicit_open   = 8 [features.field_presence = IMPLICIT]; // accept: open
+    }

--- a/experimental/ir/testdata/fields/enum_field_presence.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/fields/enum_field_presence.proto.yaml.stderr.txt
@@ -40,10 +40,10 @@ error: closed enum `example.Proto2Enum` cannot be used in a "proto3" message
            a zero value
 
 error: closed enum `example.Proto2Enum` cannot be used in a "proto3" message
-  --> proto3_message.proto:8:3
+  --> proto3_message.proto:8:12
    |
  8 |   optional Proto2Enum optional_proto2 = 2; // reject: closed, even optional
-   |   ^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^
   ::: proto2_enum.proto:1:10
    |
  1 | syntax = "proto2"; // proto2 enums are always closed
@@ -66,10 +66,10 @@ error: closed enum `example.ClosedEnum` cannot be used in a "proto3" message
            a zero value
 
 error: closed enum `example.ClosedEnum` cannot be used in a "proto3" message
-  --> proto3_message.proto:12:3
+  --> proto3_message.proto:12:12
    |
 12 |   optional ClosedEnum optional_closed = 6; // reject: closed, even optional
-   |   ^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^
   ::: editions_enums.proto:4:31
    |
  4 |   option features.enum_type = CLOSED;

--- a/experimental/ir/testdata/fields/enum_field_presence.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/fields/enum_field_presence.proto.yaml.stderr.txt
@@ -1,0 +1,81 @@
+error: closed enum `example.Proto2Enum` cannot be used in an implicit-presence
+       field
+  --> editions_message.proto:8:3
+   |
+ 8 |   Proto2Enum implicit_proto2 = 2 [features.field_presence = IMPLICIT]; // reject: closed
+   |   ^^^^^^^^^^
+  ::: proto2_enum.proto:1:10
+   |
+ 1 | syntax = "proto2"; // proto2 enums are always closed
+   |          -------- `example.Proto2Enum` is a closed enum
+   |
+   = help: an unset implicit-presence field falls back to the enum's zero value,
+           which a closed enum need not define
+
+error: closed enum `example.ClosedEnum` cannot be used in an implicit-presence
+       field
+  --> editions_message.proto:12:3
+   |
+12 |   ClosedEnum implicit_closed = 6 [features.field_presence = IMPLICIT]; // reject: closed
+   |   ^^^^^^^^^^
+  ::: editions_enums.proto:4:31
+   |
+ 4 |   option features.enum_type = CLOSED;
+   |                               ------ `example.ClosedEnum` is a closed enum
+   |
+   = help: an unset implicit-presence field falls back to the enum's zero value,
+           which a closed enum need not define
+
+error: closed enum `example.Proto2Enum` cannot be used in a "proto3" message
+  --> proto3_message.proto:7:3
+   |
+ 7 |   Proto2Enum          regular_proto2  = 1; // reject: closed
+   |   ^^^^^^^^^^
+  ::: proto2_enum.proto:1:10
+   |
+ 1 | syntax = "proto2"; // proto2 enums are always closed
+   |          -------- `example.Proto2Enum` is a closed enum
+   |
+   = help: fields in a "proto3" message must use open enums, which always define
+           a zero value
+
+error: closed enum `example.Proto2Enum` cannot be used in a "proto3" message
+  --> proto3_message.proto:8:3
+   |
+ 8 |   optional Proto2Enum optional_proto2 = 2; // reject: closed, even optional
+   |   ^^^^^^^^^^^^^^^^^^^
+  ::: proto2_enum.proto:1:10
+   |
+ 1 | syntax = "proto2"; // proto2 enums are always closed
+   |          -------- `example.Proto2Enum` is a closed enum
+   |
+   = help: fields in a "proto3" message must use open enums, which always define
+           a zero value
+
+error: closed enum `example.ClosedEnum` cannot be used in a "proto3" message
+  --> proto3_message.proto:11:3
+   |
+11 |   ClosedEnum          regular_closed  = 5; // reject: closed
+   |   ^^^^^^^^^^
+  ::: editions_enums.proto:4:31
+   |
+ 4 |   option features.enum_type = CLOSED;
+   |                               ------ `example.ClosedEnum` is a closed enum
+   |
+   = help: fields in a "proto3" message must use open enums, which always define
+           a zero value
+
+error: closed enum `example.ClosedEnum` cannot be used in a "proto3" message
+  --> proto3_message.proto:12:3
+   |
+12 |   optional ClosedEnum optional_closed = 6; // reject: closed, even optional
+   |   ^^^^^^^^^^^^^^^^^^^
+  ::: editions_enums.proto:4:31
+   |
+ 4 |   option features.enum_type = CLOSED;
+   |                               ------ `example.ClosedEnum` is a closed enum
+   |
+   = help: fields in a "proto3" message must use open enums, which always define
+           a zero value
+
+encountered 6 errors


### PR DESCRIPTION
Closed enums don't guarantee a zero-value, so they cannot be used in fields with implicit presence, which rely on zero values.