### PR TITLE
Fix public import classification when paths differ in public-ness

### DIFF
--- a/experimental/ir/ir_imports.go
+++ b/experimental/ir/ir_imports.go
@@ -75,9 +75,9 @@ type imports struct {
 	// be imported. This is used for marking which imports are used.
 	causes intern.Map[uint32]
 
-	// NOTE: public imports always come first. This ensures that when
-	// recursively determining public imports, we consider public imports'
-	// recursive imports first. Consider the following sequence of files:
+	// The transitive public segment exists because public-ness has to be
+	// propagated to files that are not directly imported at all. Consider the
+	// following sequence of files:
 	//
 	//  // a.proto
 	//  message A {}
@@ -98,29 +98,44 @@ type imports struct {
 	//  message B { A foo = 1; }
 	//
 	// Because b imports a publicly, we need a to wind up as a transitive
-	// public import so that when we search the transitive public imports of d
-	// for symbols, we pick up "a.proto".
+	// public import of d, so that when we search the transitive public imports
+	// of d for symbols, we pick up "a.proto".
 	//
 	// There is a test in ir_imports_test.go that validates this behavior. So
 	// much pain for a little-used feature...
+	//
+	// NOTE: these segments cannot classify every public import on their own. A
+	// direct import has to stay in one of the direct segments even when it is
+	// also re-exported by some other direct import, so whether an import is
+	// public is recorded on [imported] rather than derived from these offsets.
 	publicEnd, importEnd, transPublicEnd uint32
 }
 
 // imported wraps an imported [File] and the import statement declaration [ast.DeclImport].
 type imported struct {
-	file          *File
-	decl          ast.DeclImport
-	weak, option  bool
+	file         *File
+	decl         ast.DeclImport
+	weak, option bool
+
+	// Whether the importing file re-exports this file, i.e. whether this file
+	// is reachable from the importing file by following public imports only.
+	// Importers of the importing file can name symbols from such files.
+	//
+	// This is not the same as the import being declared `import public`: a
+	// plain `import` of a file that is also re-exported by a public import is
+	// still re-exported.
+	public bool
+
 	visible, used bool
 }
 
 // AddDirect appends a direct import to this imports table.
 func (i *imports) AddDirect(imp Import) {
 	if imp.Public {
-		i.Insert(imp, int(i.publicEnd), true)
+		i.Insert(imp, int(i.publicEnd), true, true)
 		i.publicEnd++
 	} else {
-		i.Insert(imp, int(i.importEnd), true)
+		i.Insert(imp, int(i.importEnd), true, false)
 	}
 
 	i.importEnd++
@@ -132,7 +147,13 @@ func (i *imports) AddDirect(imp Import) {
 //
 // Must only be called once, after all direct imports are added.
 func (i *imports) Recurse(dedup intern.Map[ast.DeclImport]) {
-	seenPublicImport := make(map[intern.ID]struct{})
+	// The same file can be reached through more than one direct import, and
+	// the public-ness of each of those paths can differ, so a transitive
+	// import cannot be classified by looking only at whichever direct import
+	// happens to pull it in first. Instead, classify every transitive import
+	// up front, quantifying over all direct imports.
+	public, visible := i.classifyTransitive()
+
 	for k, file := range seq.All(i.Directs()) {
 		for imp := range seq.Values(file.TransitiveImports()) {
 			if !mapsx.AddZero(dedup, imp.InternedPath()) {
@@ -140,23 +161,28 @@ func (i *imports) Recurse(dedup intern.Map[ast.DeclImport]) {
 				// treat this import as non-option, because this overrides it.
 				if imp.Public {
 					i.files[k].option = false
-					// For public transitive imports that we have already seen, we need to override
-					// the visibility after all imports have been added and indexed by path.
-					seenPublicImport[imp.InternedPath()] = struct{}{}
 				}
 				continue
 			}
 
-			// Transitive imports are public to us if and only if they are
-			// imported through a public import.
-			if file.Public && imp.Public {
-				i.Insert(imp, int(i.transPublicEnd), true)
+			// Files we re-export go in the transitive public segment.
+			if public.ContainsID(imp.InternedPath()) {
+				i.Insert(imp, int(i.transPublicEnd), true, true)
 				i.transPublicEnd++
 				continue
 			}
 
 			// Public imports of direct imports are visible in the current file.
-			i.Insert(imp, -1, imp.Public)
+			i.Insert(imp, -1, visible.ContainsID(imp.InternedPath()), false)
+		}
+	}
+
+	// A direct import can be re-exported by another direct import, which the
+	// segments above cannot express, because a direct import has to stay in
+	// one of the direct segments. Mark those separately.
+	for n := range i.files[:i.importEnd] {
+		if public.ContainsID(i.files[n].file.InternedPath()) {
+			i.files[n].public = true
 		}
 	}
 
@@ -166,9 +192,6 @@ func (i *imports) Recurse(dedup intern.Map[ast.DeclImport]) {
 
 	for n, imp := range i.files {
 		i.byPath[imp.file.InternedPath()] = uint32(n)
-		if _, ok := seenPublicImport[imp.file.InternedPath()]; ok {
-			i.files[n].visible = true
-		}
 	}
 
 	for k, file := range seq.All(i.Directs()) {
@@ -180,10 +203,41 @@ func (i *imports) Recurse(dedup intern.Map[ast.DeclImport]) {
 	}
 }
 
+// classifyTransitive computes, for the transitive imports of every direct
+// import, whether the current file re-exports them and whether their symbols
+// are nameable from the current file.
+//
+// public is the set of files the current file re-exports: those re-exported by
+// a direct import that is itself public. visible is the set of files whose
+// symbols the current file can name because some direct import re-exports
+// them; unlike public, this does not require the direct import to be public.
+// public is therefore a subset of visible.
+//
+// Neither set includes the direct imports themselves, which are always
+// visible, nor files reached only through non-public imports, which are
+// neither.
+func (i *imports) classifyTransitive() (public, visible intern.Set) {
+	public = make(intern.Set)
+	visible = make(intern.Set)
+	for file := range seq.Values(i.Directs()) {
+		for imp := range seq.Values(file.TransitiveImports()) {
+			if !imp.Public {
+				continue
+			}
+
+			visible.AddID(imp.InternedPath())
+			if file.Public {
+				public.AddID(imp.InternedPath())
+			}
+		}
+	}
+	return public, visible
+}
+
 // Insert inserts a new import at the given position. It also builds up the path map for lookups.
 //
 // If pos is < 0, appends at the end.
-func (i *imports) Insert(imp Import, pos int, visible bool) {
+func (i *imports) Insert(imp Import, pos int, visible, public bool) {
 	if pos < 0 {
 		pos = len(i.files)
 	}
@@ -193,6 +247,7 @@ func (i *imports) Insert(imp Import, pos int, visible bool) {
 		decl:    imp.Decl,
 		weak:    imp.Weak,
 		option:  imp.Option,
+		public:  public,
 		visible: visible,
 	})
 }
@@ -252,12 +307,10 @@ func (i *imports) Transitive() seq.Indexer[Import] {
 	return seq.NewFixedSlice(
 		slice,
 		func(j int, imported imported) Import {
-			n := uint32(j)
 			return Import{
-				File: imported.file,
-				Public: n < i.publicEnd ||
-					(n >= i.importEnd && n < i.transPublicEnd),
-				Direct:  n < i.importEnd,
+				File:    imported.file,
+				Public:  imported.public,
+				Direct:  uint32(j) < i.importEnd,
 				Visible: imported.visible,
 				Decl:    imported.decl,
 			}

--- a/experimental/ir/ir_imports_test.go
+++ b/experimental/ir/ir_imports_test.go
@@ -42,7 +42,7 @@ func TestImportResolution(t *testing.T) {
 	// a -> b
 	b := buildFile(s, "b.proto", ir.Import{File: a})
 	assert.Equal(t, []imp{{path: "a.proto"}}, directs(b))
-	assert.Equal(t, []imp{{path: "a.proto"}}, transitive(b))
+	assert.Equal(t, []imp{{path: "a.proto", visible: true}}, transitive(b))
 
 	// a -> b -
 	// \        \
@@ -50,29 +50,46 @@ func TestImportResolution(t *testing.T) {
 	c := buildFile(s, "c.proto", ir.Import{File: a})
 	d := buildFile(s, "d.proto", ir.Import{File: b}, ir.Import{File: c})
 	assert.Equal(t, []imp{{path: "b.proto"}, {path: "c.proto"}}, directs(d))
-	assert.Equal(t, []imp{{path: "b.proto"}, {path: "c.proto"}, {path: "a.proto"}}, transitive(d))
+	assert.Equal(t, []imp{
+		{path: "b.proto", visible: true},
+		{path: "c.proto", visible: true},
+		{path: "a.proto"},
+	}, transitive(d))
 
 	// a => e
 	e := buildFile(s, "e.proto", ir.Import{File: a, Public: true})
 	assert.Equal(t, []imp{{path: "a.proto", public: true}}, directs(e))
-	assert.Equal(t, []imp{{path: "a.proto", public: true}}, transitive(e))
+	assert.Equal(t, []imp{{path: "a.proto", public: true, visible: true}}, transitive(e))
 
 	// a => e -> f
 	f := buildFile(s, "f.proto", ir.Import{File: e})
 	assert.Equal(t, []imp{{path: "e.proto"}}, directs(f))
-	assert.Equal(t, []imp{{path: "e.proto"}, {path: "a.proto"}}, transitive(f))
+	assert.Equal(t, []imp{
+		{path: "e.proto", visible: true},
+		// f does not re-export a, because it imports e non-publicly, but a's
+		// symbols are still nameable from f.
+		{path: "a.proto", visible: true},
+	}, transitive(f))
 
 	// a => e => g
 	g := buildFile(s, "g.proto", ir.Import{File: e, Public: true})
 	assert.Equal(t, []imp{{path: "e.proto", public: true}}, directs(g))
-	assert.Equal(t, []imp{{path: "e.proto", public: true}, {path: "a.proto", public: true}}, transitive(g))
+	assert.Equal(t, []imp{
+		{path: "e.proto", public: true, visible: true},
+		{path: "a.proto", public: true, visible: true},
+	}, transitive(g))
 
 	// a -> b -
 	// \        \
 	//   -> c -> d => h
 	h := buildFile(s, "h.proto", ir.Import{File: d, Public: true})
 	assert.Equal(t, []imp{{path: "d.proto", public: true}}, directs(h))
-	assert.Equal(t, []imp{{path: "d.proto", public: true}, {path: "b.proto"}, {path: "c.proto"}, {path: "a.proto"}}, transitive(h))
+	assert.Equal(t, []imp{
+		{path: "d.proto", public: true, visible: true},
+		{path: "b.proto"},
+		{path: "c.proto"},
+		{path: "a.proto"},
+	}, transitive(h))
 
 	// This test case is particularly important, because it validates that
 	// in a diamond configuration, we don't lose public-ness of a transitive
@@ -84,22 +101,76 @@ func TestImportResolution(t *testing.T) {
 	i := buildFile(s, "i.proto", ir.Import{File: a, Public: true})
 	j := buildFile(s, "j.proto", ir.Import{File: c}, ir.Import{File: i, Public: true})
 	assert.Equal(t, []imp{{path: "i.proto", public: true}, {path: "c.proto"}}, directs(j))
-	assert.Equal(t, []imp{{path: "i.proto", public: true}, {path: "c.proto"}, {path: "a.proto", public: true}}, transitive(j))
+	assert.Equal(t, []imp{
+		{path: "i.proto", public: true, visible: true},
+		{path: "c.proto", visible: true},
+		{path: "a.proto", public: true, visible: true},
+	}, transitive(j))
 	// Same as above but order is swapped.
 	j2 := buildFile(s, "j.proto", ir.Import{File: i, Public: true}, ir.Import{File: c})
 	assert.Equal(t, []imp{{path: "i.proto", public: true}, {path: "c.proto"}}, directs(j2))
-	assert.Equal(t, []imp{{path: "i.proto", public: true}, {path: "c.proto"}, {path: "a.proto", public: true}}, transitive(j2))
+	assert.Equal(t, []imp{
+		{path: "i.proto", public: true, visible: true},
+		{path: "c.proto", visible: true},
+		{path: "a.proto", public: true, visible: true},
+	}, transitive(j2))
+
+	// Like the diamond above, but both of m's imports are public, so the public
+	// segment of Directs() does not order the path that re-exports a first. a
+	// must still be re-exported by m, and therefore be nameable from n.
+	//
+	// a -> c => m -> n
+	// \         /
+	//   => e ==
+	m := buildFile(s, "m.proto", ir.Import{File: c, Public: true}, ir.Import{File: e, Public: true})
+	assert.Equal(t, []imp{{path: "c.proto", public: true}, {path: "e.proto", public: true}}, directs(m))
+	assert.Equal(t, []imp{
+		{path: "c.proto", public: true, visible: true},
+		{path: "e.proto", public: true, visible: true},
+		{path: "a.proto", public: true, visible: true},
+	}, transitive(m))
+	n := buildFile(s, "n.proto", ir.Import{File: m})
+	assert.Equal(t, []imp{{path: "m.proto"}}, directs(n))
+	assert.Equal(t, []imp{
+		{path: "m.proto", visible: true},
+		{path: "c.proto", visible: true},
+		{path: "e.proto", visible: true},
+		{path: "a.proto", visible: true},
+	}, transitive(n))
+
+	// A direct import can also be re-exported by one of the other direct
+	// imports. o re-exports a via e, even though o's own import of a is not
+	// public, so a is nameable from p.
+	//
+	// a => e => o -> p
+	// \         /
+	//   ------
+	o := buildFile(s, "o.proto", ir.Import{File: a}, ir.Import{File: e, Public: true})
+	// a is not declared `public`, so it stays out of the public segment of
+	// Directs() and therefore out of public_dependency.
+	assert.Equal(t, []imp{{path: "e.proto", public: true}, {path: "a.proto"}}, directs(o))
+	assert.Equal(t, []imp{
+		{path: "e.proto", public: true, visible: true},
+		{path: "a.proto", public: true, visible: true},
+	}, transitive(o))
+	p := buildFile(s, "p.proto", ir.Import{File: o})
+	assert.Equal(t, []imp{{path: "o.proto"}}, directs(p))
+	assert.Equal(t, []imp{
+		{path: "o.proto", visible: true},
+		{path: "e.proto", visible: true},
+		{path: "a.proto", visible: true},
+	}, transitive(p))
 
 	// a ~> k
 	// NOTE: weak imports are not tracked transitively.
 	k := buildFile(s, "k.proto", ir.Import{File: a, Weak: true})
 	assert.Equal(t, []imp{{path: "a.proto", weak: true}}, directs(k))
-	assert.Equal(t, []imp{{path: "a.proto"}}, transitive(k))
+	assert.Equal(t, []imp{{path: "a.proto", visible: true}}, transitive(k))
 
 	// a ~> k ~> l
 	l := buildFile(s, "l.proto", ir.Import{File: k, Weak: true})
 	assert.Equal(t, []imp{{path: "k.proto", weak: true}}, directs(l))
-	assert.Equal(t, []imp{{path: "k.proto"}, {path: "a.proto"}}, transitive(l))
+	assert.Equal(t, []imp{{path: "k.proto", visible: true}, {path: "a.proto"}}, transitive(l))
 }
 
 // buildFile implements the most basic rudiments of building a File with a
@@ -121,7 +192,7 @@ func buildFile(
 		table.AddDirect(imp)
 	}
 	table.Recurse(dedup)
-	table.Insert(ir.Import{}, -1, false) // Dummy descriptor.proto.
+	table.Insert(ir.Import{}, -1, false, false) // Dummy descriptor.proto.
 
 	return file
 }
@@ -129,16 +200,19 @@ func buildFile(
 type imp struct {
 	path         string
 	public, weak bool
+	// Only meaningful for transitive imports; direct imports are always
+	// visible, so [directs] does not populate this.
+	visible bool
 }
 
 func directs(f *ir.File) []imp {
 	return slices.Collect(seq.Map(ir.GetImports(f).Directs(), func(i ir.Import) imp {
-		return imp{i.File.Path(), i.Public, i.Weak}
+		return imp{path: i.File.Path(), public: i.Public, weak: i.Weak}
 	}))
 }
 
 func transitive(f *ir.File) []imp {
 	return slices.Collect(seq.Map(ir.GetImports(f).Transitive(), func(i ir.Import) imp {
-		return imp{i.File.Path(), i.Public, i.Weak}
+		return imp{path: i.File.Path(), public: i.Public, weak: i.Weak, visible: i.Visible}
 	}))
 }

--- a/experimental/ir/lower_imports.go
+++ b/experimental/ir/lower_imports.go
@@ -118,7 +118,7 @@ func buildImports(file *File, r *report.Report, importer Importer) {
 	// If this is descriptor.proto itself, use it. This step is necessary to
 	// avoid cycles.
 	if file.IsDescriptorProto() {
-		file.imports.Insert(Import{File: file}, -1, false)
+		file.imports.Insert(Import{File: file}, -1, false, false)
 		file.imports.byPath[file.session.builtins.DescriptorFile] = uint32(len(file.imports.files) - 1)
 		file.imports.causes[file.session.builtins.DescriptorFile] = uint32(len(file.imports.files) - 1)
 		return
@@ -135,7 +135,7 @@ func buildImports(file *File, r *report.Report, importer Importer) {
 		panic(fmt.Errorf("importing %q produced an invalid file", DescriptorProtoPath))
 	}
 
-	file.imports.Insert(Import{File: dproto, Decl: ast.DeclImport{}}, -1, false)
+	file.imports.Insert(Import{File: dproto, Decl: ast.DeclImport{}}, -1, false, false)
 	file.imports.byPath[file.session.builtins.DescriptorFile] = uint32(len(file.imports.files) - 1)
 	file.imports.causes[file.session.builtins.DescriptorFile] = uint32(len(file.imports.files) - 1)
 }

--- a/experimental/ir/testdata/imports/public_diamond.proto.yaml
+++ b/experimental/ir/testdata/imports/public_diamond.proto.yaml
@@ -1,0 +1,55 @@
+# A file can be re-exported through more than one public import, with
+# differing public-ness along each path. Here main.proto sees Leaf because
+# reexport.proto re-exports public_leaf.proto, which re-exports leaf.proto.
+# plain_leaf.proto also reaches leaf.proto, but not publicly, and it is
+# declared first; that must not stop leaf.proto from being re-exported.
+descriptor: true
+exclude: "unused import"
+files:
+- path: "main.proto"
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "reexport.proto";
+
+    message Main {
+      optional Leaf leaf = 1;
+    }
+
+- path: "reexport.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import public "plain_leaf.proto";
+    import public "public_leaf.proto";
+
+- path: "plain_leaf.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "leaf.proto";
+
+    message PlainLeaf {
+      optional Leaf leaf = 1;
+    }
+
+- path: "public_leaf.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import public "leaf.proto";
+
+- path: "leaf.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    message Leaf {}

--- a/experimental/ir/testdata/imports/public_diamond.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/public_diamond.proto.yaml.fds.yaml
@@ -1,0 +1,34 @@
+file:
+- { name: "leaf.proto", package: "buf.test", message_type: [{ name: "Leaf" }] }
+- name: "public_leaf.proto"
+  package: "buf.test"
+  dependency: ["leaf.proto"]
+  public_dependency: [0]
+- name: "plain_leaf.proto"
+  package: "buf.test"
+  dependency: ["leaf.proto"]
+  message_type:
+  - name: "PlainLeaf"
+    field:
+    - name: "leaf"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.Leaf"
+      json_name: "leaf"
+- name: "reexport.proto"
+  package: "buf.test"
+  dependency: ["plain_leaf.proto", "public_leaf.proto"]
+  public_dependency: [0, 1]
+- name: "main.proto"
+  package: "buf.test"
+  dependency: ["reexport.proto"]
+  message_type:
+  - name: "Main"
+    field:
+    - name: "leaf"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.Leaf"
+      json_name: "leaf"

--- a/experimental/ir/testdata/imports/public_shadowed.proto.yaml
+++ b/experimental/ir/testdata/imports/public_shadowed.proto.yaml
@@ -1,0 +1,46 @@
+# A plain import of a file that is also re-exported by a public import is
+# still re-exported. Here reexport.proto imports leaf.proto directly and
+# non-publicly, but it also re-exports public_leaf.proto, which re-exports
+# leaf.proto, so main.proto can name Leaf.
+descriptor: true
+exclude: "unused import"
+files:
+- path: "main.proto"
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "reexport.proto";
+
+    message Main {
+      optional Leaf leaf = 1;
+    }
+
+- path: "reexport.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import "leaf.proto";
+    import public "public_leaf.proto";
+
+    message Reexport {
+      optional Leaf leaf = 1;
+    }
+
+- path: "public_leaf.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    import public "leaf.proto";
+
+- path: "leaf.proto"
+  import: true
+  text: |
+    syntax = "proto2";
+    package buf.test;
+
+    message Leaf {}

--- a/experimental/ir/testdata/imports/public_shadowed.proto.yaml.fds.yaml
+++ b/experimental/ir/testdata/imports/public_shadowed.proto.yaml.fds.yaml
@@ -1,0 +1,31 @@
+file:
+- { name: "leaf.proto", package: "buf.test", message_type: [{ name: "Leaf" }] }
+- name: "public_leaf.proto"
+  package: "buf.test"
+  dependency: ["leaf.proto"]
+  public_dependency: [0]
+- name: "reexport.proto"
+  package: "buf.test"
+  dependency: ["leaf.proto", "public_leaf.proto"]
+  public_dependency: [1]
+  message_type:
+  - name: "Reexport"
+    field:
+    - name: "leaf"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.Leaf"
+      json_name: "leaf"
+- name: "main.proto"
+  package: "buf.test"
+  dependency: ["reexport.proto"]
+  message_type:
+  - name: "Main"
+    field:
+    - name: "leaf"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".buf.test.Leaf"
+      json_name: "leaf"


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/4633. Since `buf` v1.68.0 (which switched to the new compiler), a symbol re-exported via `import public` is not always found by importers. `protoc` and the legacy compiler accept the same files.

## Root cause

`imports.Recurse` classified each transitive import by looking only at whichever direct import happened to pull it in first, so a file reachable through several direct imports with differing public-ness could be misclassified. Two shapes were affected, both of which `protoc` accepts.

**1. The public path is not visited first.**

```protobuf
// reexport.proto
import public "plain_leaf.proto";   // imports leaf.proto non-publicly
import public "public_leaf.proto";  // imports leaf.proto publicly
```

Public imports are ordered first in `Directs()` precisely so that the public path wins, but that does not disambiguate when *both* direct imports are public. `plain_leaf.proto` is visited first, `file.Public && imp.Public` is false, and `leaf.proto` lands in the trailing non-public segment, so `reexport.proto` stops re-exporting it.

#665 patched the `visible` half of this with `seenPublicImport`, which is why `reexport.proto` itself still compiled. But `Transitive().Public` was left wrong, so importers of `reexport.proto` could not name `Leaf`.

**2. A direct import that is also re-exported.**

```protobuf
// reexport.proto
import "leaf.proto";
import public "public_leaf.proto";  // imports leaf.proto publicly
```

`reexport.proto` re-exports `leaf.proto` via `public_leaf.proto`, but `leaf.proto` has to stay in a direct segment, and `Transitive()` derived public-ness purely from the segment offsets, so it could not represent this at all.

## Fix

Classify every transitive import up front in `classifyTransitive`, quantifying over all direct imports, and record public-ness as a bit on `imported` rather than deriving it from the segment offsets. The offsets still order the table, but they are no longer the source of truth for `Transitive().Public`.

This makes the classification match `protoc`'s `DescriptorBuilder::RecordPublicDependencies`, which is a closure over `public_dependency` edges and therefore order-independent.

## Testing

- `TestImportResolution` gains the two shapes above; both fail without the fix. It also now asserts `Import.Visible`, which had no coverage.
- New golden tests `imports/public_diamond` and `imports/public_shadowed`; their `fds.yaml` output was checked byte-for-byte against `protoc` 33.3, including that `public_dependency` is unchanged in shape 2.
- Differential fuzzing against `protoc`: 700 random import DAGs of up to 12 files, each file referencing every symbol `protoc`'s rule says is visible (zero rejections), plus 838 pairwise accept/reject probes agreeing with `protoc` in both directions. The same fuzzer flags the bug on an unpatched build within ~30 seeds.