### PR TITLE
Fix race on cancelled incremental queries

### DIFF
--- a/experimental/incremental/cancel_test.go
+++ b/experimental/incremental/cancel_test.go
@@ -1,0 +1,163 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package incremental_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
+)
+
+func TestCancelWhileLeaderExecutes(t *testing.T) {
+	t.Parallel()
+
+	// The interleaving is timing-dependent; repeat to give the race detector
+	// a chance to observe conflicting accesses.
+	for range 10 {
+		exec := incremental.New(incremental.WithParallelism(4))
+		blocking := Blocking{
+			Started: make(chan struct{}),
+			Release: make(chan struct{}),
+		}
+
+		var (
+			leaderResults []incremental.Result[int]
+			leaderErr     error
+			leaderDone    = make(chan struct{})
+		)
+		go func() {
+			defer close(leaderDone)
+			leaderResults, _, leaderErr = incremental.Run(t.Context(), exec, incremental.Query[int](blocking))
+		}()
+		<-blocking.Started
+
+		ctx, cancel := context.WithCancel(t.Context())
+		signal := Signal{Executed: make(chan struct{})}
+		waiterErr := make(chan error)
+		go func() {
+			_, _, err := incremental.Run(ctx, exec, incremental.Query[int](signal), incremental.Query[int](blocking))
+			waiterErr <- err
+		}()
+		<-signal.Executed
+
+		cancel()
+		close(blocking.Release)
+		require.ErrorIs(t, <-waiterErr, context.Canceled)
+		<-leaderDone
+
+		require.NoError(t, leaderErr)
+		assert.Equal(t, 42, leaderResults[0].Value)
+	}
+}
+
+func TestCancelWhileLeaderPanics(t *testing.T) {
+	t.Parallel()
+
+	// The waiter may instead re-execute the query as a new leader (see
+	// PanicBlocking); repeat so the pending-waiter path is exercised.
+	for range 10 {
+		exec := incremental.New(incremental.WithParallelism(4))
+		blocking := PanicBlocking{
+			Started: make(chan struct{}),
+			Release: make(chan struct{}),
+		}
+
+		leaderDone := make(chan struct{})
+		go func() {
+			defer close(leaderDone)
+			_, _, err := incremental.Run(t.Context(), exec, incremental.Query[int](blocking))
+			var panicked *incremental.ErrPanic
+			assert.ErrorAs(t, err, &panicked)
+		}()
+		<-blocking.Started
+
+		ctx, cancel := context.WithCancel(t.Context())
+		signal := Signal{Executed: make(chan struct{})}
+		waiterErr := make(chan error)
+		go func() {
+			_, _, err := incremental.Run(ctx, exec, incremental.Query[int](signal), incremental.Query[int](blocking))
+			waiterErr <- err
+		}()
+		<-signal.Executed
+
+		// The panic resets the shared result to nil without closing its done
+		// channel; cancel only afterwards so the waiter wakes to the nil
+		// result.
+		close(blocking.Release)
+		<-leaderDone
+		cancel()
+		require.ErrorIs(t, <-waiterErr, context.Canceled)
+	}
+}
+
+// Blocking signals when it starts executing and then blocks until released.
+type Blocking struct {
+	Started chan struct{}
+	Release chan struct{}
+}
+
+func (b Blocking) Key() any {
+	return b
+}
+
+func (b Blocking) Execute(_ *incremental.Task) (int, error) {
+	close(b.Started)
+	<-b.Release
+	return 42, nil
+}
+
+// PanicBlocking is like Blocking, but panics once released.
+type PanicBlocking struct {
+	Started chan struct{}
+	Release chan struct{}
+}
+
+func (b PanicBlocking) Key() any {
+	return b
+}
+
+func (b PanicBlocking) Execute(task *incremental.Task) (int, error) {
+	select {
+	case <-b.Started:
+		// Re-executed as the new leader after the panic below wiped the
+		// result; block so the caller still observes cancellation.
+		<-task.Context().Done()
+		return 0, task.Context().Err()
+	default:
+	}
+	close(b.Started)
+	<-b.Release
+	panic("boom")
+}
+
+// Signal closes Executed when it runs. Resolve spawns goroutines for all
+// queries after the first before executing the first synchronously, so once a
+// leading Signal executes, later queries in the same Run are in flight.
+type Signal struct {
+	Executed chan struct{}
+}
+
+func (s Signal) Key() any {
+	return s
+}
+
+func (s Signal) Execute(_ *incremental.Task) (int, error) {
+	close(s.Executed)
+	return 0, nil
+}

--- a/experimental/incremental/cancel_test.go
+++ b/experimental/incremental/cancel_test.go
@@ -106,6 +106,35 @@ func TestCancelWhileLeaderPanics(t *testing.T) {
 	}
 }
 
+func TestCancelledRunWaitsForLeaders(t *testing.T) {
+	t.Parallel()
+
+	exec := incremental.New(incremental.WithParallelism(4))
+	stubborn := Stubborn{
+		Started:  make(chan struct{}),
+		Release:  make(chan struct{}),
+		Finished: new(bool),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	signal := Signal{Executed: make(chan struct{})}
+	runErr := make(chan error)
+	go func() {
+		_, _, err := incremental.Run(ctx, exec, incremental.Query[int](signal), incremental.Query[int](stubborn))
+		runErr <- err
+	}()
+	<-stubborn.Started
+
+	cancel()
+	close(stubborn.Release)
+	require.ErrorIs(t, <-runErr, context.Canceled)
+
+	// Run must not return before the leader it spawned has exited; otherwise
+	// this read is unsynchronized with the write in Stubborn.Execute, and
+	// Evict could run concurrently with a query.
+	assert.True(t, *stubborn.Finished)
+}
+
 // Blocking signals when it starts executing and then blocks until released.
 type Blocking struct {
 	Started chan struct{}
@@ -119,6 +148,25 @@ func (b Blocking) Key() any {
 func (b Blocking) Execute(_ *incremental.Task) (int, error) {
 	close(b.Started)
 	<-b.Release
+	return 42, nil
+}
+
+// Stubborn is like Blocking, but ignores cancellation and sets Finished on
+// its way out.
+type Stubborn struct {
+	Started  chan struct{}
+	Release  chan struct{}
+	Finished *bool
+}
+
+func (s Stubborn) Key() any {
+	return s
+}
+
+func (s Stubborn) Execute(_ *incremental.Task) (int, error) {
+	close(s.Started)
+	<-s.Release
+	*s.Finished = true
 	return 42, nil
 }
 

--- a/experimental/incremental/doc.go
+++ b/experimental/incremental/doc.go
@@ -33,10 +33,10 @@ actually computing it. Queries can partially succeed: instead of a query
 returning (T, error), it only returns a T, and errors are flagged to the [Task]
 argument.
 
-If a query cannot proceed, it can call [Task.Fail], which will mark the query
-as failed and exit the goroutine dedicated to running that query. No queries
-that depend on it will be executed. Non-fatal errors can be recorded with
-[Task.Error].
+If a query cannot proceed, it can return a non-nil fatal error from
+[Query].Execute, which queries that depend on it will observe as
+[Result].Fatal. Non-fatal errors can be recorded as diagnostics on the
+[report.Report] returned by [Task.Report].
 
 This means that generally queries do not need to worry about propagating errors
 correctly; this happens automatically in the framework. The entry-point for

--- a/experimental/incremental/executor.go
+++ b/experimental/incremental/executor.go
@@ -154,8 +154,12 @@ func Run[T any](ctx context.Context, e *Executor, queries ...Query[T]) ([]Result
 		result:          &result{done: make(chan struct{})},
 		runID:           generation,
 		timer:           timings,
+		wg:              new(sync.WaitGroup),
 		onRootGoroutine: true,
 	}
+	// Wait for spawned goroutines before releasing the dirty lock, even on
+	// cancellation, so Evict never runs concurrently with a query.
+	defer root.wg.Wait()
 
 	// Need to acquire a hold on the global semaphore to represent the root
 	// task we're about to execute.

--- a/experimental/incremental/executor.go
+++ b/experimental/incremental/executor.go
@@ -98,8 +98,7 @@ func WithDebugEvict(wait time.Duration) ExecutorOption {
 func (e *Executor) Keys() (keys []string) {
 	e.tasks.Range(func(k, t any) bool {
 		task := t.(*task) //nolint:errcheck // All values in this map are tasks.
-		result := task.result.Load()
-		if result == nil || !closed(result.done) {
+		if task.completed() == nil {
 			return true
 		}
 		keys = append(keys, fmt.Sprintf("%#v", k))
@@ -131,17 +130,21 @@ func Run[T any](ctx context.Context, e *Executor, queries ...Query[T]) ([]Result
 	e.dirty.RLock()
 	defer e.dirty.RUnlock()
 
-	// Verify we haven't reëntrantly called Run.
-	if callers, ok := ctx.Value(&runExecutorKey).(*[]*Executor); ok {
-		if slices.Contains(*callers, e) {
-			panic("protocompile/incremental: reentrant call to Run")
-		}
-		*callers = append(*callers, e)
-	} else {
-		ctx = context.WithValue(ctx, &runExecutorKey, &[]*Executor{e})
+	// Verify we haven't reëntrantly called Run. The slice is cloned, not
+	// mutated in place, so that concurrent nested Runs do not race and
+	// entries do not outlive their call.
+	callers, _ := ctx.Value(&runExecutorKey).([]*Executor)
+	if slices.Contains(callers, e) {
+		panic("protocompile/incremental: reentrant call to Run")
 	}
+	ctx = context.WithValue(ctx, &runExecutorKey, append(slices.Clip(slices.Clone(callers)), e))
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
+
+	var timings *timer
+	if m, ok := ctx.Value(&timingsKey).(map[any]time.Duration); ok && m != nil {
+		timings = &timer{m: m}
+	}
 
 	generation := e.counter.Add(1)
 	root := &Task{
@@ -150,6 +153,7 @@ func Run[T any](ctx context.Context, e *Executor, queries ...Query[T]) ([]Result
 		exec:            e,
 		result:          &result{done: make(chan struct{})},
 		runID:           generation,
+		timer:           timings,
 		onRootGoroutine: true,
 	}
 
@@ -185,12 +189,20 @@ func Run[T any](ctx context.Context, e *Executor, queries ...Query[T]) ([]Result
 		if _, ok := dedup[node]; ok {
 			continue
 		}
+		dedup[node] = struct{}{}
+
+		// The append-only deps graph may lead to tasks only requested by
+		// withdrawn attempts; their reports are leftovers at best, and may be
+		// concurrently rewritten by another Run at worst.
+		if node.completed() == nil {
+			continue
+		}
+
 		node.deps.Range(func(depAny any, _ any) bool {
 			dep := depAny.(*task) //nolint:errcheck
 			tasks = append(tasks, dep)
 			return true
 		})
-		dedup[node] = struct{}{}
 		report.Diagnostics = append(report.Diagnostics, node.report.Diagnostics...)
 	}
 	report.Canonicalize()

--- a/experimental/incremental/executor_test.go
+++ b/experimental/incremental/executor_test.go
@@ -206,6 +206,7 @@ func TestTimings(t *testing.T) {
 		assert.Equal(t, time.Millisecond, results[0].Elapsed)
 		assert.Equal(t, 2*time.Millisecond, results[1].Elapsed)
 
+		assert.Len(t, timings, 7) // One entry per Wait query executed.
 		for k, v := range timings {
 			id := k.(int) //nolint:errcheck
 			assert.Equal(t, time.Duration(id)*time.Millisecond, v)

--- a/experimental/incremental/queries/fds.go
+++ b/experimental/incremental/queries/fds.go
@@ -64,7 +64,8 @@ func (l FDS) Execute(t *incremental.Task) (*descriptorpb.FileDescriptorSet, erro
 		return nil, linkResult[0].Fatal
 	}
 
-	irs := linkResult[0].Value
+	// Clone before filtering to avoid mutating memoized Link results.
+	irs := slices.Clone(linkResult[0].Value)
 	irs = slices.DeleteFunc(irs, func(f *ir.File) bool { return f == nil })
 
 	fdpQueries := slicesx.Transform(

--- a/experimental/incremental/query.go
+++ b/experimental/incremental/query.go
@@ -38,7 +38,7 @@ type Query[T any] interface {
 	// this query is not already in the [Executor]'s cache.
 	//
 	// The error return should only be used to signal if the query failed. For
-	// non-fatal errors, you should record that information with [Task.NonFatal].
+	// non-fatal errors, you should record diagnostics with [Task.Report].
 	//
 	// Implementations of this function MUST NOT call [Run] on the executor that
 	// is executing them. This will defeat correctness detection, and lead to

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -568,8 +568,14 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 // waitUntilDone waits for this task to be completed by another goroutine.
 func (t *task) waitUntilDone(caller *Task, output *result, q *AnyQuery, async bool) *result {
 	if err := t.checkCycle(caller, q); err != nil {
-		output.Fatal = err
-		return output
+		// Return a new result rather than writing to the shared one, which the
+		// leader and other waiters may be accessing concurrently.
+		done := make(chan struct{})
+		close(done)
+		return &result{
+			Result: Result[any]{Fatal: err},
+			done:   done,
+		}
 	}
 
 	// If this task is being executed synchronously with its caller, we need to
@@ -595,8 +601,15 @@ func (t *task) waitUntilDone(caller *Task, output *result, q *AnyQuery, async bo
 	}
 
 	// Reload the result pointer. This is needed if the leader panics,
-	// because the result will be set to nil.
-	return t.result.Load()
+	// because the result will be set to nil (and possibly replaced by a
+	// new leader).
+	output = t.result.Load()
+	if output == nil || !closed(output.done) {
+		// The leader panicked, or the caller's context was cancelled while
+		// the leader was still executing, so the result is not safe to read.
+		return nil
+	}
+	return output
 }
 
 // underlying returns the tasks query underlying key.

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -131,6 +131,12 @@ func (t *Task) release() {
 // transferFrom acquires a hold on the global semaphore from the given task.
 func (t *Task) transferFrom(that *Task) {
 	if t.holding || !that.holding {
+		if context.Cause(t.ctx) != nil {
+			// This context was cancelled, so acquires prior to this transfer
+			// may have failed, in which case we do nothing instead of panic.
+			return
+		}
+
 		t.abort(errBadAcquire)
 	}
 
@@ -229,6 +235,18 @@ func Resolve[T any](caller *Task, queries ...Query[T]) (Results[T], error) {
 	anyQueries := make([]*AnyQuery, len(queries))
 	deps := make([]*task, len(queries))
 
+	if caller.task != nil {
+		// Remove the waiting edges stored below once the caller is no longer
+		// blocked on them.
+		defer func() {
+			for _, dep := range deps {
+				if dep != nil {
+					caller.task.waiting.Delete(dep)
+				}
+			}
+		}()
+	}
+
 	// We use a semaphore here instead of a WaitGroup so that when we block
 	// on it later in this function, we can bail if caller.ctx is cancelled.
 	join := semaphore.NewWeighted(int64(len(queries)))
@@ -255,6 +273,10 @@ func Resolve[T any](caller *Task, queries ...Query[T]) (Results[T], error) {
 		}
 		callerTask.deps.Store(dep, struct{}{})
 		dep.callers.Store(callerTask, struct{}{})
+
+		// The query is stored as the value so that cycle errors can name the
+		// request that produced each edge.
+		callerTask.waiting.Store(dep, q)
 	}
 
 	// Schedule all but the first query to run asynchronously.
@@ -323,6 +345,10 @@ type task struct {
 	// Written by multiple tasks concurrently.
 	// TODO: See the comment on Executor.tasks.
 	callers sync.Map // [*task]struct{}
+	// The tasks this task is currently blocked on, mapped to the query that
+	// requested each of them. Maintained by [Resolve], which removes edges
+	// once it returns; used for cycle detection in [task.checkCycle].
+	waiting sync.Map // [*task]*AnyQuery
 
 	// If this task has not been started yet, this is nil.
 	// Otherwise, if it is complete, result.done will be closed.
@@ -406,8 +432,7 @@ type result struct {
 // the computation is in fact executing asynchronously as a result.
 func (t *task) start(caller *Task, q *AnyQuery, sync bool, done func(*result)) (async bool) {
 	// Common case for cached values; no need to spawn a separate goroutine.
-	r := t.result.Load()
-	if r != nil && closed(r.done) {
+	if r := t.completed(); r != nil {
 		caller.logf("cache hit", "%[1]T/%[1]v", q.Underlying())
 		caller.timer.record(q.Key(), 0)
 		done(r)
@@ -428,10 +453,21 @@ func (t *task) start(caller *Task, q *AnyQuery, sync bool, done func(*result)) (
 
 // checkCycle checks for a potential cycle. This is only possible if output is
 // pending; if it isn't, it can't be in our history path.
+//
+// This searches the waiting graph rather than deps: deps edges are never
+// removed, so edges left over from a previously-diagnosed cycle would make
+// unrelated waiters appear to be part of a cycle.
 func (t *task) checkCycle(caller *Task, q *AnyQuery) error {
+	// edge records the task each node was reached from, and the query for
+	// that edge, which carries request information the memoized query lacks.
+	type edge struct {
+		from  *task
+		query *AnyQuery
+	}
+
 	deps := slicesx.NewQueue[*task](1)
 	deps.PushFront(t)
-	parent := make(map[*task]*task)
+	parent := make(map[*task]edge)
 	hasCycle := false
 
 	for node, ok := deps.PopFront(); ok; node, ok = deps.PopFront() {
@@ -439,10 +475,10 @@ func (t *task) checkCycle(caller *Task, q *AnyQuery) error {
 			hasCycle = true
 			break
 		}
-		node.deps.Range(func(depAny any, _ any) bool {
+		node.waiting.Range(func(depAny, queryAny any) bool {
 			dep := depAny.(*task) //nolint:errcheck
 			if _, ok := parent[dep]; !ok {
-				parent[dep] = node
+				parent[dep] = edge{from: node, query: queryAny.(*AnyQuery)} //nolint:errcheck
 				deps.PushBack(dep)
 			}
 			return true
@@ -453,46 +489,90 @@ func (t *task) checkCycle(caller *Task, q *AnyQuery) error {
 		return nil
 	}
 
-	// Reconstruct the cycle path from t.task back to target.
-	var cycle []*AnyQuery
-	cycle = append(cycle, caller.task.query)
-	for current := parent[caller.task]; current != nil && current != t; current = parent[current] {
-		cycle = append(cycle, current.query)
+	// Reconstruct the cycle from the edge queries along t -> ... -> caller.
+	// The edge into t is q, which begins and ends the cycle.
+	var reversed []*AnyQuery
+	for current := caller.task; current != nil && current != t; current = parent[current].from {
+		reversed = append(reversed, parent[current].query)
 	}
-	cycle = append(cycle, t.query)
+	slices.Reverse(reversed)
 
-	// Reverse to get the correct dependency order (target -> ... -> t.task).
-	slices.Reverse(cycle)
-
-	// Add q at the end to complete the cycle (target -> ... -> t.task -> targetQuery).
-	// We use q instead of t.query because it has the import request info.
+	cycle := make([]*AnyQuery, 0, len(reversed)+2)
+	cycle = append(cycle, q)
+	cycle = append(cycle, reversed...)
 	cycle = append(cycle, q)
 
 	return &ErrCycle{Cycle: cycle}
 }
 
-// run actually executes the query passed to start. It is called on its own
-// goroutine.
-func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
-	output = t.result.Load()
-	if output != nil {
-		if closed(output.done) {
-			return output
-		}
-		return t.waitUntilDone(caller, output, q, async)
-	}
-
-	// Try to become the leader (the task responsible for computing the result).
-	output = &result{done: make(chan struct{})}
-	if !t.result.CompareAndSwap(nil, output) {
-		// We failed to become the executor, so we're gonna go to sleep
-		// until it's done.
+// run either waits for or computes the result of the query passed to start,
+// retrying as necessary if attempts by other tasks' leaders fail.
+//
+// Returns nil if, and only if, the caller's context is cancelled.
+func (t *task) run(caller *Task, q *AnyQuery, async bool) *result {
+	for {
 		output := t.result.Load()
 		if output == nil {
-			return nil // Leader panicked but we did see a result.
+			// Try to become the leader (the task responsible for computing
+			// the result).
+			output = &result{done: make(chan struct{})}
+			if t.result.CompareAndSwap(nil, output) {
+				return t.lead(caller, q, async, output)
+			}
+			// Someone else became the leader; retry and wait on their result.
+			continue
 		}
-		return t.waitUntilDone(caller, output, q, async)
+
+		if closed(output.done) {
+			if r := t.completed(); r != nil {
+				return r
+			}
+			continue // This attempt was withdrawn, retry.
+		}
+
+		output = t.waitUntilDone(caller, output, q, async)
+		if output != nil {
+			return output
+		}
+		if context.Cause(caller.ctx) != nil {
+			return nil // Our own run is being torn down.
+		}
+		// The leader failed but our run is still live; retry.
 	}
+}
+
+// completed returns this task's completed result, or nil if the task never
+// started, is pending, or its last attempt was withdrawn.
+func (t *task) completed() *result {
+	r := t.result.Load()
+	if r == nil || !closed(r.done) {
+		return nil
+	}
+	// A withdrawn attempt is unpublished before done is closed, so a result
+	// still published after done was observed closed must have completed.
+	// Attempts are never republished, so there is no ABA hazard.
+	if t.result.Load() != r {
+		return nil
+	}
+	return r
+}
+
+// withdraw unpublishes a failed pending attempt and wakes its waiters, who
+// will retry rather than read it. Unpublishing before closing done is what
+// distinguishes a withdrawn attempt from a completed one. See
+// [task.completed].
+func (t *task) withdraw(r *result) {
+	t.result.CompareAndSwap(r, nil)
+	close(r.done)
+}
+
+// lead computes the result of a query as the leader of the pending attempt,
+// and records it by closing pending.done.
+//
+// Returns nil if, and only if, the caller's context is cancelled. The attempt
+// is then withdrawn rather than published.
+func (t *task) lead(caller *Task, q *AnyQuery, async bool, pending *result) (output *result) {
+	output = pending
 
 	callee := &Task{
 		ctx:    caller.ctx,
@@ -506,13 +586,22 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 		onRootGoroutine: caller.onRootGoroutine && !async,
 	}
 
+	// Discard leftovers from a withdrawn attempt so its diagnostics are not
+	// duplicated. Reports are only read from completed tasks, which are never
+	// re-executed, so this cannot race.
+	t.report = report.Report{Options: caller.exec.reportOptions}
+
 	defer func() {
 		if caller.aborted() == nil {
 			if panicked := recover(); panicked != nil {
 				caller.logf("panic", "%[1]T/%[1]v, %[2]v", q.Underlying(), panicked)
 
-				t.result.CompareAndSwap(output, nil)
-				output = nil
+				// output is nil if the attempt was already withdrawn and a
+				// deferred call panicked.
+				if output != nil {
+					t.withdraw(output)
+					output = nil
+				}
 
 				caller.cancel(&ErrPanic{
 					Query:     q,
@@ -522,10 +611,11 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 			}
 		} else {
 			// If this task is pending and we're the leader, do not allow it to
-			// stick around. This will cause future calls to the same failed
-			// query to hit the cache.
-			t.result.CompareAndSwap(output, nil)
-			output = nil
+			// stick around.
+			if output != nil {
+				t.withdraw(output)
+				output = nil
+			}
 
 			if !callee.onRootGoroutine {
 				// For Gs spawned by the executor, we just kill them here without
@@ -545,6 +635,8 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 	if async {
 		// If synchronous, this is executing under the hold of the caller query.
 		if !callee.acquire() {
+			// Cancelled while queued on the semaphore, withdraw it.
+			t.withdraw(output)
 			return nil
 		}
 		defer callee.release()
@@ -559,6 +651,14 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 	output.Value, output.Fatal = t.query.Execute(callee)
 	output.Elapsed = callee.stopwatch.Stop()
 	output.runID = callee.runID
+
+	if context.Cause(callee.ctx) != nil {
+		// The result may have been influenced by the cancellation, withdraw
+		// it rather than memoize it.
+		t.withdraw(output)
+		return nil
+	}
+
 	callee.timer.record(q.Key(), output.Elapsed)
 	callee.logf("returning", "%[1]T/%[1]v, took %v", q.Underlying(), output.Elapsed)
 
@@ -566,6 +666,9 @@ func (t *task) run(caller *Task, q *AnyQuery, async bool) (output *result) {
 }
 
 // waitUntilDone waits for this task to be completed by another goroutine.
+//
+// Returns nil if the caller's context was cancelled, or if the leader
+// withdrew the attempt, in which case the caller should retry.
 func (t *task) waitUntilDone(caller *Task, output *result, q *AnyQuery, async bool) *result {
 	if err := t.checkCycle(caller, q); err != nil {
 		// Return a new result rather than writing to the shared one, which the
@@ -600,16 +703,8 @@ func (t *task) waitUntilDone(caller *Task, output *result, q *AnyQuery, async bo
 		return nil
 	}
 
-	// Reload the result pointer. This is needed if the leader panics,
-	// because the result will be set to nil (and possibly replaced by a
-	// new leader).
-	output = t.result.Load()
-	if output == nil || !closed(output.done) {
-		// The leader panicked, or the caller's context was cancelled while
-		// the leader was still executing, so the result is not safe to read.
-		return nil
-	}
-	return output
+	// Reload the result, since the leader may have withdrawn the attempt.
+	return t.completed()
 }
 
 // underlying returns the tasks query underlying key.

--- a/experimental/incremental/task.go
+++ b/experimental/incremental/task.go
@@ -57,6 +57,9 @@ type Task struct {
 
 	timer *timer
 
+	// Counts goroutines spawned on behalf of this task's Run, so that Run
+	// does not return while any of them are still executing.
+	wg *sync.WaitGroup
 	// Set if we're currently holding the executor's semaphore. This exists to
 	// ensure that we do not violate concurrency assumptions, and is never
 	// itself mutated concurrently.
@@ -445,7 +448,9 @@ func (t *task) start(caller *Task, q *AnyQuery, sync bool, done func(*result)) (
 	}
 
 	// Complete the rest of the computation asynchronously.
+	caller.wg.Add(1)
 	go func() {
+		defer caller.wg.Done()
 		done(t.run(caller, q, true))
 	}()
 	return true
@@ -582,6 +587,7 @@ func (t *task) lead(caller *Task, q *AnyQuery, async bool, pending *result) (out
 		task:   t,
 		result: output,
 		timer:  caller.timer,
+		wg:     caller.wg,
 
 		onRootGoroutine: caller.onRootGoroutine && !async,
 	}

--- a/experimental/incremental/withdraw_test.go
+++ b/experimental/incremental/withdraw_test.go
@@ -1,0 +1,364 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package incremental_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bufbuild/protocompile/experimental/incremental"
+)
+
+func TestCancelDoesNotPoisonCache(t *testing.T) {
+	t.Parallel()
+
+	exec := incremental.New(incremental.WithParallelism(4))
+	query := FlakyOnce{
+		Started: make(chan struct{}),
+		Calls:   new(atomic.Int32),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	run1 := make(chan error)
+	go func() {
+		_, _, err := incremental.Run(ctx, exec, query)
+		run1 <- err
+	}()
+	<-query.Started
+	cancel()
+	require.ErrorIs(t, <-run1, context.Canceled)
+
+	// A fresh Run recomputes the query rather than hitting the cache.
+	results, _, err := incremental.Run(t.Context(), exec, query)
+	require.NoError(t, err)
+	require.NoError(t, results[0].Fatal)
+	assert.Equal(t, 42, results[0].Value)
+	assert.True(t, results[0].Changed)
+	assert.Equal(t, int32(2), query.Calls.Load())
+}
+
+func TestConcurrentRunSurvivesLeaderPanic(t *testing.T) {
+	t.Parallel()
+
+	exec := incremental.New(incremental.WithParallelism(4))
+	query := PanicOnce{
+		Started: make(chan struct{}),
+		Release: make(chan struct{}),
+		Calls:   new(atomic.Int32),
+	}
+
+	run1 := make(chan error)
+	go func() {
+		_, _, err := incremental.Run(t.Context(), exec, query)
+		run1 <- err
+	}()
+	<-query.Started
+
+	type run2Result struct {
+		value int
+		err   error
+	}
+	run2 := make(chan run2Result)
+	go func() {
+		results, _, err := incremental.Run(t.Context(), exec, query)
+		if err != nil {
+			run2 <- run2Result{err: err}
+			return
+		}
+		run2 <- run2Result{value: results[0].Value, err: results[0].Fatal}
+	}()
+
+	// Give the second Run time to become a waiter on the pending attempt,
+	// then let the leader panic.
+	time.Sleep(50 * time.Millisecond)
+	close(query.Release)
+
+	var panicked *incremental.ErrPanic
+	require.ErrorAs(t, <-run1, &panicked)
+
+	select {
+	case r := <-run2:
+		require.NoError(t, r.err)
+		assert.Equal(t, 42, r.value)
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent Run deadlocked after leader panicked")
+	}
+}
+
+func TestCancelledAcquireDoesNotWedgeTask(t *testing.T) {
+	t.Parallel()
+
+	// Parallelism 1 so that the second query's leader queues on the
+	// semaphore behind the first.
+	exec := incremental.New(incremental.WithParallelism(1))
+	gate := Gate{
+		Started: make(chan struct{}),
+		Release: make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	run1 := make(chan error)
+	go func() {
+		_, _, err := incremental.Run(ctx, exec, GatedPair{Gate: gate})
+		run1 <- err
+	}()
+
+	// The gate holds the only semaphore slot; cancelling now makes
+	// WedgeTarget's queued acquisition fail.
+	<-gate.Started
+	cancel()
+	close(gate.Release)
+	require.ErrorIs(t, <-run1, context.Canceled)
+
+	results, _, err := incremental.Run(t.Context(), exec, WedgeTarget{})
+	require.NoError(t, err)
+	require.NoError(t, results[0].Fatal)
+	assert.Equal(t, 7, results[0].Value)
+}
+
+func TestRetryDoesNotDuplicateDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	exec := incremental.New(incremental.WithParallelism(4))
+	query := FlakyOnce{
+		Started:  make(chan struct{}),
+		Calls:    new(atomic.Int32),
+		Diagnose: true,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	run1 := make(chan error)
+	go func() {
+		_, _, err := incremental.Run(ctx, exec, query)
+		run1 <- err
+	}()
+	<-query.Started
+	cancel()
+	require.ErrorIs(t, <-run1, context.Canceled)
+
+	_, report, err := incremental.Run(t.Context(), exec, query)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.Len(t, report.Diagnostics, 1)
+	assert.Equal(t, int32(2), query.Calls.Load())
+}
+
+func TestNoFalseCycleAfterResolvedCycleError(t *testing.T) {
+	t.Parallel()
+
+	shared := &falseCycleState{
+		detected: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+
+	exec := incremental.New(incremental.WithParallelism(4))
+	results, _, err := incremental.Run(t.Context(), exec, FalseCycleA{state: shared})
+	require.NoError(t, err)
+	require.NoError(t, results[0].Fatal)
+
+	// B saw a genuine cycle error for its request of A; C, an innocent
+	// bystander waiting on B, must not.
+	errB, _ := shared.cycleSeenByB.Load().(error)
+	var cycle *incremental.ErrCycle
+	require.ErrorAs(t, errB, &cycle)
+	errC, _ := shared.errSeenByC.Load().(error)
+	require.NoError(t, errC, "C must not observe a cycle error")
+	assert.Equal(t, 1, results[0].Value)
+}
+
+// FlakyOnce blocks until cancelled on its first execution, and succeeds on
+// subsequent ones. If Diagnose is set, it reports a diagnostic each time.
+type FlakyOnce struct {
+	Started  chan struct{}
+	Calls    *atomic.Int32
+	Diagnose bool
+}
+
+func (f FlakyOnce) Key() any {
+	return "flaky-once"
+}
+
+func (f FlakyOnce) Execute(t *incremental.Task) (int, error) {
+	if f.Diagnose {
+		t.Report().Errorf("flaky query executed")
+	}
+	if f.Calls.Add(1) == 1 {
+		close(f.Started)
+		<-t.Context().Done()
+		return 0, context.Cause(t.Context())
+	}
+	return 42, nil
+}
+
+// PanicOnce blocks until released and panics on its first execution, and
+// succeeds on subsequent ones.
+type PanicOnce struct {
+	Started chan struct{}
+	Release chan struct{}
+	Calls   *atomic.Int32
+}
+
+func (p PanicOnce) Key() any {
+	return "panic-once"
+}
+
+func (p PanicOnce) Execute(_ *incremental.Task) (int, error) {
+	if p.Calls.Add(1) == 1 {
+		close(p.Started)
+		<-p.Release
+		panic("boom")
+	}
+	return 42, nil
+}
+
+// Gate signals when it starts executing and then blocks until released.
+type Gate struct {
+	Started chan struct{}
+	Release chan struct{}
+}
+
+func (g Gate) Key() any {
+	return "gate"
+}
+
+func (g Gate) Execute(_ *incremental.Task) (int, error) {
+	close(g.Started)
+	<-g.Release
+	return 1, nil
+}
+
+// GatedPair resolves a Gate and a WedgeTarget together, so that the latter's
+// leader queues on the executor semaphore behind the former.
+type GatedPair struct {
+	Gate Gate
+}
+
+func (p GatedPair) Key() any {
+	return "gated-pair"
+}
+
+func (p GatedPair) Execute(t *incremental.Task) (int, error) {
+	_, err := incremental.Resolve(t, p.Gate, WedgeTarget{})
+	return 0, err
+}
+
+// WedgeTarget is a trivial query used to check that a key does not become
+// permanently pending.
+type WedgeTarget struct{}
+
+func (WedgeTarget) Key() any {
+	return "wedge-target"
+}
+
+func (WedgeTarget) Execute(_ *incremental.Task) (int, error) {
+	return 7, nil
+}
+
+// falseCycleState orchestrates TestNoFalseCycleAfterResolvedCycleError:
+// A resolves B and C together; B resolves A and receives a genuine cycle
+// error; C then resolves B, which is still pending. Following B's stale
+// B -> A edge would fabricate the cycle C -> B -> A -> C.
+type falseCycleState struct {
+	detected     chan struct{}
+	release      chan struct{}
+	releaseOnce  sync.Once
+	cycleSeenByB atomic.Value // error
+	errSeenByC   atomic.Value // error
+}
+
+// releaseB unblocks FalseCycleB, at most once.
+func (s *falseCycleState) releaseB() {
+	s.releaseOnce.Do(func() { close(s.release) })
+}
+
+// FalseCycleA resolves both FalseCycleB and FalseCycleC.
+type FalseCycleA struct {
+	state *falseCycleState
+}
+
+func (a FalseCycleA) Key() any {
+	return "false-cycle-a"
+}
+
+func (a FalseCycleA) Execute(t *incremental.Task) (int, error) {
+	results, err := incremental.Resolve(t,
+		FalseCycleB(a),
+		FalseCycleC(a),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return results[1].Value, results[1].Fatal
+}
+
+// FalseCycleB requests FalseCycleA, expecting a cycle error, and then blocks
+// until released.
+type FalseCycleB struct {
+	state *falseCycleState
+}
+
+func (b FalseCycleB) Key() any {
+	return "false-cycle-b"
+}
+
+func (b FalseCycleB) Execute(t *incremental.Task) (int, error) {
+	results, err := incremental.Resolve(t, FalseCycleA(b))
+	if err != nil {
+		return 0, err
+	}
+	if fatal := results[0].Fatal; fatal != nil {
+		b.state.cycleSeenByB.Store(fatal)
+	}
+	close(b.state.detected)
+	<-b.state.release
+	return 1, nil
+}
+
+// FalseCycleC waits for FalseCycleB to have observed its cycle error and then
+// requests it, which must not produce a cycle error.
+type FalseCycleC struct {
+	state *falseCycleState
+}
+
+func (c FalseCycleC) Key() any {
+	return "false-cycle-c"
+}
+
+func (c FalseCycleC) Execute(t *incremental.Task) (int, error) {
+	<-c.state.detected
+
+	// Release B only once we are (very likely) already waiting on it, and
+	// again after Resolve returns so that a spurious cycle error fails the
+	// test instead of deadlocking it.
+	timer := time.AfterFunc(50*time.Millisecond, c.state.releaseB)
+	defer timer.Stop()
+	defer c.state.releaseB()
+
+	results, err := incremental.Resolve(t, FalseCycleB(c))
+	if err != nil {
+		return 0, err
+	}
+	if fatal := results[0].Fatal; fatal != nil {
+		c.state.errSeenByC.Store(fatal)
+		return 0, fatal
+	}
+	return results[0].Value, nil
+}

--- a/experimental/ir/lower_imports.go
+++ b/experimental/ir/lower_imports.go
@@ -34,8 +34,9 @@ const DescriptorProtoPath = "google/protobuf/descriptor.proto"
 // Importer is a callback to resolve the imports of an [ast.File] being
 // lowered.
 //
-// If a cycle is encountered, should return an *[incremental.ErrCycle],
-// starting from decl and ending when the currently lowered file is imported.
+// If a cycle is encountered, should return an *[ErrCycle] containing the
+// chain of import declarations forming the cycle, beginning and ending with
+// decl itself.
 //
 // [Session.Lower] may not call this function on all imports; only those for
 // which it needs the caller to resolve a [File] for it.
@@ -141,18 +142,25 @@ func buildImports(file *File, r *report.Report, importer Importer) {
 }
 
 // diagnoseCycle generates a diagnostic for an import cycle, showing each
-// import contributing to the cycle in turn.
+// import contributing to the cycle in turn. The chain begins and ends at the
+// same import, making the loop explicit.
 func diagnoseCycle(r *report.Report, cycle *ErrCycle) {
 	path := cycle.Cycle[0].ImportPath().AsLiteral().AsString().Text()
 	err := r.Errorf("detected cyclic import while importing %q", path)
 
-	for i, imp := range cycle.Cycle {
+	decls := cycle.Cycle
+	if len(decls) == 2 && decls[0] == decls[1] {
+		// A file that imports itself; the whole loop is a single import.
+		decls = decls[:1]
+	}
+
+	for i, imp := range decls {
 		var message string
 		if path := imp.ImportPath().AsLiteral().AsString(); !path.IsZero() {
 			switch i {
 			case 0:
 				message = "imported here"
-			case len(cycle.Cycle) - 1:
+			case len(decls) - 1:
 				message = fmt.Sprintf("...which imports %q, completing the cycle", path.Text())
 			default:
 				message = fmt.Sprintf("...which imports %q...", path.Text())

--- a/experimental/ir/testdata/imports/cycle.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/cycle.proto.yaml.stderr.txt
@@ -1,8 +1,13 @@
-error: detected cyclic import while importing "b.proto"
-  --> a.proto:4:1
+error: detected cyclic import while importing "a.proto"
+  --> c.proto:4:1
+   |
+ 4 | import "a.proto";
+   | ^^^^^^^^^^^^^^^^^ imported here
+   |
+  ::: a.proto:4:1
    |
  4 | import "b.proto";
-   | ^^^^^^^^^^^^^^^^^ imported here
+   | ----------------- ...which imports "b.proto"...
    |
   ::: b.proto:4:1
    |

--- a/experimental/ir/testdata/imports/cycle_dependency.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/cycle_dependency.proto.yaml.stderr.txt
@@ -1,12 +1,12 @@
 error: detected cyclic import while importing "foo/v1/bar.proto"
-  --> foo/v1/foo.proto:4:1
+  --> foo/v2/foo.proto:4:1
    |
  4 | import "foo/v1/bar.proto";
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ imported here
    |
-  ::: foo/v1/foo.proto:5:1
+  ::: foo/v1/bar.proto:4:1
    |
- 5 | import "foo/v2/foo.proto";
+ 4 | import "foo/v2/foo.proto";
    | -------------------------- ...which imports "foo/v2/foo.proto"...
    |
   ::: foo/v2/foo.proto:4:1

--- a/experimental/ir/testdata/imports/cycle_long.proto.yaml.stderr.txt
+++ b/experimental/ir/testdata/imports/cycle_long.proto.yaml.stderr.txt
@@ -1,5 +1,5 @@
 error: detected cyclic import while importing "b1.proto"
-  --> a1.proto:4:1
+  --> d2.proto:4:1
    |
  4 | import "b1.proto";
    | ^^^^^^^^^^^^^^^^^^ imported here
@@ -14,9 +14,9 @@ error: detected cyclic import while importing "b1.proto"
  4 | import "d1.proto";
    | ------------------ ...which imports "d1.proto"...
    |
-  ::: a1.proto:5:1
+  ::: d1.proto:4:1
    |
- 5 | import "b2.proto";
+ 4 | import "b2.proto";
    | ------------------ ...which imports "b2.proto"...
    |
   ::: b2.proto:4:1


### PR DESCRIPTION
This fixes a race found with repeated cancellations in the LSP from testing. Auditing the surround found a couple of issues around pending tasks:

- Results computed under a cancelled context were cached permanently
- A panicking leader only cancelled its own Run, blocking concurrent Runs
- A leader cancelled while queued on the semaphore left its key pending, blocking concurrent Runs
- Diagnostics from a failed attempt were reported again on retry.

The fix marks results as *completed* (done, closed) and *withdrawn* (unpublished, closed).  Withdrawal wakes waiters, which retry and elect a leader.

Cycle detection now walks the waiters list, instead of the deps graph. This avoids misclassification from a concurrent Run where a previous one was a cycle. Edges carry the requesting query, so cycle errors correctly identify the trail.

Also: `WithTimings` was never populated (recorded nothing); `Run`'s diagnostic collection skips uncompleted tasks; `FDS` no longer mutates the memoized `Link` slice; `transferFrom` tolerates holds lost to cancellation; the reentrant-Run guard no longer mutates a shared slice.