### PR TITLE
Fix formatter trailing comment handling

### DIFF
--- a/experimental/ast/printer/decl.go
+++ b/experimental/ast/printer/decl.go
@@ -255,38 +255,35 @@ func (p *printer) printSignature(sig ast.Signature) {
 		return
 	}
 
-	inputs := sig.Inputs()
-	if !inputs.Brackets().IsZero() {
-		p.withGroup(func(p *printer) {
-			openTok, closeTok := inputs.Brackets().StartEnd()
-			slots := p.trivia.scopeTrivia(inputs.Brackets().ID())
-			p.printToken(openTok, gapPreserve)
-			p.withIndent(func(indented *printer) {
-				indented.push(tagSoftbreak)
-				indented.printTypeListContents(inputs, slots)
-				p.push(tagSoftbreak)
-			})
-			p.printToken(closeTok, gapPreserve)
-		})
+	if !sig.Inputs().Brackets().IsZero() {
+		p.printSignatureList(sig.Inputs(), gapPreserve)
 	}
 
 	if !sig.Returns().IsZero() {
 		p.printToken(sig.Returns(), gapSpace)
-		outputs := sig.Outputs()
-		if !outputs.Brackets().IsZero() {
-			p.withGroup(func(p *printer) {
-				openTok, closeTok := outputs.Brackets().StartEnd()
-				slots := p.trivia.scopeTrivia(outputs.Brackets().ID())
-				p.printToken(openTok, gapSpace)
-				p.withIndent(func(indented *printer) {
-					indented.push(tagSoftbreak)
-					indented.printTypeListContents(outputs, slots)
-					p.push(tagSoftbreak)
-				})
-				p.printToken(closeTok, gapPreserve)
-			})
+		if !sig.Outputs().Brackets().IsZero() {
+			p.printSignatureList(sig.Outputs(), gapSpace)
 		}
 	}
+}
+
+// printSignatureList prints one bracketed type list of a signature.
+// Bracket trivia stays outside the group so a comment's forced
+// newline cannot break it.
+func (p *printer) printSignatureList(list ast.TypeList, openGap gapStyle) {
+	openTok, closeTok := list.Brackets().StartEnd()
+	slots := p.trivia.scopeTrivia(list.Brackets().ID())
+	p.printToken(openTok, openGap)
+	var closeTrailing []token.Token
+	p.withGroup(func(p *printer) {
+		p.withIndent(func(indented *printer) {
+			indented.push(tagSoftbreak)
+			indented.printTypeListContents(list, slots)
+			p.push(tagSoftbreak)
+		})
+		closeTrailing = p.printTokenSplitTrailing(closeTok, gapPreserve)
+	})
+	p.emitTrailing(closeTrailing)
 }
 
 func (p *printer) printTypeListContents(list ast.TypeList, trivia detachedTrivia) {
@@ -369,6 +366,17 @@ func (p *printer) printBody(body ast.DeclBody) {
 	})
 
 	p.emitCloseTok(closeTok, closeTok.Text(), closeComments, closeAtt)
+}
+
+// emitCloseTrivia emits a close bracket's leading comments or any
+// pending slot comments inside the indent.
+func (p *printer) emitCloseTrivia(closeComments []token.Token, blankBeforeClose bool) {
+	switch {
+	case len(closeComments) > 0:
+		p.emitCloseComments(closeComments, blankBeforeClose)
+	case p.pendingHasComments():
+		p.flushSlotComments()
+	}
 }
 
 // emitCloseComments emits close-brace leading comments inside an
@@ -475,9 +483,21 @@ func (p *printer) printCompactOptions(co ast.CompactOptions) {
 		// rest of the line, and block comments produce softline gaps that break
 		// outside the indent wrapper.
 		forceExpand := len(openTrailing) > 0 ||
-			triviaHasComments(slots) ||
-			p.scopeHasUninlineableLeadingComments(brackets) ||
 			p.firstOptionKeyHasLeadingComment(entries)
+		// Under trailing rewrite, mid entry and final slot comments
+		// render inline and must not force expansion. Slots before an
+		// entry still expand.
+		if p.options.Formatting.RewriteTrailingLineCommentsToBlock {
+			for i := 0; i < len(slots.slots) && i < entries.Len(); i++ {
+				if sliceHasComment(slots.slots[i]) {
+					forceExpand = true
+					break
+				}
+			}
+		} else if triviaHasComments(slots) ||
+			p.scopeHasUninlineableLeadingComments(brackets) {
+			forceExpand = true
+		}
 		// Layout fallback: when trailing `//` rewrite is disabled, a `//`
 		// inside an inline `[...]` would consume the closing bracket.
 		// Force broken so the comment terminates safely on its own line.
@@ -518,8 +538,11 @@ func (p *printer) printCompactOptions(co ast.CompactOptions) {
 					valueRestore()
 				}
 				p.emitTriviaSlot(slots, 1)
-				p.emitTrivia(gapNone)
+				// gapInline renders a final slot comment inline
+				// after the value, as a reparse would.
+				p.emitTrivia(gapInline)
 			}
+			// Same for the close bracket.
 			if p.options.Formatting.LiteralLayout == LayoutDynamic {
 				p.printToken(openTok, gapSpace)
 				p.withGroup(func(p *printer) {
@@ -529,11 +552,11 @@ func (p *printer) printCompactOptions(co ast.CompactOptions) {
 					})
 					p.push(tagSoftbreak)
 				})
-				p.printToken(closeTok, gapNone)
+				p.printToken(closeTok, gapInline)
 			} else {
 				p.printToken(openTok, gapSpace)
 				emitEntry(p)
-				p.printToken(closeTok, gapNone)
+				p.printToken(closeTok, gapInline)
 			}
 			singleRestore()
 
@@ -609,9 +632,7 @@ func (p *printer) printCompactOptions(co ast.CompactOptions) {
 					}
 				}
 				indented.emitTriviaSlot(slots, entries.Len())
-				if len(closeComments) > 0 {
-					indented.emitCloseComments(closeComments, slots.blankBeforeClose)
-				}
+				indented.emitCloseTrivia(closeComments, slots.blankBeforeClose)
 			})
 			p.emitTrivia(gapNone)
 			p.emitCloseTok(closeTok, closeTok.Text(), closeComments, closeAtt)

--- a/experimental/ast/printer/expr.go
+++ b/experimental/ast/printer/expr.go
@@ -306,9 +306,7 @@ func (p *printer) printArray(expr ast.ExprArray, gap gapStyle) {
 			restore()
 		}
 		indented.emitTriviaSlot(slots, elements.Len())
-		if len(closeComments) > 0 {
-			indented.emitCloseComments(closeComments, slots.blankBeforeClose)
-		}
+		indented.emitCloseTrivia(closeComments, slots.blankBeforeClose)
 	})
 
 	// Always emit `]` on its own line in broken layout, even when
@@ -474,12 +472,12 @@ func (p *printer) printDict(expr ast.ExprDict, gap gapStyle) {
 				fieldRestore = indented.ctx.with(lineToBlock(true))
 			}
 			indented.printExprField(field, fieldGap)
-			// Trailing on the comma should stay inline (the legacy
-			// formatter only puts trailing-on-VALUE block comments
-			// on their own line, not trailing-on-comma).
-			commaMods := []modifier{trailingBlockOnNewLine(false)}
+			// The elided comma's trailing comment reparses as
+			// trailing on the value, so emit it under the value's
+			// policy.
+			var commaMods []modifier
 			if rewriteFieldTrailing {
-				commaMods = append(commaMods, lineToBlock(true))
+				commaMods = append(commaMods, lineToBlock(true), trailingBlockOnNewLine(false))
 			}
 			restore := indented.ctx.with(commaMods...)
 			indented.emitCommaTrivia(elements.Comma(i))
@@ -487,8 +485,13 @@ func (p *printer) printDict(expr ast.ExprDict, gap gapStyle) {
 			fieldRestore()
 		}
 		indented.emitTriviaSlot(trivia, elements.Len())
-		if len(closeComments) > 0 {
+		switch {
+		case len(closeComments) > 0:
 			indented.emitCloseComments(closeComments, trivia.blankBeforeClose)
+		case indented.pendingHasComments():
+			// No blank preserved. With commas elided a reparse cannot
+			// reslot a blank detached comment to the right element.
+			indented.emitTrivia(gapNewline)
 		}
 	})
 
@@ -532,20 +535,19 @@ func (p *printer) printExprField(expr ast.ExprField, gap gapStyle) {
 		first = false
 	}
 	if !expr.Colon().IsZero() {
-		// gapInline ensures comments between the key and colon get a
-		// space before them but the colon follows immediately after the
-		// last comment with no gap. This prevents an idempotency issue
-		// where trivia between ] and : gets assigned differently on
-		// reparse (leading vs trailing) depending on line breaks.
-		//
-		// Exception: when the colon's leading trivia ends in an inline
-		// block comment (e.g. extension key `[ ... ] /* Three */ :`),
-		// gapInline would emit `*/:` glued. Switch to gapSpace so the
-		// `:` follows a separating space.
+		// A comment rendering as `*/` before the colon needs a
+		// separating space, whether attached to the colon or the key.
 		colonGap := gapInline
-		if att, ok := p.trivia.tokenTrivia(expr.Colon().ID()); ok {
-			if pendingEndsWithInlineBlockComment(att.leading) {
+		if p.options.Format {
+			if att, ok := p.trivia.tokenTrivia(expr.Colon().ID()); ok &&
+				p.endsWithInlineBlockComment(att.leading) {
 				colonGap = gapSpace
+			}
+			if keyTok := exprLastToken(expr.Key()); !keyTok.IsZero() {
+				if att, ok := p.trivia.tokenTrivia(keyTok.ID()); ok &&
+					p.endsWithInlineBlockComment(att.trailing) {
+					colonGap = gapSpace
+				}
 			}
 		}
 		p.printToken(expr.Colon(), colonGap)

--- a/experimental/ast/printer/options.go
+++ b/experimental/ast/printer/options.go
@@ -99,10 +99,11 @@ type Formatting struct {
 	//
 	// When true, trailing `//` comments in those tight contexts are
 	// rewritten as `/* ... */` (with `*/` in the body escaped to
-	// `* /` to keep the synthesized block comment sound). Trailing
+	// `* /` to keep the synthesized block comment sound), as are
+	// leading `//` comments that render inline after code. Trailing
 	// `//` comments in safe positions (where the next token is on a
 	// new line) are left as `//`. Matches the legacy formatter's
-	// behavior; modifies user comment text as a side effect.
+	// behavior and modifies user comment text as a side effect.
 	//
 	// When false, trailing `//` comments are emitted verbatim. If
 	// the layout would otherwise render a scope flat such that a `//`
@@ -116,13 +117,14 @@ type Formatting struct {
 	// multi-line `/* ... */` comments to a canonical form.
 	//
 	// When true, the prefix-style normalization algorithm runs on
-	// every multi-line block comment: if every non-empty interior
-	// line begins with the same non-alphanumeric character (e.g.
-	// `*`), strip per-line whitespace and re-emit with one space
-	// before the prefix character; otherwise unindent by the minimum
-	// shared indent and re-indent every line with three spaces.
-	// Matches the legacy formatter's behavior; modifies user comment
-	// text as a side effect.
+	// every multi-line block comment: if the first interior line
+	// begins with a non-alphanumeric character (e.g. `*`) and every
+	// later line begins with the same character, strip per-line
+	// whitespace and re-emit with one space before the prefix
+	// character. Otherwise unindent by the minimum shared indent and
+	// re-indent with three spaces, preserving relative indentation.
+	// Matches the legacy formatter's behavior and modifies user
+	// comment text as a side effect.
 	//
 	// When false, multi-line block comments are emitted with their
 	// interior whitespace preserved verbatim from source.

--- a/experimental/ast/printer/path.go
+++ b/experimental/ast/printer/path.go
@@ -33,6 +33,47 @@ func pathFirstToken(path ast.Path) token.Token {
 	return pc.Name()
 }
 
+// fusedEnd returns tok's close token when tok is fused, otherwise tok.
+func fusedEnd(tok token.Token) token.Token {
+	if !tok.IsZero() && !tok.IsLeaf() {
+		_, tok = tok.StartEnd()
+	}
+	return tok
+}
+
+// pathLastToken returns the token that carries the path's trailing
+// trivia. For a fused extension component this is its close paren.
+func pathLastToken(path ast.Path) token.Token {
+	last := token.Zero
+	for pc := range path.Components() {
+		if !pc.Name().IsZero() {
+			last = pc.Name()
+		} else if !pc.Separator().IsZero() {
+			last = pc.Separator()
+		}
+	}
+	return fusedEnd(last)
+}
+
+// exprLastToken returns the token that carries the expression's
+// trailing trivia, or the zero token for kinds where it is not needed.
+func exprLastToken(expr ast.ExprAny) token.Token {
+	switch expr.Kind() {
+	case ast.ExprKindPath:
+		return pathLastToken(expr.AsPath().Path)
+	case ast.ExprKindLiteral:
+		return fusedEnd(expr.AsLiteral().Token)
+	case ast.ExprKindPrefixed:
+		return exprLastToken(expr.AsPrefixed().Expr())
+	case ast.ExprKindArray:
+		return fusedEnd(expr.AsArray().Brackets())
+	case ast.ExprKindDict:
+		return fusedEnd(expr.AsDict().Braces())
+	default:
+		return token.Zero
+	}
+}
+
 // printPath prints a path (e.g., "foo.bar.baz" or "(custom.option)") with a leading gap.
 func (p *printer) printPath(path ast.Path, gap gapStyle) {
 	if path.IsZero() {
@@ -88,7 +129,10 @@ func (p *printer) printPath(path ast.Path, gap gapStyle) {
 				openTok, closeTok := parens.StartEnd()
 				trivia := p.trivia.scopeTrivia(parens.ID())
 
-				p.printToken(openTok, componentGap)
+				// Reroute trailing comments on `(` through the
+				// interior's leading trivia path, matching a reparse.
+				openTrailing := p.printTokenSplitTrailing(openTok, componentGap)
+				p.appendPending(openTrailing)
 				p.emitTriviaSlot(trivia, 0)
 				p.printPath(extn, gapPreserveTight)
 				p.emitTriviaSlot(trivia, 1)

--- a/experimental/ast/printer/printer.go
+++ b/experimental/ast/printer/printer.go
@@ -231,6 +231,21 @@ func (p *printer) pendingHasComments() bool {
 	return sliceHasComment(p.pending)
 }
 
+// flushSlotComments flushes pending slot comments, each on its own
+// line, preserving a blank line before the first comment.
+func (p *printer) flushSlotComments() {
+	newlines := 0
+	for _, tok := range p.pending {
+		if tok.Kind() == token.Comment {
+			break
+		}
+		if tok.Kind() == token.Space {
+			newlines += strings.Count(tok.Text(), "\n")
+		}
+	}
+	p.emitTrivia(commentGap(gapNewline, false, newlines))
+}
+
 // printToken emits a token with its trivia.
 func (p *printer) printToken(tok token.Token, gap gapStyle) {
 	if tok.IsZero() {
@@ -290,26 +305,10 @@ func (p *printer) emitTrailing(trailing []token.Token) {
 				}
 				switch {
 				case rewriteToBlock && p.ctx.lineToBlock && isLine:
-					// Convert // comment to /* comment */ for inline contexts.
-					body := strings.TrimPrefix(strings.TrimRight(t.Text(), " \t"), "//")
-					// Escape any `*/` in the body to `* /` so it
-					// cannot prematurely terminate the synthesized
-					// block comment. This is a correctness divergence
-					// from the legacy formatter, which skips the
-					// escape and produces invalid output for bodies
-					// containing `*/` (e.g. `// foo */ bar` becomes
-					// `/* foo */ bar */`, parsed as a comment plus
-					// leaked text `bar */`). Exercised by
-					// TestFormat/compact_options.proto, with_terminator.
-					body = strings.ReplaceAll(body, "*/", "* /")
-					p.push(dom.Text("/*" + body + " */"))
-				case !rewriteToBlock && p.ctx.lineToBlock && isLine:
-					// Verbatim emission inside a context where inline
-					// content (e.g. `;`, `]`, `.next`) follows. The
-					// `//` would consume that content, so push a
-					// newline after the comment to force a layout
-					// break. dom merges this with any adjacent newline
-					// from the surrounding broken layout.
+					p.push(dom.Text(lineCommentToBlock(t.Text())))
+				case isLine:
+					// A `//` comment consumes the rest of its line, so
+					// force a newline. dom merges adjacent whitespace.
 					p.emitComment(t)
 					p.push(tagNewline)
 				default:
@@ -320,6 +319,37 @@ func (p *printer) emitTrailing(trailing []token.Token) {
 	} else {
 		p.pending = append(p.pending, trailing...)
 	}
+}
+
+// lineCommentToBlock rewrites a `// ...` line comment as `/* ... */`,
+// escaping `*/` in the body so it cannot terminate the comment early.
+func lineCommentToBlock(text string) string {
+	body := strings.TrimPrefix(strings.TrimRight(text, " \t"), "//")
+	body = strings.ReplaceAll(body, "*/", "* /")
+	return "/*" + body + " */"
+}
+
+// printTokenSplitTrailing prints tok without its trailing comments,
+// returning them for the caller to emit at a safer boundary.
+func (p *printer) printTokenSplitTrailing(tok token.Token, gap gapStyle) []token.Token {
+	trailing := p.extractOpenTrailing(tok)
+	if !p.options.Format || len(trailing) == 0 {
+		p.printToken(tok, gap)
+		return nil
+	}
+	if att, ok := p.trivia.tokenTrivia(tok.ID()); ok {
+		p.appendPending(att.leading)
+	}
+	p.emitTrivia(gap)
+	p.push(dom.Text(tok.Text()))
+	return trailing
+}
+
+// endsWithInlineBlockComment reports whether the last comment in
+// tokens will render ending in `*/` on the current line.
+func (p *printer) endsWithInlineBlockComment(tokens []token.Token) bool {
+	return sliceHasComment(tokens) &&
+		(!lastCommentIsLine(tokens) || p.options.Formatting.RewriteTrailingLineCommentsToBlock)
 }
 
 // emitCommaTrivia emits trailing trivia from a comma token that is not
@@ -600,6 +630,12 @@ func (p *printer) emitTrivia(gap gapStyle) {
 		return base
 	}
 
+	// inlineAfterCode gaps place comments on the current line after
+	// emitted code. Such comments reparse as trailing, so emission
+	// must match [printer.emitTrailing] or passes never stabilize.
+	inlineAfterCode := gap == gapSpace || gap == gapInline ||
+		gap == gapPreserve || gap == gapPreserveTight
+
 	hasComment := false
 	prevIsLine := false
 	newlineRun := 0
@@ -633,8 +669,11 @@ func (p *printer) emitTrivia(gap gapStyle) {
 			continue
 		}
 
-		fg := inheritGap(firstGap, hasNonNewlineSpace)
-		ag := inheritGap(afterGap, hasNonNewlineSpace)
+		// A newline counts as whitespace so an inlined comment keeps
+		// the space the trailing path would emit.
+		hadSpace := hasNonNewlineSpace || newlineRun > 0
+		fg := inheritGap(firstGap, hadSpace)
+		ag := inheritGap(afterGap, hadSpace)
 
 		// Suppress the inherited space before the first comment when
 		// gapPreserveTight is used (right after an open bracket).
@@ -642,16 +681,40 @@ func (p *printer) emitTrivia(gap gapStyle) {
 			fg = firstGap
 		}
 
+		isLine := strings.HasPrefix(tok.Text(), "//")
+
+		// Match the trailing path's space. gapPreserveTight stays
+		// tight against the open bracket.
+		forceSpace := isLine && inlineAfterCode && gap != gapPreserveTight
+		if forceSpace && !hasComment && fg != gapSpace {
+			fg = gapSpace
+		}
+
+		// Blank runs around inline comments collapse.
+		gapRun := newlineRun
+		if inlineAfterCode {
+			gapRun = 0
+		}
+
 		if !hasComment {
 			p.emitGap(fg)
 		} else {
-			p.emitGap(commentGap(ag, prevIsLine, newlineRun))
+			g := commentGap(ag, prevIsLine, gapRun)
+			if forceSpace && g == gapNone {
+				g = gapSpace
+			}
+			p.emitGap(g)
 		}
 
 		hasNonNewlineSpace = false
 		newlineRun = 0
-		isLine := strings.HasPrefix(tok.Text(), "//")
-		p.emitComment(tok)
+		// Rewrite as the trailing path would.
+		if isLine && inlineAfterCode && p.options.Formatting.RewriteTrailingLineCommentsToBlock {
+			p.push(dom.Text(lineCommentToBlock(tok.Text())))
+			isLine = false
+		} else {
+			p.emitComment(tok)
+		}
 		hasComment = true
 		prevIsLine = isLine
 	}
@@ -687,7 +750,12 @@ func (p *printer) emitTrivia(gap gapStyle) {
 		// the next token, preserve that newline — otherwise the
 		// inheritGap promotion to gapSpace would inline content the
 		// user wrote on separate lines.
-		finalGap := commentGap(inheritGap(afterGap, hasNonNewlineSpace), prevIsLine, newlineRun)
+		// Blank runs after inline comments collapse.
+		finalRun := newlineRun
+		if inlineAfterCode {
+			finalRun = 0
+		}
+		finalGap := commentGap(inheritGap(afterGap, hasNonNewlineSpace), prevIsLine, finalRun)
 		if gap == gapNewline && !prevIsLine && newlineRun >= 1 && finalGap == gapSpace {
 			finalGap = gapNewline
 		}
@@ -925,13 +993,13 @@ func (p *printer) emitComment(tok token.Token) {
 // rather than rewritten to a canonical prefix or plain style.
 //
 // The normalization algorithm matches the legacy formatter's behavior:
-//   - Detect if all non-empty interior lines share a common non-alphanumeric
-//     prefix character (e.g., *, =). If so, strip all whitespace and re-add
-//     " " before each line (prefix style). If the prefix is *, the closing
-//     line becomes " */".
+//   - Detect if the first interior line starts with a non-alphanumeric
+//     prefix character (e.g., *, =) that every later line shares. If so,
+//     strip all whitespace and re-add " " before each line (prefix
+//     style). If the prefix is *, the closing line becomes " */".
 //   - Otherwise (plain style), compute the minimum visual indentation of
 //     non-empty interior lines, unindent by that amount, then add "   "
-//     (3 spaces) before each line.
+//     (3 spaces) before each line, preserving relative indentation.
 func (p *printer) emitBlockComment(text string) {
 	lines := strings.Split(text, "\n")
 	if len(lines) <= 1 {
@@ -975,31 +1043,31 @@ func (p *printer) emitBlockComment(text string) {
 	lastTrimmed := strings.TrimLeft(lines[len(lines)-1], " \t")
 	standaloneClose := strings.HasPrefix(lastTrimmed, "*/") && strings.TrimRight(lastTrimmed, " \t") == "*/"
 
-	// Compute minimum indent and detect prefix character across all
-	// lines after the first (interior + closing).
+	// The first interior line seeds the prefix and any mismatching
+	// later line clears it for good, matching the legacy formatter.
 	minIndent := -1
 	var prefix byte
-	prefixSet := false
+	seeded := false
 	for i := 1; i < len(lines); i++ {
 		trimmed := strings.TrimLeft(lines[i], " \t")
-		if trimmed == "" || trimmed == "*/" {
+		if trimmed == "*/" {
 			continue
 		}
-
-		indent := computeVisualIndent(lines[i])
-		if minIndent < 0 || indent < minIndent {
-			minIndent = indent
+		if trimmed != "" {
+			indent := computeVisualIndent(lines[i])
+			if minIndent < 0 || indent < minIndent {
+				minIndent = indent
+			}
 		}
 
-		ch := trimmed[0]
-		if isCommentPrefix(ch) {
-			if !prefixSet {
-				prefix = ch
-				prefixSet = true
-			} else if ch != prefix {
-				prefix = 0
-			}
-		} else {
+		var ch byte
+		if trimmed != "" && isCommentPrefix(trimmed[0]) {
+			ch = trimmed[0]
+		}
+		if !seeded {
+			prefix = ch
+			seeded = true
+		} else if ch != prefix {
 			prefix = 0
 		}
 	}

--- a/experimental/ast/printer/testdata/format/block_comment_interior_indent.proto
+++ b/experimental/ast/printer/testdata/format/block_comment_interior_indent.proto
@@ -1,0 +1,19 @@
+// Relative interior indentation of block comments must be preserved.
+syntax = "proto3";
+
+service ExampleService {
+  /**
+     Reverse lookup a user from an identifier.
+
+     - OK - response contains the resolved user id
+     - NOT_FOUND - identifier was not found
+     - INVALID_ARGUMENT - invalid identifier type
+                        - missing identifier
+                        - provided identifier is already USER_ID
+  */
+  rpc GetUserId(GetUserIdRequest) returns (GetUserIdResponse);
+}
+
+message GetUserIdRequest {}
+
+message GetUserIdResponse {}

--- a/experimental/ast/printer/testdata/format/block_comment_interior_indent.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/block_comment_interior_indent.proto.default.txt
@@ -1,0 +1,18 @@
+// Relative interior indentation of block comments must be preserved.
+syntax = "proto3";
+
+service ExampleService {
+  /**
+     Reverse lookup a user from an identifier.
+     - OK - response contains the resolved user id
+     - NOT_FOUND - identifier was not found
+     - INVALID_ARGUMENT - invalid identifier type
+                        - missing identifier
+                        - provided identifier is already USER_ID
+  */
+  rpc GetUserId(GetUserIdRequest) returns (GetUserIdResponse);
+}
+
+message GetUserIdRequest {}
+
+message GetUserIdResponse {}

--- a/experimental/ast/printer/testdata/format/block_comment_interior_indent.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/block_comment_interior_indent.proto.legacy.txt
@@ -1,0 +1,19 @@
+// Relative interior indentation of block comments must be preserved.
+syntax = "proto3";
+
+service ExampleService {
+  /**
+     Reverse lookup a user from an identifier.
+
+     - OK - response contains the resolved user id
+     - NOT_FOUND - identifier was not found
+     - INVALID_ARGUMENT - invalid identifier type
+                        - missing identifier
+                        - provided identifier is already USER_ID
+  */
+  rpc GetUserId(GetUserIdRequest) returns (GetUserIdResponse);
+}
+
+message GetUserIdRequest {}
+
+message GetUserIdResponse {}

--- a/experimental/ast/printer/testdata/format/comment_stability.proto
+++ b/experimental/ast/printer/testdata/format/comment_stability.proto
@@ -1,0 +1,104 @@
+// Comment placements that historically corrupted formatter output or
+// oscillated between format passes.
+syntax = "proto3"
+// before the syntax semicolon
+;
+
+import "google/protobuf/descriptor.proto";
+
+option java_package
+// between path and equals
+= "com.foo";
+
+option (
+// trailing on extension open paren
+file_conf) = "x";
+
+extend google
+// mid path
+.protobuf.FileOptions {
+  string file_conf = 50000;
+}
+
+extend google.protobuf.FieldOptions {
+  Conf conf = 50001;
+}
+
+message Conf {
+  string key = 1;
+  repeated string vals = 2;
+}
+
+message Fields
+// before the body brace
+{
+  bool
+  // between type and name
+  a = 1;
+  bool b = 2 // before the semicolon
+  ;
+  bool c = 3
+
+  // blank wrapped before the semicolon
+
+  ;
+  bool d = 4 [deprecated = true // trailing on the option value
+  ];
+  bool e = 5 [deprecated = true
+  // before the close bracket
+  ];
+  bool f = 6 [deprecated = true
+
+  // blank wrapped before the close bracket
+
+  ];
+  bool g = 7 [
+    deprecated = true,
+    json_name = "g"
+    // final slot in expanded options
+  ];
+  bool h = 8 [(conf) = {
+    key // before the colon
+    : "v",
+    vals: ["x" // trailing before the comma
+    , "y"]
+  }];
+  bool i = 9 [(conf) = {
+    key: "v", /* after comma on a scalar value */
+    vals: ["x"]
+  }];
+  bool j = 10 [(conf) = {
+    vals: ["x"], /* after comma on a composite value */
+    key: "v"
+  }];
+  bool k = 11 [(conf) = {
+    key: "v"
+
+    // blank wrapped before the dict close
+
+  }];
+  bool l = 12 /* inline
+  multi line */;
+}
+
+service S {
+  rpc M
+  // before the inputs
+  (In) returns
+  // before the outputs
+  (Out) {}
+  rpc N(In) // trailing on the inputs close paren
+  returns (Out) {}
+}
+
+message In {}
+
+message Out {}
+
+enum E {
+  E_UNSPECIFIED = 0
+
+  // blank wrapped before the enum semicolon
+
+  ;
+}

--- a/experimental/ast/printer/testdata/format/comment_stability.proto.default.txt
+++ b/experimental/ast/printer/testdata/format/comment_stability.proto.default.txt
@@ -1,0 +1,100 @@
+// Comment placements that historically corrupted formatter output or
+// oscillated between format passes.
+syntax = "proto3" // before the syntax semicolon
+;
+
+import "google/protobuf/descriptor.proto";
+
+option java_package // between path and equals
+= "com.foo";
+option (// trailing on extension open paren
+file_conf) = "x";
+
+extend google // mid path
+.protobuf.FileOptions {
+  string file_conf = 50000;
+}
+
+extend google.protobuf.FieldOptions {
+  Conf conf = 50001;
+}
+
+message Conf {
+  string key = 1;
+  repeated string vals = 2;
+}
+
+message Fields // before the body brace
+{
+  bool // between type and name
+  a = 1;
+  bool b = 2 // before the semicolon
+  ;
+  bool c = 3 // blank wrapped before the semicolon
+  ;
+  bool d = 4 [
+    deprecated = true // trailing on the option value
+  ];
+  bool e = 5 [
+    deprecated = true
+    // before the close bracket
+  ];
+  bool f = 6 [
+    deprecated = true
+
+    // blank wrapped before the close bracket
+  ];
+  bool g = 7 [
+    deprecated = true,
+    json_name = "g"
+    // final slot in expanded options
+  ];
+  bool h = 8 [
+    (conf) = {
+      key // before the colon
+      : "v"
+      vals: [
+        "x" // trailing before the comma
+        ,
+        "y"
+      ]
+    }
+  ];
+  bool i = 9 [
+    (conf) = {
+      key: "v" /* after comma on a scalar value */
+      vals: ["x"]
+    }
+  ];
+  bool j = 10 [
+    (conf) = {
+      vals: ["x"] /* after comma on a composite value */
+      key: "v"
+    }
+  ];
+  bool k = 11 [
+    (conf) = {
+      key: "v"
+      // blank wrapped before the dict close
+    }
+  ];
+  bool l = 12 /* inline
+  multi line */;
+}
+
+service S {
+  rpc M // before the inputs
+  (In) returns // before the outputs
+  (Out) {}
+  rpc N(In) // trailing on the inputs close paren
+  returns (Out) {}
+}
+
+message In {}
+
+message Out {}
+
+enum E {
+  E_UNSPECIFIED = 0 // blank wrapped before the enum semicolon
+  ;
+}

--- a/experimental/ast/printer/testdata/format/comment_stability.proto.legacy.txt
+++ b/experimental/ast/printer/testdata/format/comment_stability.proto.legacy.txt
@@ -1,0 +1,73 @@
+// Comment placements that historically corrupted formatter output or
+// oscillated between format passes.
+syntax = "proto3" /* before the syntax semicolon */;
+
+import "google/protobuf/descriptor.proto";
+
+option java_package /* between path and equals */ = "com.foo";
+option (/* trailing on extension open paren */file_conf) = "x";
+
+extend google /* mid path */.protobuf.FileOptions {
+  string file_conf = 50000;
+}
+
+extend google.protobuf.FieldOptions {
+  Conf conf = 50001;
+}
+
+message Conf {
+  string key = 1;
+  repeated string vals = 2;
+}
+
+message Fields /* before the body brace */ {
+  bool /* between type and name */ a = 1;
+  bool b = 2 // before the semicolon
+  ;
+  bool c = 3 /* blank wrapped before the semicolon */;
+  bool d = 4 [deprecated = true /* trailing on the option value */];
+  bool e = 5 [deprecated = true /* before the close bracket */];
+  bool f = 6 [deprecated = true /* blank wrapped before the close bracket */];
+  bool g = 7 [
+    deprecated = true,
+    json_name = "g"
+    // final slot in expanded options
+  ];
+  bool h = 8 [(conf) = {
+    key /* before the colon */ : "v"
+    vals: [
+      "x" // trailing before the comma
+      ,
+      "y"
+    ]
+  }];
+  bool i = 9 [(conf) = {
+    key: "v"
+    /* after comma on a scalar value */
+    vals: ["x"]
+  }];
+  bool j = 10 [(conf) = {
+    vals: ["x"] /* after comma on a composite value */
+    key: "v"
+  }];
+  bool k = 11 [(conf) = {
+    key: "v"
+    // blank wrapped before the dict close
+  }];
+  bool l = 12 /* inline
+     multi line */;
+}
+
+service S {
+  rpc M /* before the inputs */ (In) returns /* before the outputs */ (Out) {}
+  rpc N(In) // trailing on the inputs close paren
+  returns (Out) {}
+}
+
+message In {}
+
+message Out {}
+
+enum E {
+  E_UNSPECIFIED = 0 /* blank wrapped before the enum semicolon */;
+}

--- a/experimental/ast/printer/trivia.go
+++ b/experimental/ast/printer/trivia.go
@@ -82,23 +82,16 @@ func sliceHasComment(tokens []token.Token) bool {
 	return false
 }
 
-// pendingEndsWithInlineBlockComment reports whether the trailing
-// portion of pending will be emitted as an inline `/* ... */` block
-// comment — that is, the last comment in the slice is a block (not
-// `//`) comment with no following newline. Callers use this to decide
-// whether a following inline-bound token (e.g., `:`) needs a space
-// separator so it doesn't sit flush against `*/`.
-func pendingEndsWithInlineBlockComment(tokens []token.Token) bool {
-	endsInBlock := false
+// lastCommentIsLine reports whether the last comment in tokens is a
+// `//` line comment.
+func lastCommentIsLine(tokens []token.Token) bool {
+	isLine := false
 	for _, tok := range tokens {
-		switch {
-		case tok.Kind() == token.Comment:
-			endsInBlock = !strings.HasPrefix(tok.Text(), "//")
-		case tok.Kind() == token.Space && strings.Contains(tok.Text(), "\n"):
-			endsInBlock = false
+		if tok.Kind() == token.Comment {
+			isLine = strings.HasPrefix(tok.Text(), "//")
 		}
 	}
-	return endsInBlock
+	return isLine
 }
 
 // firstNewlineIndex returns the index of the first Space token containing


### PR DESCRIPTION
This fixes formatter regressions in trailing comments and non-idempotent formatting of them.

Towards https://github.com/bufbuild/buf/issues/4650