### PR TITLE
Fix reserve range within groups

### DIFF
--- a/experimental/ir/testdata/extend/overlap.proto.stderr.txt
+++ b/experimental/ir/testdata/extend/overlap.proto.stderr.txt
@@ -8,7 +8,8 @@ error: unexpected extension range within enum definition
 21 | | }
    | \_- ...cannot be declared within this enum definition
    |
-   = help: this extension range can only appear within a message definition
+   = help: this extension range can only appear within one of message definition
+           or group definition
 
 error: use of reserved field number `2`
   --> testdata/extend/overlap.proto:7:25

--- a/experimental/ir/testdata/fields/groups/ranges.proto
+++ b/experimental/ir/testdata/fields/groups/ranges.proto
@@ -1,0 +1,38 @@
+//% descriptor: true
+syntax = "proto2";
+
+package test;
+
+message Foo {
+    extensions 100 to 200;
+
+    optional group Bar = 1 {
+        extensions 10 to 20;
+
+        reserved 5;
+        reserved 6, 7 to 8;
+        reserved "a", "b";
+
+        optional group Baz = 9 {
+            extensions 10 to max;
+            reserved 2;
+            reserved "c";
+        }
+    }
+
+    oneof O {
+        group Quux = 2 {
+            extensions 10 to max;
+            reserved 2;
+            reserved "d";
+        }
+    }
+}
+
+extend Foo {
+    optional group Extn = 100 {
+        extensions 10 to max;
+        reserved 2;
+        reserved "e";
+    }
+}

--- a/experimental/ir/testdata/fields/groups/ranges.proto.fds.yaml
+++ b/experimental/ir/testdata/fields/groups/ranges.proto.fds.yaml
@@ -1,0 +1,57 @@
+file:
+- name: "testdata/fields/groups/ranges.proto"
+  package: "test"
+  message_type:
+  - name: "Foo"
+    field:
+    - name: "bar"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_GROUP
+      type_name: ".test.Foo.Bar"
+      json_name: "bar"
+    - name: "quux"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_GROUP
+      type_name: ".test.Foo.Quux"
+      oneof_index: 0
+      json_name: "quux"
+    nested_type:
+    - name: "Bar"
+      field:
+      - name: "baz"
+        number: 9
+        label: LABEL_OPTIONAL
+        type: TYPE_GROUP
+        type_name: ".test.Foo.Bar.Baz"
+        json_name: "baz"
+      nested_type:
+      - name: "Baz"
+        extension_range: [{ start: 10, end: 536870912 }]
+        reserved_range: [{ start: 2, end: 3 }]
+        reserved_name: ["c"]
+      extension_range: [{ start: 10, end: 21 }]
+      reserved_range:
+      - { start: 5, end: 6 }
+      - { start: 6, end: 7 }
+      - { start: 7, end: 9 }
+      reserved_name: ["a", "b"]
+    - name: "Quux"
+      extension_range: [{ start: 10, end: 536870912 }]
+      reserved_range: [{ start: 2, end: 3 }]
+      reserved_name: ["d"]
+    extension_range: [{ start: 100, end: 201 }]
+    oneof_decl: [{ name: "O" }]
+  - name: "Extn"
+    extension_range: [{ start: 10, end: 536870912 }]
+    reserved_range: [{ start: 2, end: 3 }]
+    reserved_name: ["e"]
+  extension:
+  - name: "extn"
+    number: 100
+    label: LABEL_OPTIONAL
+    type: TYPE_GROUP
+    type_name: ".test.Extn"
+    extendee: ".test.Foo"
+    json_name: "extn"

--- a/experimental/ir/testdata/fields/groups/ranges.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/groups/ranges.proto.stderr.txt
@@ -1,0 +1,29 @@
+warning: group syntax is deprecated
+  --> testdata/fields/groups/ranges.proto:9:14
+   |
+ 9 |     optional group Bar = 1 {
+   |              ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+warning: group syntax is deprecated
+  --> testdata/fields/groups/ranges.proto:16:18
+   |
+16 |         optional group Baz = 9 {
+   |                  ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+warning: group syntax is deprecated
+  --> testdata/fields/groups/ranges.proto:24:9
+   |
+24 |         group Quux = 2 {
+   |         ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+warning: group syntax is deprecated
+  --> testdata/fields/groups/ranges.proto:33:14
+   |
+33 |     optional group Extn = 100 {
+   |              ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+encountered 4 warnings

--- a/experimental/ir/testdata/fields/groups/reserved.proto
+++ b/experimental/ir/testdata/fields/groups/reserved.proto
@@ -1,0 +1,15 @@
+//% exclude: ["group syntax is deprecated"]
+syntax = "proto2";
+
+package test;
+
+// Reserved tags and names must still be enforced inside a group body.
+message Foo {
+    optional group Bar = 1 {
+        reserved 5;
+        reserved "a";
+
+        optional int32 bad_tag = 5;
+        optional int32 a = 6;
+    }
+}

--- a/experimental/ir/testdata/fields/groups/reserved.proto.stderr.txt
+++ b/experimental/ir/testdata/fields/groups/reserved.proto.stderr.txt
@@ -1,0 +1,21 @@
+error: use of reserved field number `5`
+  --> testdata/fields/groups/reserved.proto:12:34
+   |
+ 9 |         reserved 5;
+   |                  - field number reserved here
+10 |         reserved "a";
+11 |
+12 |         optional int32 bad_tag = 5;
+   |                                  ^ used here
+
+error: use of reserved message field name
+  --> testdata/fields/groups/reserved.proto:13:24
+   |
+10 |         reserved "a";
+   |                  --- `a` reserved here
+11 |
+12 |         optional int32 bad_tag = 5;
+13 |         optional int32 a = 6;
+   |                        ^
+
+encountered 2 errors

--- a/experimental/parser/legalize_decl.go
+++ b/experimental/parser/legalize_decl.go
@@ -83,7 +83,9 @@ func legalizeDecl(p *parser, parent classified, decl ast.DeclAny) {
 // legalizeDecl legalizes an extension or reserved range.
 func legalizeRange(p *parser, parent classified, decl ast.DeclRange) {
 	in := taxa.Extensions
-	validParents := taxa.Message.AsSet()
+	// A group defines a nested message, so its body permits ranges just like a
+	// message body does.
+	validParents := taxa.NewSet(taxa.Message, taxa.Group)
 	if decl.IsReserved() {
 		in = taxa.Reserved
 		validParents = validParents.With(taxa.Enum)

--- a/experimental/parser/testdata/parser/range/group.proto
+++ b/experimental/parser/testdata/parser/range/group.proto
@@ -1,0 +1,37 @@
+syntax = "proto2";
+
+package test;
+
+message Foo {
+    extensions 100 to 200;
+
+    optional group Bar = 1 {
+        extensions 10 to 20;
+
+        reserved 5;
+        reserved 6, 7 to 8;
+        reserved "a", "b";
+
+        optional group Baz = 9 {
+            extensions 10 to max;
+            reserved 2;
+            reserved "c";
+        }
+    }
+
+    oneof O {
+        group Quux = 2 {
+            extensions 10 to max;
+            reserved 2;
+            reserved "d";
+        }
+    }
+}
+
+extend Foo {
+    optional group Extn = 100 {
+        extensions 10 to max;
+        reserved 2;
+        reserved "e";
+    }
+}

--- a/experimental/parser/testdata/parser/range/group.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/range/group.proto.stderr.txt
@@ -1,0 +1,29 @@
+warning: group syntax is deprecated
+  --> testdata/parser/range/group.proto:8:14
+   |
+ 8 |     optional group Bar = 1 {
+   |              ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+warning: group syntax is deprecated
+  --> testdata/parser/range/group.proto:15:18
+   |
+15 |         optional group Baz = 9 {
+   |                  ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+warning: group syntax is deprecated
+  --> testdata/parser/range/group.proto:23:9
+   |
+23 |         group Quux = 2 {
+   |         ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+warning: group syntax is deprecated
+  --> testdata/parser/range/group.proto:32:14
+   |
+32 |     optional group Extn = 100 {
+   |              ^^^^^
+   = note: group syntax is not available in proto3 or editions
+
+encountered 4 warnings

--- a/experimental/parser/testdata/parser/range/group.proto.yaml
+++ b/experimental/parser/testdata/parser/range/group.proto.yaml
@@ -1,0 +1,92 @@
+decls:
+- syntax: { kind: KIND_SYNTAX, value.literal.string_value: "proto2" }
+- package.path.components: [{ ident: "test" }]
+- def:
+    kind: KIND_MESSAGE
+    name.components: [{ ident: "Foo" }]
+    body.decls:
+    - range:
+        kind: KIND_EXTENSIONS
+        ranges:
+        - range: { start.literal.int_value: 100, end.literal.int_value: 200 }
+    - def:
+        kind: KIND_GROUP
+        name.components: [{ ident: "Bar" }]
+        type.prefixed:
+          prefix: PREFIX_OPTIONAL
+          type.path.components: [{ ident: "group" }]
+        value.literal.int_value: 1
+        body.decls:
+        - range:
+            kind: KIND_EXTENSIONS
+            ranges:
+            - range: { start.literal.int_value: 10, end.literal.int_value: 20 }
+        - range: { kind: KIND_RESERVED, ranges: [{ literal.int_value: 5 }] }
+        - range:
+            kind: KIND_RESERVED
+            ranges:
+            - literal.int_value: 6
+            - range: { start.literal.int_value: 7, end.literal.int_value: 8 }
+        - range:
+            kind: KIND_RESERVED
+            ranges:
+            - literal.string_value: "a"
+            - literal.string_value: "b"
+        - def:
+            kind: KIND_GROUP
+            name.components: [{ ident: "Baz" }]
+            type.prefixed:
+              prefix: PREFIX_OPTIONAL
+              type.path.components: [{ ident: "group" }]
+            value.literal.int_value: 9
+            body.decls:
+            - range:
+                kind: KIND_EXTENSIONS
+                ranges:
+                - range:
+                    start.literal.int_value: 10
+                    end.path.components: [{ ident: "max" }]
+            - range: { kind: KIND_RESERVED, ranges: [{ literal.int_value: 2 }] }
+            - range:
+                kind: KIND_RESERVED
+                ranges: [{ literal.string_value: "c" }]
+    - def:
+        kind: KIND_ONEOF
+        name.components: [{ ident: "O" }]
+        body.decls:
+        - def:
+            kind: KIND_GROUP
+            name.components: [{ ident: "Quux" }]
+            type.path.components: [{ ident: "group" }]
+            value.literal.int_value: 2
+            body.decls:
+            - range:
+                kind: KIND_EXTENSIONS
+                ranges:
+                - range:
+                    start.literal.int_value: 10
+                    end.path.components: [{ ident: "max" }]
+            - range: { kind: KIND_RESERVED, ranges: [{ literal.int_value: 2 }] }
+            - range:
+                kind: KIND_RESERVED
+                ranges: [{ literal.string_value: "d" }]
+- def:
+    kind: KIND_EXTEND
+    name.components: [{ ident: "Foo" }]
+    body.decls:
+    - def:
+        kind: KIND_GROUP
+        name.components: [{ ident: "Extn" }]
+        type.prefixed:
+          prefix: PREFIX_OPTIONAL
+          type.path.components: [{ ident: "group" }]
+        value.literal.int_value: 100
+        body.decls:
+        - range:
+            kind: KIND_EXTENSIONS
+            ranges:
+            - range:
+                start.literal.int_value: 10
+                end.path.components: [{ ident: "max" }]
+        - range: { kind: KIND_RESERVED, ranges: [{ literal.int_value: 2 }] }
+        - range: { kind: KIND_RESERVED, ranges: [{ literal.string_value: "e" }] }

--- a/experimental/parser/testdata/parser/range/invalid_parent.proto.stderr.txt
+++ b/experimental/parser/testdata/parser/range/invalid_parent.proto.stderr.txt
@@ -8,7 +8,8 @@ error: unexpected extension range within service definition
  8 | | }
    | \_- ...cannot be declared within this service definition
    |
-   = help: this extension range can only appear within a message definition
+   = help: this extension range can only appear within one of message definition
+           or group definition
 
 error: unexpected reserved range within service definition
   --> testdata/parser/range/invalid_parent.proto:7:5
@@ -20,8 +21,8 @@ error: unexpected reserved range within service definition
  8 | | }
    | \_- ...cannot be declared within this service definition
    |
-   = help: this reserved range can only appear within one of message definition
-           or enum definition
+   = help: this reserved range can only appear within one of message definition,
+           enum definition, or group definition
 
 error: unexpected extension range within message extension block
   --> testdata/parser/range/invalid_parent.proto:11:5
@@ -33,7 +34,8 @@ error: unexpected extension range within message extension block
 13 | | }
    | \_- ...cannot be declared within this message extension block
    |
-   = help: this extension range can only appear within a message definition
+   = help: this extension range can only appear within one of message definition
+           or group definition
 
 error: unexpected reserved range within message extension block
   --> testdata/parser/range/invalid_parent.proto:12:5
@@ -45,8 +47,8 @@ error: unexpected reserved range within message extension block
 13 | | }
    | \_- ...cannot be declared within this message extension block
    |
-   = help: this reserved range can only appear within one of message definition
-           or enum definition
+   = help: this reserved range can only appear within one of message definition,
+           enum definition, or group definition
 
 error: unexpected extension range within enum definition
   --> testdata/parser/range/invalid_parent.proto:16:5
@@ -57,6 +59,7 @@ error: unexpected extension range within enum definition
 17 | | }
    | \_- ...cannot be declared within this enum definition
    |
-   = help: this extension range can only appear within a message definition
+   = help: this extension range can only appear within one of message definition
+           or group definition
 
 encountered 5 errors


### PR DESCRIPTION
This updates the legalizer to allow reserved and extension ranges in group bodies. Before `reserved` and `extensions` inside a group were rejected as bad nesting. This conforms with protoc behavior. 

Fixes https://github.com/bufbuild/protocompile/issues/753